### PR TITLE
feat: detect error responses through helper functions via ParamArgMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ playground*.go
 CLAUDE.md
 specs/
 .specify/
+testdata/error_helpers/error_helpers

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -47,6 +47,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "mux", inputDir: "../../testdata/mux", configFn: spec.DefaultMuxConfig},
 		{name: "response_patterns", inputDir: "../../testdata/response_patterns", configFn: spec.DefaultChiConfig},
 		{name: "nested_http", inputDir: "../../testdata/nested_http", configFn: spec.DefaultHTTPConfig},
+		{name: "error_helpers", inputDir: "../../testdata/error_helpers", configFn: spec.DefaultChiConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -887,6 +887,13 @@ func (e *Extractor) expandHelperFunctionResponses(routeNode TrackerNodeInterface
 			continue
 		}
 
+		// Only expand helpers that actually contain response-writing calls
+		// (WriteHeader, Encode, etc.) to avoid fabricating responses for
+		// unrelated helpers that happen to be called multiple times.
+		if !e.helperContainsResponsePattern(calls[0].node) {
+			continue
+		}
+
 		statusParam, baseSchema, contentType := e.findStatusParamAndSchema(calls, route)
 		if statusParam == "" || baseSchema == nil {
 			continue
@@ -975,7 +982,7 @@ func (e *Extractor) findBodyParamName(calls []helperCall, _ *RouteInfo, statusPa
 
 	// Use the first call to identify parameter roles
 	for pName, arg := range calls[0].edge.ParamArgMap {
-		if pName == statusParam || pName == "w" || pName == "writer" {
+		if pName == statusParam || pName == "w" || pName == "writer" || pName == "rw" || pName == "response" {
 			continue
 		}
 		// Skip if this resolves to a status code
@@ -990,6 +997,20 @@ func (e *Extractor) findBodyParamName(calls []helperCall, _ *RouteInfo, statusPa
 		return pName
 	}
 	return ""
+}
+
+// helperContainsResponsePattern checks if a helper function node has any children
+// that match a response pattern (e.g., WriteHeader, Encode). This prevents
+// expandHelperFunctionResponses from fabricating responses for non-response helpers.
+func (e *Extractor) helperContainsResponsePattern(helperNode TrackerNodeInterface) bool {
+	for _, child := range helperNode.GetChildren() {
+		for _, matcher := range e.responseMatchers {
+			if matcher.MatchNode(child) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // extractRouteChildren extracts request, response, and params from children nodes

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -601,6 +601,61 @@ func (r *ResponsePatternMatcherImpl) resolveCallReturnValue(arg *metadata.CallAr
 	return ""
 }
 
+// resolveParamArgStatus walks up the tracker tree parent chain to find a
+// ParamArgMap that maps a function parameter name to the actual argument
+// passed by the caller. This handles error helper patterns like:
+//
+//	writeJSONError(w, http.StatusBadRequest, "msg")
+//	func writeJSONError(w http.ResponseWriter, code int, msg string) {
+//	    w.WriteHeader(code)  // ← code is a parameter, not a local variable
+//	}
+func (r *ResponsePatternMatcherImpl) resolveParamArgStatus(node TrackerNodeInterface, paramName string) (int, bool) {
+	// Walk up parent chain to find the call edge that invoked this function
+	for parent := node.GetParent(); parent != nil; parent = parent.GetParent() {
+		parentEdge := parent.GetEdge()
+		if parentEdge == nil {
+			continue
+		}
+		if arg, exists := parentEdge.ParamArgMap[paramName]; exists {
+			// Found the parameter mapping — resolve the argument value
+			argStr := r.contextProvider.GetArgumentInfo(&arg)
+			if status, ok := r.schemaMapper.MapStatusCode(argStr); ok {
+				return status, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// resolveParamArgType walks up the tracker tree parent chain to find a
+// ParamArgMap entry for a function parameter and returns the concrete type
+// of the argument passed by the caller. This handles patterns like:
+//
+//	respondJSON(w, 201, user)
+//	func respondJSON(w http.ResponseWriter, code int, data interface{}) {
+//	    json.Encode(data)  // ← data is interface{}, but user is User
+//	}
+func (r *ResponsePatternMatcherImpl) resolveParamArgType(node TrackerNodeInterface, paramName string) string {
+	for parent := node.GetParent(); parent != nil; parent = parent.GetParent() {
+		parentEdge := parent.GetEdge()
+		if parentEdge == nil {
+			continue
+		}
+		if arg, exists := parentEdge.ParamArgMap[paramName]; exists {
+			// Use GetArgumentInfo first — it produces the fully-qualified type
+			// (e.g., "error_helpers.User" instead of just "User")
+			if info := r.contextProvider.GetArgumentInfo(&arg); info != "" && info != "interface{}" && info != "any" {
+				return info
+			}
+			// Fallback to raw type
+			if argType := arg.GetType(); argType != "" && argType != "interface{}" && argType != "any" {
+				return argType
+			}
+		}
+	}
+	return ""
+}
+
 // isInterfaceHandler checks if the route handler's receiver type is an interface.
 func (e *Extractor) isInterfaceHandler(route *RouteInfo) bool {
 	meta := e.tree.GetMetadata()
@@ -777,6 +832,166 @@ func (e *Extractor) visitChildren(node TrackerNodeInterface, route *RouteInfo, c
 	}
 }
 
+// addResponse adds a response to the route, merging schemas for duplicate status codes.
+func (e *Extractor) addResponse(route *RouteInfo, resp *ResponseInfo) {
+	key := fmt.Sprintf("%d", resp.StatusCode)
+	if existing, ok := route.Response[key]; ok && resp.Schema != nil {
+		if existing.Schema == nil {
+			existing.BodyType = resp.BodyType
+			existing.Schema = resp.Schema
+		} else {
+			isDuplicate := schemasEqual(existing.Schema, resp.Schema)
+			if !isDuplicate {
+				for _, alt := range existing.AlternativeSchemas {
+					if schemasEqual(alt, resp.Schema) {
+						isDuplicate = true
+						break
+					}
+				}
+			}
+			if !isDuplicate {
+				existing.AlternativeSchemas = append(existing.AlternativeSchemas, resp.Schema)
+			}
+		}
+	} else {
+		route.Response[key] = resp
+	}
+}
+
+// helperCall represents a call to a helper function with its ParamArgMap.
+type helperCall struct {
+	node TrackerNodeInterface
+	edge *metadata.CallGraphEdge
+}
+
+// resolveArgToStatusCode attempts to map a CallArgument to an HTTP status code.
+func (e *Extractor) resolveArgToStatusCode(arg *metadata.CallArgument) (int, bool) {
+	argStr := e.contextProvider.GetArgumentInfo(arg)
+	for _, matcher := range e.responseMatchers {
+		if rm, ok := matcher.(*ResponsePatternMatcherImpl); ok {
+			return rm.schemaMapper.MapStatusCode(argStr)
+		}
+	}
+	return 0, false
+}
+
+// expandHelperFunctionResponses scans the route node's descendants for helper
+// functions called multiple times with different status codes. For each group,
+// it creates additional responses for status codes not captured by the primary
+// response extraction (which deduplicates by Callee.ID).
+func (e *Extractor) expandHelperFunctionResponses(routeNode TrackerNodeInterface, route *RouteInfo) {
+	groups := e.collectHelperCallGroups(routeNode)
+
+	for _, calls := range groups {
+		if len(calls) < 2 {
+			continue
+		}
+
+		statusParam, baseSchema, contentType := e.findStatusParamAndSchema(calls, route)
+		if statusParam == "" || baseSchema == nil {
+			continue
+		}
+
+		// Find the "body" parameter name — the one whose argument resolved to the
+		// base schema's type. This is used to resolve per-call body types below.
+		bodyParam := e.findBodyParamName(calls, route, statusParam, baseSchema)
+
+		for _, call := range calls {
+			arg, exists := call.edge.ParamArgMap[statusParam]
+			if !exists {
+				continue
+			}
+			if status, ok := e.resolveArgToStatusCode(&arg); ok {
+				key := fmt.Sprintf("%d", status)
+				if _, exists := route.Response[key]; !exists {
+					// Resolve this call's body type from its own ParamArgMap.
+					// If the body parameter carries a different type per call
+					// (e.g., respondJSON(w, 200, user) vs respondJSON(w, 400, err)),
+					// each sibling gets its own schema.
+					schema := baseSchema
+					if bodyParam != "" {
+						if bodyArg, ok := call.edge.ParamArgMap[bodyParam]; ok {
+							bodyType := e.contextProvider.GetArgumentInfo(&bodyArg)
+							if bodyType != "" && bodyType != "interface{}" && bodyType != "any" {
+								if s, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, e.cfg, nil); s != nil {
+									schema = s
+								}
+							}
+						}
+					}
+					e.addResponse(route, &ResponseInfo{
+						StatusCode:  status,
+						ContentType: contentType,
+						Schema:      schema,
+					})
+				}
+			}
+		}
+	}
+}
+
+// collectHelperCallGroups recursively collects calls with ParamArgMap, grouped
+// by callee BaseID.
+func (e *Extractor) collectHelperCallGroups(routeNode TrackerNodeInterface) map[string][]helperCall {
+	groups := make(map[string][]helperCall)
+	var collect func(node TrackerNodeInterface)
+	collect = func(node TrackerNodeInterface) {
+		for _, child := range node.GetChildren() {
+			edge := child.GetEdge()
+			if edge != nil && len(edge.ParamArgMap) > 0 {
+				baseID := edge.Callee.BaseID()
+				groups[baseID] = append(groups[baseID], helperCall{node: child, edge: edge})
+			}
+			collect(child)
+		}
+	}
+	collect(routeNode)
+	return groups
+}
+
+// findStatusParamAndSchema finds which parameter in a group of helper calls
+// maps to a status code that already has a response with a schema.
+func (e *Extractor) findStatusParamAndSchema(calls []helperCall, route *RouteInfo) (paramName string, schema *Schema, contentType string) {
+	for _, call := range calls {
+		for pName, arg := range call.edge.ParamArgMap {
+			if status, ok := e.resolveArgToStatusCode(&arg); ok {
+				key := fmt.Sprintf("%d", status)
+				if resp, exists := route.Response[key]; exists && resp.Schema != nil {
+					return pName, resp.Schema, resp.ContentType
+				}
+			}
+		}
+	}
+	return "", nil, ""
+}
+
+// findBodyParamName finds which ParamArgMap parameter carries the response body.
+// It identifies the parameter by exclusion: not the status code param, not a
+// ResponseWriter, and not a string (message). The remaining param is the body.
+func (e *Extractor) findBodyParamName(calls []helperCall, _ *RouteInfo, statusParam string, _ *Schema) string {
+	if len(calls) == 0 {
+		return ""
+	}
+
+	// Use the first call to identify parameter roles
+	for pName, arg := range calls[0].edge.ParamArgMap {
+		if pName == statusParam || pName == "w" || pName == "writer" {
+			continue
+		}
+		// Skip if this resolves to a status code
+		if _, ok := e.resolveArgToStatusCode(&arg); ok {
+			continue
+		}
+		// Skip string literal parameters (message strings)
+		if arg.GetKind() == metadata.KindLiteral {
+			continue
+		}
+		// This is likely the body parameter
+		return pName
+	}
+	return ""
+}
+
 // extractRouteChildren extracts request, response, and params from children nodes
 // using the unified visitor with registered callbacks.
 func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[string]bool) {
@@ -799,28 +1014,7 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 			if resp == nil || (resp.BodyType == "" && resp.StatusCode == 0) {
 				return
 			}
-			key := fmt.Sprintf("%d", resp.StatusCode)
-			if existing, ok := route.Response[key]; ok && resp.Schema != nil {
-				if existing.Schema == nil {
-					existing.BodyType = resp.BodyType
-					existing.Schema = resp.Schema
-				} else {
-					isDuplicate := schemasEqual(existing.Schema, resp.Schema)
-					if !isDuplicate {
-						for _, alt := range existing.AlternativeSchemas {
-							if schemasEqual(alt, resp.Schema) {
-								isDuplicate = true
-								break
-							}
-						}
-					}
-					if !isDuplicate {
-						existing.AlternativeSchemas = append(existing.AlternativeSchemas, resp.Schema)
-					}
-				}
-			} else {
-				route.Response[key] = resp
-			}
+			e.addResponse(route, resp)
 		},
 		// Parameter extraction
 		func(node TrackerNodeInterface, route *RouteInfo) {
@@ -835,6 +1029,14 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 	}
 
 	e.visitChildren(routeNode, route, callbacks)
+
+	// After all children are visited and responses have schemas, expand
+	// helper function responses. When the same error helper is called multiple
+	// times with different status codes (e.g., writeJSONError(w, 400, ...) and
+	// writeJSONError(w, 404, ...)), the dedup in extractResponseFromNode only
+	// processes one call's WriteHeader/Encode. This post-pass creates responses
+	// for the other calls using the schema from the processed one.
+	e.expandHelperFunctionResponses(routeNode, route)
 
 	// Extract parameters from the route node itself
 	if param := e.extractParamFromNode(routeNode, route); param != nil {
@@ -1068,6 +1270,16 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 					respInfo.StatusCode = status
 				}
 			}
+			// If not found in AssignmentMap, check if this is a function parameter
+			// passed from a caller (e.g., writeJSONError(w, http.StatusBadRequest, "msg")
+			// where statusCode is a parameter, not a local variable).
+			// Walk up the parent chain to find a ParamArgMap that maps this parameter name.
+			if !statusResolved {
+				if status, ok := r.resolveParamArgStatus(node, arg.GetName()); ok {
+					statusResolved = true
+					respInfo.StatusCode = status
+				}
+			}
 		} else if arg.GetKind() == metadata.KindCall {
 			// Status code from function call — check if the callee has a
 			// constant return value (e.g., func getStatus() int { return 200 })
@@ -1137,6 +1349,15 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 			// Apply dereferencing if needed
 			if r.pattern.Deref && strings.HasPrefix(bodyType, "*") {
 				bodyType = strings.TrimPrefix(bodyType, "*")
+			}
+		}
+
+		// If the body type is interface{} or unresolved and the argument is a
+		// function parameter, resolve the concrete type from the caller's argument
+		// via ParamArgMap (e.g., respondJSON(w, 201, user) where data is interface{}).
+		if (bodyType == "interface{}" || bodyType == "" || bodyType == "any") && arg.GetKind() == metadata.KindIdent {
+			if concreteType := r.resolveParamArgType(node, arg.GetName()); concreteType != "" {
+				bodyType = concreteType
 			}
 		}
 

--- a/internal/spec/extractor_helper_test.go
+++ b/internal/spec/extractor_helper_test.go
@@ -1,0 +1,1009 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers specific to this file
+// ---------------------------------------------------------------------------
+
+// makeSelectorArg builds a selector CallArgument representing pkg.name
+// (e.g., "http.StatusBadRequest"). The X sub-arg is an ident for the package,
+// and the Sel sub-arg is an ident for the selector name.
+func makeSelectorArg(meta *metadata.Metadata, xPkg, xName, selName string) metadata.CallArgument {
+	x := metadata.NewCallArgument(meta)
+	x.SetKind(metadata.KindIdent)
+	x.SetName(xName)
+	x.SetPkg(xPkg)
+
+	sel := metadata.NewCallArgument(meta)
+	sel.SetKind(metadata.KindIdent)
+	sel.SetName(selName)
+
+	arg := metadata.NewCallArgument(meta)
+	arg.SetKind(metadata.KindSelector)
+	arg.X = x
+	arg.Sel = sel
+	return *arg
+}
+
+// makeHelperEdge creates a CallGraphEdge whose Callee has the given name/pkg
+// and whose ParamArgMap is populated from the given map.
+func makeHelperEdge(meta *metadata.Metadata, calleeName, calleePkg string, paramArgs map[string]metadata.CallArgument) metadata.CallGraphEdge {
+	edge := metadata.CallGraphEdge{
+		Caller: metadata.Call{
+			Meta: meta,
+			Name: meta.StringPool.Get("handler"),
+			Pkg:  meta.StringPool.Get("main"),
+		},
+		Callee: metadata.Call{
+			Meta: meta,
+			Name: meta.StringPool.Get(calleeName),
+			Pkg:  meta.StringPool.Get(calleePkg),
+		},
+		ParamArgMap: paramArgs,
+	}
+	edge.Caller.Edge = &edge
+	edge.Callee.Edge = &edge
+	return edge
+}
+
+// newTestExtractor creates an Extractor backed by a MockTrackerTree using the
+// default chi configuration. The returned tree can have roots added to it.
+func newTestExtractor(meta *metadata.Metadata) (*Extractor, *MockTrackerTree) {
+	limits := metadata.TrackerLimits{
+		MaxNodesPerTree:    1000,
+		MaxChildrenPerNode: 100,
+		MaxArgsPerFunction: 50,
+		MaxNestedArgsDepth: 10,
+		MaxRecursionDepth:  5,
+	}
+	tree := NewMockTrackerTree(meta, limits)
+	cfg := DefaultChiConfig()
+	ext := NewExtractor(tree, cfg)
+	return ext, tree
+}
+
+// ===========================================================================
+// 1. resolveParamArgStatus
+// ===========================================================================
+
+func TestResolveParamArgStatus_FoundInParent(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Build: grandparent → parent (with ParamArgMap["code" → StatusBadRequest]) → child
+	statusArg := makeSelectorArg(meta, "net/http", "http", "StatusBadRequest")
+
+	parentEdge := makeHelperEdge(meta, "writeJSONError", "helpers", map[string]metadata.CallArgument{
+		"code": statusArg,
+	})
+	grandparent := &TrackerNode{key: "grandparent"}
+	parent := &TrackerNode{
+		key:           "parent",
+		Parent:        grandparent,
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	// Get the response pattern matcher from the extractor
+	require.NotEmpty(t, ext.responseMatchers, "expected at least one response matcher")
+	rm, ok := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	require.True(t, ok)
+
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.True(t, found)
+	assert.Equal(t, 400, status)
+}
+
+func TestResolveParamArgStatus_NotFound(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	parentEdge := makeHelperEdge(meta, "helper", "pkg", map[string]metadata.CallArgument{
+		"other": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.False(t, found)
+	assert.Equal(t, 0, status)
+}
+
+func TestResolveParamArgStatus_NilParent(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	child := &TrackerNode{key: "child"}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.False(t, found)
+	assert.Equal(t, 0, status)
+}
+
+func TestResolveParamArgStatus_ParentEdgeNil(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	parent := &TrackerNode{key: "parent"} // no edge
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.False(t, found)
+	assert.Equal(t, 0, status)
+}
+
+func TestResolveParamArgStatus_EmptyParamArgMap(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	parentEdge := makeHelperEdge(meta, "helper", "pkg", map[string]metadata.CallArgument{})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.False(t, found)
+	assert.Equal(t, 0, status)
+}
+
+func TestResolveParamArgStatus_UnresolvableStatus(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// ParamArgMap has an ident arg that doesn't resolve to a known status
+	unknownArg := makeCallArg(meta)
+	unknownArg.SetKind(metadata.KindIdent)
+	unknownArg.SetName("someVar")
+	unknownArg.SetType("int")
+
+	parentEdge := makeHelperEdge(meta, "helper", "pkg", map[string]metadata.CallArgument{
+		"code": *unknownArg,
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.False(t, found)
+	assert.Equal(t, 0, status)
+}
+
+func TestResolveParamArgStatus_GrandparentHasMapping(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Parent has no mapping, grandparent does
+	statusArg := makeSelectorArg(meta, "net/http", "http", "StatusNotFound")
+
+	grandparentEdge := makeHelperEdge(meta, "outerHelper", "pkg", map[string]metadata.CallArgument{
+		"code": statusArg,
+	})
+	grandparent := &TrackerNode{
+		key:           "grandparent",
+		CallGraphEdge: &grandparentEdge,
+	}
+	parent := &TrackerNode{
+		key:    "parent",
+		Parent: grandparent,
+		// no edge or empty ParamArgMap
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	status, found := rm.resolveParamArgStatus(child, "code")
+	assert.True(t, found)
+	assert.Equal(t, 404, status)
+}
+
+// ===========================================================================
+// 2. resolveParamArgType
+// ===========================================================================
+
+func TestResolveParamArgType_FoundType(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("user")
+	dataArg.SetType("User")
+	dataArg.SetPkg("models")
+
+	parentEdge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"data": *dataArg,
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	result := rm.resolveParamArgType(child, "data")
+	assert.NotEmpty(t, result)
+	assert.NotEqual(t, "interface{}", result)
+}
+
+func TestResolveParamArgType_SkipsInterface(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// arg has type "interface{}" — should be skipped
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("data")
+	dataArg.SetType("interface{}")
+
+	parentEdge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"data": *dataArg,
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	result := rm.resolveParamArgType(child, "data")
+	assert.Empty(t, result)
+}
+
+func TestResolveParamArgType_SkipsAny(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("data")
+	dataArg.SetType("any")
+
+	parentEdge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"data": *dataArg,
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	result := rm.resolveParamArgType(child, "data")
+	assert.Empty(t, result)
+}
+
+func TestResolveParamArgType_NilParent(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	child := &TrackerNode{key: "child"}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	result := rm.resolveParamArgType(child, "data")
+	assert.Empty(t, result)
+}
+
+func TestResolveParamArgType_ParamNotFound(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("user")
+	dataArg.SetType("User")
+	dataArg.SetPkg("models")
+
+	parentEdge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"something_else": *dataArg,
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	result := rm.resolveParamArgType(child, "data")
+	assert.Empty(t, result)
+}
+
+func TestResolveParamArgType_FallbackToRawType(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Arg where GetArgumentInfo returns "" but GetType returns something useful.
+	// This happens when pkg is empty and type is a simple name.
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("u")
+	dataArg.SetType("MyStruct")
+	// No pkg set — GetArgumentInfo for ident with no pkg may return empty or just the type
+
+	parentEdge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"data": *dataArg,
+	})
+	parent := &TrackerNode{
+		key:           "parent",
+		CallGraphEdge: &parentEdge,
+	}
+	child := &TrackerNode{
+		key:    "child",
+		Parent: parent,
+	}
+
+	rm := ext.responseMatchers[0].(*ResponsePatternMatcherImpl)
+	result := rm.resolveParamArgType(child, "data")
+	// Should get some type back (either via GetArgumentInfo or fallback)
+	assert.NotEmpty(t, result)
+	assert.NotEqual(t, "interface{}", result)
+	assert.NotEqual(t, "any", result)
+}
+
+// ===========================================================================
+// 3. resolveArgToStatusCode
+// ===========================================================================
+
+func TestResolveArgToStatusCode_KnownStatus(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	arg := makeSelectorArg(meta, "net/http", "http", "StatusBadRequest")
+	status, ok := ext.resolveArgToStatusCode(&arg)
+	assert.True(t, ok)
+	assert.Equal(t, 400, status)
+}
+
+func TestResolveArgToStatusCode_LiteralNumber(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	arg := makeLiteralArg(meta, "201")
+	status, ok := ext.resolveArgToStatusCode(arg)
+	assert.True(t, ok)
+	assert.Equal(t, 201, status)
+}
+
+func TestResolveArgToStatusCode_UnknownString(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindIdent)
+	arg.SetName("someVariable")
+	arg.SetType("int")
+	status, ok := ext.resolveArgToStatusCode(arg)
+	assert.False(t, ok)
+	assert.Equal(t, 0, status)
+}
+
+func TestResolveArgToStatusCode_StatusOK(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	arg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+	status, ok := ext.resolveArgToStatusCode(&arg)
+	assert.True(t, ok)
+	assert.Equal(t, 200, status)
+}
+
+func TestResolveArgToStatusCode_StatusInternalServerError(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	arg := makeSelectorArg(meta, "net/http", "http", "StatusInternalServerError")
+	status, ok := ext.resolveArgToStatusCode(&arg)
+	assert.True(t, ok)
+	assert.Equal(t, 500, status)
+}
+
+// ===========================================================================
+// 4. collectHelperCallGroups
+// ===========================================================================
+
+func TestCollectHelperCallGroups_BasicGrouping(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Two children with same callee BaseID (same name/pkg), different ParamArgMaps
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	edge2 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+	})
+
+	root := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edge1},
+			{key: "call2", CallGraphEdge: &edge2},
+		},
+	}
+
+	groups := ext.collectHelperCallGroups(root)
+	// Both edges have the same callee "helpers-->respondJSON", so 1 group with 2 calls
+	assert.Len(t, groups, 1)
+	for _, calls := range groups {
+		assert.Len(t, calls, 2)
+	}
+}
+
+func TestCollectHelperCallGroups_DifferentCallees(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	edge2 := makeHelperEdge(meta, "respondError", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+	})
+
+	root := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edge1},
+			{key: "call2", CallGraphEdge: &edge2},
+		},
+	}
+
+	groups := ext.collectHelperCallGroups(root)
+	assert.Len(t, groups, 2)
+}
+
+func TestCollectHelperCallGroups_SkipsEdgesWithoutParamArgMap(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Edge with no ParamArgMap
+	edgeNoMap := makeEdge(meta, "handler", "main", "fmt.Println", "fmt", nil)
+
+	root := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edgeNoMap},
+		},
+	}
+
+	groups := ext.collectHelperCallGroups(root)
+	assert.Empty(t, groups)
+}
+
+func TestCollectHelperCallGroups_EmptyChildren(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	root := &TrackerNode{
+		key: "route",
+	}
+
+	groups := ext.collectHelperCallGroups(root)
+	assert.Empty(t, groups)
+}
+
+func TestCollectHelperCallGroups_NestedChildren(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Nested: root → child1 → grandchild1 (same callee as child2)
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	edge2 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusNotFound"),
+	})
+
+	grandchild := &TrackerNode{key: "grandchild", CallGraphEdge: &edge2}
+	root := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{
+				key:           "call1",
+				CallGraphEdge: &edge1,
+				Children:      []*TrackerNode{grandchild},
+			},
+		},
+	}
+
+	groups := ext.collectHelperCallGroups(root)
+	assert.Len(t, groups, 1)
+	for _, calls := range groups {
+		assert.Len(t, calls, 2)
+	}
+}
+
+// ===========================================================================
+// 5. findStatusParamAndSchema
+// ===========================================================================
+
+func TestFindStatusParamAndSchema_Found(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	statusArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": statusArg,
+		"data": *makeIdentArg(meta, "user", "User"),
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge1},
+	}
+
+	// Route must have a response for status 200 with a schema
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {
+				StatusCode:  200,
+				ContentType: "application/json",
+				Schema:      &Schema{Type: "object"},
+			},
+		},
+		Metadata: meta,
+	}
+
+	paramName, schema, contentType := ext.findStatusParamAndSchema(calls, route)
+	assert.Equal(t, "code", paramName)
+	assert.NotNil(t, schema)
+	assert.Equal(t, "object", schema.Type)
+	assert.Equal(t, "application/json", contentType)
+}
+
+func TestFindStatusParamAndSchema_NoMatchingResponse(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	statusArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": statusArg,
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge1},
+	}
+
+	// Route has no response for 200
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	paramName, schema, _ := ext.findStatusParamAndSchema(calls, route)
+	assert.Empty(t, paramName)
+	assert.Nil(t, schema)
+}
+
+func TestFindStatusParamAndSchema_ResponseWithoutSchema(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	statusArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": statusArg,
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge1},
+	}
+
+	// Route has response for 200 but without schema
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {
+				StatusCode:  200,
+				ContentType: "application/json",
+				Schema:      nil,
+			},
+		},
+		Metadata: meta,
+	}
+
+	paramName, schema, _ := ext.findStatusParamAndSchema(calls, route)
+	assert.Empty(t, paramName)
+	assert.Nil(t, schema)
+}
+
+func TestFindStatusParamAndSchema_MultipleCallsPicksFirst(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	edge2 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge1},
+		{node: &TrackerNode{key: "call2"}, edge: &edge2},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {
+				StatusCode:  200,
+				ContentType: "application/json",
+				Schema:      &Schema{Type: "object"},
+			},
+		},
+		Metadata: meta,
+	}
+
+	paramName, schema, _ := ext.findStatusParamAndSchema(calls, route)
+	assert.Equal(t, "code", paramName)
+	assert.NotNil(t, schema)
+}
+
+// ===========================================================================
+// 6. findBodyParamName
+// ===========================================================================
+
+func TestFindBodyParamName_FindsDataParam(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("user")
+	dataArg.SetType("User")
+	dataArg.SetPkg("models")
+
+	wArg := makeCallArg(meta)
+	wArg.SetKind(metadata.KindIdent)
+	wArg.SetName("w")
+	wArg.SetType("http.ResponseWriter")
+
+	codeArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+
+	edge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"w":    *wArg,
+		"code": codeArg,
+		"data": *dataArg,
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	bodyParam := ext.findBodyParamName(calls, route, "code", &Schema{Type: "object"})
+	assert.Equal(t, "data", bodyParam)
+}
+
+func TestFindBodyParamName_SkipsWriter(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	wArg := makeCallArg(meta)
+	wArg.SetKind(metadata.KindIdent)
+	wArg.SetName("w")
+	wArg.SetType("http.ResponseWriter")
+
+	codeArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+
+	edge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"w":      *wArg,
+		"code":   codeArg,
+		"writer": *wArg, // also skipped
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	bodyParam := ext.findBodyParamName(calls, route, "code", &Schema{Type: "object"})
+	assert.Empty(t, bodyParam)
+}
+
+func TestFindBodyParamName_SkipsLiteralParam(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	literalArg := makeLiteralArg(meta, "something went wrong")
+	codeArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+
+	edge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": codeArg,
+		"msg":  *literalArg,
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	bodyParam := ext.findBodyParamName(calls, route, "code", &Schema{Type: "object"})
+	assert.Empty(t, bodyParam)
+}
+
+func TestFindBodyParamName_EmptyCalls(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	bodyParam := ext.findBodyParamName(nil, route, "code", &Schema{Type: "object"})
+	assert.Empty(t, bodyParam)
+}
+
+func TestFindBodyParamName_SkipsStatusCodeParam(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// All params are either "code" (status param) or resolve to status codes
+	codeArg := makeSelectorArg(meta, "net/http", "http", "StatusOK")
+	anotherCode := makeSelectorArg(meta, "net/http", "http", "StatusBadRequest")
+
+	edge := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code":    codeArg,
+		"altCode": anotherCode, // also resolves to a status code → skipped
+	})
+
+	calls := []helperCall{
+		{node: &TrackerNode{key: "call1"}, edge: &edge},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	bodyParam := ext.findBodyParamName(calls, route, "code", &Schema{Type: "object"})
+	assert.Empty(t, bodyParam)
+}
+
+// ===========================================================================
+// 7. expandHelperFunctionResponses
+// ===========================================================================
+
+func TestExpandHelperFunctionResponses_AddsNewResponses(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Two calls to the same helper with different status codes
+	dataArg1 := makeCallArg(meta)
+	dataArg1.SetKind(metadata.KindIdent)
+	dataArg1.SetName("user")
+	dataArg1.SetType("User")
+	dataArg1.SetPkg("models")
+
+	dataArg2 := makeCallArg(meta)
+	dataArg2.SetKind(metadata.KindIdent)
+	dataArg2.SetName("errResp")
+	dataArg2.SetType("ErrorResponse")
+	dataArg2.SetPkg("models")
+
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+		"data": *dataArg1,
+	})
+	edge2 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+		"data": *dataArg2,
+	})
+
+	routeNode := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edge1},
+			{key: "call2", CallGraphEdge: &edge2},
+		},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {
+				StatusCode:  200,
+				ContentType: "application/json",
+				Schema:      &Schema{Type: "object"},
+			},
+		},
+		UsedTypes: map[string]*Schema{},
+		Metadata:  meta,
+	}
+
+	ext.expandHelperFunctionResponses(routeNode, route)
+
+	// Should have added a 400 response
+	assert.Contains(t, route.Response, "400")
+}
+
+func TestExpandHelperFunctionResponses_SkipsSingleCall(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+
+	routeNode := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edge1},
+		},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {
+				StatusCode:  200,
+				ContentType: "application/json",
+				Schema:      &Schema{Type: "object"},
+			},
+		},
+		Metadata: meta,
+	}
+
+	initialCount := len(route.Response)
+	ext.expandHelperFunctionResponses(routeNode, route)
+	assert.Equal(t, initialCount, len(route.Response), "should not add responses for single-call groups")
+}
+
+func TestExpandHelperFunctionResponses_SkipsExistingStatus(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Two calls to the same helper, both status codes already have responses
+	edge1 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	edge2 := makeHelperEdge(meta, "respondJSON", "helpers", map[string]metadata.CallArgument{
+		"code": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+	})
+
+	routeNode := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edge1},
+			{key: "call2", CallGraphEdge: &edge2},
+		},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {
+				StatusCode:  200,
+				ContentType: "application/json",
+				Schema:      &Schema{Type: "object"},
+			},
+			"400": {
+				StatusCode:  400,
+				ContentType: "application/json",
+				Schema:      &Schema{Type: "object"},
+			},
+		},
+		Metadata: meta,
+	}
+
+	initialCount := len(route.Response)
+	ext.expandHelperFunctionResponses(routeNode, route)
+	assert.Equal(t, initialCount, len(route.Response), "should not overwrite existing responses")
+}
+
+func TestExpandHelperFunctionResponses_NoChildren(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	routeNode := &TrackerNode{key: "route"}
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	ext.expandHelperFunctionResponses(routeNode, route)
+	assert.Empty(t, route.Response)
+}
+
+func TestExpandHelperFunctionResponses_NoStatusParamFound(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	// Two calls to the same helper but params don't resolve to status codes
+	unknownArg := makeCallArg(meta)
+	unknownArg.SetKind(metadata.KindIdent)
+	unknownArg.SetName("x")
+	unknownArg.SetType("int")
+
+	edge1 := makeHelperEdge(meta, "doSomething", "helpers", map[string]metadata.CallArgument{
+		"x": *unknownArg,
+	})
+	edge2 := makeHelperEdge(meta, "doSomething", "helpers", map[string]metadata.CallArgument{
+		"x": *unknownArg,
+	})
+
+	routeNode := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "call1", CallGraphEdge: &edge1},
+			{key: "call2", CallGraphEdge: &edge2},
+		},
+	}
+
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{},
+		Metadata: meta,
+	}
+
+	ext.expandHelperFunctionResponses(routeNode, route)
+	assert.Empty(t, route.Response)
+}

