### PR TITLE
fix: add CI/Release badges, fix test that mutated fixture file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # go-apispec: Generate OpenAPI from Go code
 
+[![CI](https://github.com/antst/go-apispec/actions/workflows/ci.yml/badge.svg)](https://github.com/antst/go-apispec/actions/workflows/ci.yml)
+[![Release](https://github.com/antst/go-apispec/actions/workflows/release.yml/badge.svg)](https://github.com/antst/go-apispec/actions/workflows/release.yml)
 ![Coverage](https://img.shields.io/badge/coverage-67.0%25-red.svg)
-
 [![Go Version](https://img.shields.io/badge/go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/antst/go-apispec/blob/main/LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/antst/go-apispec.svg)](https://pkg.go.dev/github.com/antst/go-apispec)

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -768,9 +768,9 @@ var DefaultFormat = "uppercase"`,
 			// sanitizeMetadataForTest removes temporary directory paths from metadata to ensure consistent test output
 			sanitizedMeta := sanitizeMetadataForTest(meta)
 
-			// Only write metadata files during development/testing, not during CI/CD
-			// This prevents temporary directory paths from being committed to git
-			if err := metadata.WriteMetadata(sanitizedMeta, fmt.Sprintf("../spec/tests/%s.yaml", tc.src[0].Name)); err != nil {
+			// Write to temp file for validation — never overwrite checked-in fixtures
+			tmpFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.yaml", tc.src[0].Name))
+			if err := metadata.WriteMetadata(sanitizedMeta, tmpFile); err != nil {
 				t.Errorf("Failed to write metadata.yaml: %v", err)
 			}
 


### PR DESCRIPTION
## Summary
- Add CI and Release workflow status badges to README
- Fix `metadata_test.go` that was writing to `internal/spec/tests/example.yaml` (a checked-in fixture) as a side effect on every test run — now writes to `t.TempDir()` instead

## Test plan
- [x] `go test ./internal/metadata/` passes
- [x] `internal/spec/tests/example.yaml` is no longer modified after running tests
- [x] Full test suite passes