### PR TITLE
feat: multi-framework detection and pattern merging

### DIFF
--- a/internal/core/detector.go
+++ b/internal/core/detector.go
@@ -30,13 +30,18 @@ func NewFrameworkDetector() *FrameworkDetector {
 	return &FrameworkDetector{}
 }
 
-// Detect determines which web framework is being used in the given directory
-func (d *FrameworkDetector) Detect(dir string) (string, error) {
+// Detect determines which web frameworks are used in the given directory.
+// Returns all detected frameworks. Falls back to ["net/http"] if none found.
+func (d *FrameworkDetector) Detect(dir string) ([]string, error) {
 	// Collect Go files
 	goFiles, err := CollectGoFiles(dir)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
+
+	// Track which frameworks we've seen (preserves detection order)
+	seen := make(map[string]bool)
+	var frameworks []string
 
 	// Parse files to check for framework imports
 	fset := token.NewFileSet()
@@ -46,25 +51,32 @@ func (d *FrameworkDetector) Detect(dir string) (string, error) {
 			continue // Skip files that can't be parsed
 		}
 
-		// Check imports for framework indicators
 		for _, imp := range f.Imports {
 			importPath := strings.Trim(imp.Path.Value, "\"")
+			var fw string
 			switch {
 			case strings.Contains(importPath, "gin-gonic/gin"):
-				return "gin", nil
+				fw = "gin"
 			case strings.Contains(importPath, "go-chi/chi"):
-				return "chi", nil
+				fw = "chi"
 			case strings.Contains(importPath, "labstack/echo"):
-				return "echo", nil
+				fw = "echo"
 			case strings.Contains(importPath, "gofiber/fiber"):
-				return "fiber", nil
+				fw = "fiber"
 			case strings.Contains(importPath, "gorilla/mux"):
-				return "mux", nil
+				fw = "mux"
+			}
+			if fw != "" && !seen[fw] {
+				seen[fw] = true
+				frameworks = append(frameworks, fw)
 			}
 		}
 	}
 
-	return "net/http", nil
+	if len(frameworks) == 0 {
+		return []string{"net/http"}, nil
+	}
+	return frameworks, nil
 }
 
 // CollectGoFiles recursively collects all .go files from a directory

--- a/internal/core/detector_test.go
+++ b/internal/core/detector_test.go
@@ -40,14 +40,14 @@ func TestDetect_NoGoFiles(t *testing.T) {
 	}()
 
 	detector := NewFrameworkDetector()
-	framework, err := detector.Detect(tempDir)
+	frameworks, err := detector.Detect(tempDir)
 	if err != nil {
 		t.Fatalf("Detect failed: %v", err)
 	}
 
-	// Should return "net/http" as default when no Go files are found
-	if framework != "net/http" {
-		t.Errorf("Expected net/http framework, got %s", framework)
+	// Should return ["net/http"] as default when no Go files are found
+	if len(frameworks) != 1 || frameworks[0] != "net/http" {
+		t.Errorf("Expected [net/http], got %v", frameworks)
 	}
 }
 
@@ -81,14 +81,14 @@ func main() {
 	}
 
 	detector := NewFrameworkDetector()
-	framework, err := detector.Detect(tempDir)
+	frameworks, err := detector.Detect(tempDir)
 	if err != nil {
 		t.Fatalf("Detect failed: %v", err)
 	}
 
 	// Should detect net/http framework
-	if framework != "net/http" {
-		t.Errorf("Expected net/http framework, got %s", framework)
+	if len(frameworks) != 1 || frameworks[0] != "net/http" {
+		t.Errorf("Expected [net/http], got %v", frameworks)
 	}
 }
 