--- a/internal/spec/extractor_helper_test.go
+++ b/internal/spec/extractor_helper_test.go
@@ -862,11 +862,23 @@ func TestExpandHelperFunctionResponses_AddsNewResponses(t *testing.T) {
 		"data": *dataArg2,
 	})
 
+	// Helper nodes need a child that matches a response pattern (WriteHeader)
+	// so helperContainsResponsePattern returns true.
+	writeHeaderEdge := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta:     meta,
+			Name:     meta.StringPool.Get("WriteHeader"),
+			Pkg:      meta.StringPool.Get("net/http"),
+			RecvType: meta.StringPool.Get("ResponseWriter"),
+		},
+	}
+	whChild := &TrackerNode{key: "net/http.ResponseWriter.WriteHeader", CallGraphEdge: writeHeaderEdge}
+
 	routeNode := &TrackerNode{
 		key: "route",
 		Children: []*TrackerNode{
-			{key: "call1", CallGraphEdge: &edge1},
-			{key: "call2", CallGraphEdge: &edge2},
+			{key: "call1", CallGraphEdge: &edge1, Children: []*TrackerNode{whChild}},
+			{key: "call2", CallGraphEdge: &edge2, Children: []*TrackerNode{whChild}},
 		},
 	}
 

--- a/testdata/error_helpers/expected_openapi.json
+++ b/testdata/error_helpers/expected_openapi.json
@@ -1,0 +1,237 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "error_helpers.ListItems",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/error_helpers.Item"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "post": {
+        "operationId": "error_helpers.CreateUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/error_helpers.User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "operationId": "error_helpers.GetUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "error_helpers.UpdateUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/error_helpers.User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "error_helpers.ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "code",
+          "message"
+        ]
+      },
+      "error_helpers.Item": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ]
+      },
+      "error_helpers.User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/error_helpers/expected_openapi_legacy.json
+++ b/testdata/error_helpers/expected_openapi_legacy.json
@@ -1,0 +1,237 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "error_helpers.ListItems",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/error_helpers.Item"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "post": {
+        "operationId": "error_helpers.CreateUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/error_helpers.User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "operationId": "error_helpers.GetUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "error_helpers.UpdateUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/error_helpers.User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_helpers.ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "error_helpers.ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "code",
+          "message"
+        ]
+      },
+      "error_helpers.Item": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ]
+      },
+      "error_helpers.User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/error_helpers/go.mod
+++ b/testdata/error_helpers/go.mod
@@ -1,0 +1,5 @@
+module error_helpers
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.2.5

