### PR TITLE
fix: detector tests use []string after multi-framework merge

### DIFF
--- a/internal/core/detector_test.go
+++ b/internal/core/detector_test.go
@@ -116,12 +116,12 @@ var _ = ` + tt.name + `.New
 				t.Fatal(err)
 			}
 			detector := NewFrameworkDetector()
-			fw, err := detector.Detect(tempDir)
+			fws, err := detector.Detect(tempDir)
 			if err != nil {
 				t.Fatalf("Detect failed: %v", err)
 			}
-			if fw != tt.expected {
-				t.Errorf("Expected %s, got %s", tt.expected, fw)
+			if len(fws) == 0 || fws[0] != tt.expected {
+				t.Errorf("Expected [%s], got %v", tt.expected, fws)
 			}
 		})
 	}
@@ -133,12 +133,12 @@ func TestDetect_SkipsUnparsableFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	detector := NewFrameworkDetector()
-	fw, err := detector.Detect(tempDir)
+	fws, err := detector.Detect(tempDir)
 	if err != nil {
 		t.Fatalf("Detect failed: %v", err)
 	}
-	if fw != "net/http" {
-		t.Errorf("Expected net/http fallback, got %s", fw)
+	if len(fws) != 1 || fws[0] != "net/http" {
+		t.Errorf("Expected [net/http] fallback, got %v", fws)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix build failure caused by merging multi-framework PR (#1) and coverage PR (#3) — the coverage tests used the old `(string, error)` return type for `Detect()` but it now returns `([]string, error)`.

## Test plan
- [x] All 13 detector tests pass
- [x] Full test suite passes