@@ -150,6 +150,60 @@ func main() {}`
 		if !found {
 			t.Errorf("Expected Go file %s not found", expectedFile)
 		}
+	}
+}
+
+func TestDetect_MultipleFrameworks(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "apispec_test_multi")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Errorf("Failed to remove temp directory: %v", err)
+		}
+	}()
+
+	// Create a file importing Chi
+	chiFile := filepath.Join(tempDir, "chi_routes.go")
+	err = os.WriteFile(chiFile, []byte(`package main
+import "github.com/go-chi/chi/v5"
+func chiRoutes(r chi.Router) {}
+`), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write chi file: %v", err)
+	}
+
+	// Create a file importing Gin
+	ginFile := filepath.Join(tempDir, "gin_routes.go")
+	err = os.WriteFile(ginFile, []byte(`package main
+import "github.com/gin-gonic/gin"
+func ginRoutes(r *gin.Engine) {}
+`), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write gin file: %v", err)
+	}
+
+	detector := NewFrameworkDetector()
+	frameworks, err := detector.Detect(tempDir)
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+
+	if len(frameworks) != 2 {
+		t.Fatalf("Expected 2 frameworks, got %d: %v", len(frameworks), frameworks)
+	}
+
+	// Both chi and gin should be detected (order depends on file walk order)
+	seen := make(map[string]bool)
+	for _, fw := range frameworks {
+		seen[fw] = true
+	}
+	if !seen["chi"] {
+		t.Error("Expected chi to be detected")
+	}
+	if !seen["gin"] {
+		t.Error("Expected gin to be detected")
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -411,35 +411,44 @@ func (e *Engine) generateDiagram(meta *metadata.Metadata) error {
 	return nil
 }
 
+// defaultConfigForFramework returns the built-in config for a framework name.
+func defaultConfigForFramework(name string) *spec.APISpecConfig {
+	switch name {
+	case "gin":
+		return spec.DefaultGinConfig()
+	case "chi":
+		return spec.DefaultChiConfig()
+	case "echo":
+		return spec.DefaultEchoConfig()
+	case "fiber":
+		return spec.DefaultFiberConfig()
+	case "mux":
+		return spec.DefaultMuxConfig()
+	default:
+		return spec.DefaultHTTPConfig()
+	}
+}
+
 // loadOrDetectConfig loads or auto-detects the API spec configuration.
 // When a config file is provided, it is merged with the auto-detected
 // framework defaults — absent sections fall back to built-in patterns.
+// Supports multiple frameworks: patterns from all detected frameworks are merged.
 func (e *Engine) loadOrDetectConfig() (*spec.APISpecConfig, error) {
 	if e.config.APISpecConfig != nil {
 		return e.config.APISpecConfig, nil
 	}
 
-	// Always detect framework for defaults
+	// Detect all frameworks used in the project
 	detector := core.NewFrameworkDetector()
-	framework, err := detector.Detect(e.config.moduleRoot)
+	frameworks, err := detector.Detect(e.config.moduleRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect framework: %w", err)
 	}
 
-	var defaults *spec.APISpecConfig
-	switch framework {
-	case "gin":
-		defaults = spec.DefaultGinConfig()
-	case "chi":
-		defaults = spec.DefaultChiConfig()
-	case "echo":
-		defaults = spec.DefaultEchoConfig()
-	case "fiber":
-		defaults = spec.DefaultFiberConfig()
-	case "mux":
-		defaults = spec.DefaultMuxConfig()
-	default:
-		defaults = spec.DefaultHTTPConfig()
+	// Build merged defaults from all detected frameworks
+	defaults := defaultConfigForFramework(frameworks[0])
+	for _, fw := range frameworks[1:] {
+		appendFrameworkPatterns(defaults, defaultConfigForFramework(fw))
 	}
 
 	if e.config.ConfigFile == "" {
@@ -490,6 +499,17 @@ func mergeConfigWithDefaults(userCfg, defaults *spec.APISpecConfig) {
 	if userCfg.Defaults.ResponseStatus == 0 {
 		userCfg.Defaults.ResponseStatus = defaults.Defaults.ResponseStatus
 	}
+}
+
+// appendFrameworkPatterns appends all patterns from src into dst.
+// Used to merge multiple detected framework configs into one.
+func appendFrameworkPatterns(dst, src *spec.APISpecConfig) {
+	dst.Framework.RoutePatterns = append(dst.Framework.RoutePatterns, src.Framework.RoutePatterns...)
+	dst.Framework.RequestBodyPatterns = append(dst.Framework.RequestBodyPatterns, src.Framework.RequestBodyPatterns...)
+	dst.Framework.ResponsePatterns = append(dst.Framework.ResponsePatterns, src.Framework.ResponsePatterns...)
+	dst.Framework.ParamPatterns = append(dst.Framework.ParamPatterns, src.Framework.ParamPatterns...)
+	dst.Framework.MountPatterns = append(dst.Framework.MountPatterns, src.Framework.MountPatterns...)
+	dst.Framework.ContentTypePatterns = append(dst.Framework.ContentTypePatterns, src.Framework.ContentTypePatterns...)
 }
 
 // applyConfigDefaults fills in missing config fields from engine defaults


### PR DESCRIPTION
## Summary
- `Detect()` now returns all frameworks found in a project, not just the first match
- `loadOrDetectConfig()` merges patterns from all detected frameworks into one config
- Projects using multiple frameworks (e.g., Chi on :8080 + Gin on :9090) now get routes from both in the OpenAPI spec

## Changes
- `internal/core/detector.go` — `Detect()` returns `[]string`, collects all matches
- `internal/engine/engine.go` — `appendFrameworkPatterns()` merges multi-framework configs
- `internal/core/detector_test.go` — new `TestDetect_MultipleFrameworks` test

## Test plan
- [x] All 12 golden file tests pass (single-framework output unchanged)
- [x] Full test suite passes
- [x] Lint clean
- [x] New test verifies Chi+Gin both detected from a mixed project