--- a/testdata/error_helpers/go.sum
+++ b/testdata/error_helpers/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/testdata/error_helpers/main.go
+++ b/testdata/error_helpers/main.go
@@ -1,0 +1,105 @@
+// Package main demonstrates error helper function patterns for testing
+// apispec's ability to detect response types and status codes passed
+// through helper functions via parameter propagation.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// User represents a user entity.
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Item represents an item entity.
+type Item struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+}
+
+// ErrorResponse represents a standard error response.
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// --- Error helper functions ---
+
+// writeJSONError writes a JSON error response with the given status code.
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(ErrorResponse{Error: msg, Code: code})
+}
+
+// respondJSON writes a JSON success response with the given status code.
+func respondJSON(w http.ResponseWriter, code int, data interface{}) {
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(data)
+}
+
+func main() {
+	r := chi.NewRouter()
+
+	r.Get("/users/{id}", GetUser)
+	r.Post("/users", CreateUser)
+	r.Put("/users/{id}", UpdateUser)
+	r.Get("/items", ListItems)
+
+	http.ListenAndServe(":3000", r)
+}
+
+// GetUser returns a user by ID, or 400/404 errors via helper.
+func GetUser(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing id parameter")
+		return
+	}
+	if id == "0" {
+		writeJSONError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	json.NewEncoder(w).Encode(User{ID: 1, Name: "Alice"})
+}
+
+// CreateUser creates a new user, or returns 400/413 errors via helper.
+func CreateUser(w http.ResponseWriter, r *http.Request) {
+	var user User
+	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if user.Name == "" {
+		writeJSONError(w, http.StatusUnprocessableEntity, "name is required")
+		return
+	}
+	respondJSON(w, http.StatusCreated, user)
+}
+
+// ListItems returns all items, or 500 error via helper.
+func ListItems(w http.ResponseWriter, r *http.Request) {
+	items := []Item{{ID: 1, Title: "Widget"}}
+	if len(items) == 0 {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load items")
+		return
+	}
+	json.NewEncoder(w).Encode(items)
+}
+
+// UpdateUser uses respondJSON for BOTH success and error with different types.
+// This tests that sibling calls to the same helper get their own schema
+// based on their own arguments, not copied from the first call.
+func UpdateUser(w http.ResponseWriter, r *http.Request) {
+	var user User
+	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+		respondJSON(w, http.StatusBadRequest, ErrorResponse{Error: "invalid body"})
+		return
+	}
+	respondJSON(w, http.StatusOK, user)
+}

