### PR TITLE
fix: dynamic content-type falls back to application/octet-stream

### DIFF
--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -184,6 +184,17 @@ type Extractor struct {
 	paramMatchers    []ParamPatternMatcher
 }
 
+// isLikelyMediaType checks if a string looks like a valid MIME type (type/subtype).
+// Returns false for Go variable/field paths like "model.Document.MimeType".
+func isLikelyMediaType(v string) bool {
+	// Strip parameters (e.g., "text/plain; charset=utf-8" → "text/plain")
+	if idx := strings.IndexByte(v, ';'); idx >= 0 {
+		v = strings.TrimSpace(v[:idx])
+	}
+	parts := strings.SplitN(v, "/", 2)
+	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+}
+
 // checkContentTypePattern checks if a node matches a Content-Type header set pattern
 // (e.g., w.Header().Set("Content-Type", "image/png")) and stores the detected
 // content type on all route responses.
@@ -222,10 +233,10 @@ func (e *Extractor) checkContentTypePattern(node TrackerNodeInterface, route *Ro
 			if strings.EqualFold(headerName, "Content-Type") && len(edge.Args) > pattern.HeaderValueArgIndex {
 				val := e.contextProvider.GetArgumentInfo(edge.Args[pattern.HeaderValueArgIndex])
 				val = strings.Trim(val, "\"")
-				// If the value doesn't look like a valid MIME type (must contain "/"),
-				// it's a variable or field path (e.g., doc.MimeType). Fall back to
-				// application/octet-stream for dynamic content types.
-				if val != "" && !strings.Contains(val, "/") {
+				// Validate the value looks like a MIME type (type/subtype).
+				// Variable or field paths (e.g., doc.MimeType) don't contain "/"
+				// and should fall back to application/octet-stream.
+				if val != "" && !isLikelyMediaType(val) {
 					val = "application/octet-stream"
 				}
 				if val != "" {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -187,6 +187,10 @@ type Extractor struct {
 // isLikelyMediaType checks if a string looks like a valid MIME type (type/subtype).
 // Returns false for Go variable/field paths like "model.Document.MimeType".
 func isLikelyMediaType(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
 	// Strip parameters (e.g., "text/plain; charset=utf-8" → "text/plain")
 	if idx := strings.IndexByte(v, ';'); idx >= 0 {
 		v = strings.TrimSpace(v[:idx])

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -222,6 +222,12 @@ func (e *Extractor) checkContentTypePattern(node TrackerNodeInterface, route *Ro
 			if strings.EqualFold(headerName, "Content-Type") && len(edge.Args) > pattern.HeaderValueArgIndex {
 				val := e.contextProvider.GetArgumentInfo(edge.Args[pattern.HeaderValueArgIndex])
 				val = strings.Trim(val, "\"")
+				// If the value doesn't look like a valid MIME type (must contain "/"),
+				// it's a variable or field path (e.g., doc.MimeType). Fall back to
+				// application/octet-stream for dynamic content types.
+				if val != "" && !strings.Contains(val, "/") {
+					val = "application/octet-stream"
+				}
 				if val != "" {
 					// Override content type on existing responses that use the
 					// default. Don't override responses with pattern-specific

--- a/internal/spec/extractor_additional_test.go
+++ b/internal/spec/extractor_additional_test.go
@@ -2357,3 +2357,65 @@ func TestHandleVariableMount_NilMetadata(_ *testing.T) {
 	// Should not panic when tree metadata is nil
 	ext.handleVariableMount(arg, "/api/", nil, &[]*RouteInfo{})
 }
+
+func TestCheckContentTypePattern_DynamicVariable_FallsBackToOctetStream(t *testing.T) {
+	meta := newTestMeta()
+
+	// Build edge: Header().Set("Content-Type", doc.MimeType)
+	// doc.MimeType resolves to a Go field path, not a MIME type
+	headerNameArg := makeLiteralArg(meta, `"Content-Type"`)
+	headerValueArg := metadata.NewCallArgument(meta)
+	headerValueArg.SetKind(metadata.KindSelector)
+	headerValueArg.SetName("MimeType")
+	headerValueArg.SetPkg("model")
+	headerValueArg.SetType("string")
+	headerValueArg.Sel = metadata.NewCallArgument(meta)
+	headerValueArg.Sel.SetName("MimeType")
+
+	edge := metadata.CallGraphEdge{
+		Caller: metadata.Call{
+			Meta: meta,
+			Name: meta.StringPool.Get("handler"),
+			Pkg:  meta.StringPool.Get("main"),
+		},
+		Callee: metadata.Call{
+			Meta:     meta,
+			Name:     meta.StringPool.Get("Set"),
+			Pkg:      meta.StringPool.Get("net/http"),
+			RecvType: meta.StringPool.Get("Header"),
+		},
+		Args: []*metadata.CallArgument{headerNameArg, headerValueArg},
+	}
+	edge.Caller.Edge = &edge
+	edge.Callee.Edge = &edge
+	node := makeTrackerNode(&edge)
+
+	tree := NewMockTrackerTree(meta, metadata.TrackerLimits{
+		MaxNodesPerTree: 100, MaxChildrenPerNode: 10, MaxArgsPerFunction: 5, MaxNestedArgsDepth: 3,
+	})
+	cfg := &APISpecConfig{
+		Defaults: Defaults{ResponseContentType: "application/json"},
+		Framework: FrameworkConfig{
+			ContentTypePatterns: []ContentTypePattern{
+				{
+					BasePattern:         BasePattern{CallRegex: "^Set$", RecvTypeRegex: "Header"},
+					HeaderNameArgIndex:  0,
+					HeaderValueArgIndex: 1,
+				},
+			},
+		},
+	}
+	ext := NewExtractor(tree, cfg)
+
+	route := NewRouteInfo()
+	route.Response["200"] = &ResponseInfo{
+		StatusCode:  200,
+		ContentType: "application/json",
+	}
+
+	ext.checkContentTypePattern(node, route)
+
+	// Dynamic content type (Go field path without "/") should fall back to application/octet-stream
+	assert.Equal(t, "application/octet-stream", route.Response["200"].ContentType)
+	assert.Equal(t, "application/octet-stream", route.detectedContentType)
+}


### PR DESCRIPTION
## Summary
When `w.Header().Set("Content-Type", doc.MimeType)` uses a variable or struct field instead of a literal string, the resolved value is a Go field path (e.g., `model.Document.MimeType`) which is not a valid MIME type.

Now detects non-MIME values (no `/` in the string) and falls back to `application/octet-stream`.

## Before
```yaml
content:
  model.Document.MimeType:  # ← Go field path as content type key
    schema: ...
```

## After
```yaml
content:
  application/octet-stream:  # ← proper fallback for dynamic MIME types
    schema: ...
```

## Test plan
- [x] All 16 golden files pass (no regressions)
- [x] Literal MIME types (image/png, text/plain) still work
- [x] New unit test for dynamic variable fallback
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-literal or dynamically determined Content-Type values are now normalized: if a value doesn't resemble a MIME type, responses will default to application/octet-stream to ensure consistent response content-type assignment.

* **Tests**
  * Added a unit test confirming dynamic/non-literal Content-Type values fall back to application/octet-stream and that detected response content types are set accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->