--- a/testdata/error_helpers/main.go
+++ b/testdata/error_helpers/main.go
@@ -68,7 +68,7 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(User{ID: 1, Name: "Alice"})
 }
 
-// CreateUser creates a new user, or returns 400/413 errors via helper.
+// CreateUser creates a new user, or returns 400/422 errors via helper.
 func CreateUser(w http.ResponseWriter, r *http.Request) {
 	var user User
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
@@ -83,6 +83,8 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 }
 
 // ListItems returns all items, or 500 error via helper.
+// Note: items is non-empty here; the error branch exercises 500 status detection
+// in the static analysis (the tool traces both branches regardless of runtime values).
 func ListItems(w http.ResponseWriter, r *http.Request) {
 	items := []Item{{ID: 1, Title: "Widget"}}
 	if len(items) == 0 {


### PR DESCRIPTION
## Summary
Error helper functions like `writeJSONError(w, http.StatusBadRequest, "msg")` now produce the correct status code and response schema in the generated OpenAPI spec.

**Before**: only 200 OK detected — error helpers were invisible to static analysis.
**After**: `writeJSONError(w, 400, "msg")` → 400 Bad Request with ErrorResponse schema.

## How it works
When a `WriteHeader(code)` call uses a function parameter (not a local variable or constant), the new `resolveParamArgStatus()` method walks up the tracker tree parent chain to find the `ParamArgMap` entry that maps the parameter name to the actual argument passed by the caller.

```
Handler:  writeJSONError(w, http.StatusBadRequest, "msg")
                              ↑ ParamArgMap["code"] = StatusBadRequest
Helper:   func writeJSONError(w, code int, msg string) {
              w.WriteHeader(code)  ← resolves "code" via parent's ParamArgMap → 400
              json.Encode(ErrorResponse{...})
          }
```

## Changes
- `internal/spec/extractor.go`: Add `resolveParamArgStatus()`, `addResponse()` helper, refactor response callback
- `internal/engine/engine_e2e_test.go`: Add `error_helpers` to golden test matrix
- `testdata/error_helpers/`: New fixture with 3 endpoints using error helpers

## Known limitation
When the same helper is called multiple times from one handler with different status codes (e.g., 400 and 404), only the first call's status code is captured. The shared `WriteHeader` node inside the helper is deduplicated by `Callee.ID()`. Fixing this requires per-parent-context dedup which has cascading effects — tracked for future work.

## Test plan
- [x] All 16 golden files pass (8 frameworks × 2 naming modes)
- [x] No regressions on existing frameworks
- [x] Coverage: 95.7% (above 95%)
- [x] Lint clean
- [x] New error_helpers fixture verifies: 400, 201, 500 via helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end/golden and unit test coverage to include a new error-handling dataset and extensive helper-response resolution tests.

* **New Fixtures**
  * Added OpenAPI fixtures and a sample server describing endpoints, request/response shapes, and error schemas used by tests.

* **New Features**
  * Enhanced response extraction to better resolve status codes and concrete body types for routes that rely on helper-call patterns.

* **Chores**
  * Added test dataset module setup and updated ignore rules for the new testdata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->