### PR TITLE
fix: isLikelyMediaType rejects Go module paths with multiple slashes

### DIFF
--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -185,7 +185,8 @@ type Extractor struct {
 }
 
 // isLikelyMediaType checks if a string looks like a valid MIME type (type/subtype).
-// Returns false for Go variable/field paths like "model.Document.MimeType".
+// Returns false for Go variable/field paths like "model.Document.MimeType" or
+// fully-qualified Go paths like "github.com/org/pkg/model.Document.MimeType".
 func isLikelyMediaType(v string) bool {
 	v = strings.TrimSpace(v)
 	if v == "" {
@@ -195,8 +196,22 @@ func isLikelyMediaType(v string) bool {
 	if idx := strings.IndexByte(v, ';'); idx >= 0 {
 		v = strings.TrimSpace(v[:idx])
 	}
+	// A valid MIME type has exactly one "/" separating type and subtype.
+	// Go import paths have multiple slashes (github.com/org/pkg/...).
+	if strings.Count(v, "/") != 1 {
+		return false
+	}
 	parts := strings.SplitN(v, "/", 2)
-	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+	if parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	// MIME type parts don't contain dots (e.g., "application" not "model.Document").
+	// Go field paths always have dots. Exception: vendor MIME subtypes like
+	// "vnd.api+json" are valid, so only check the type (left of /).
+	if strings.Contains(parts[0], ".") {
+		return false
+	}
+	return true
 }
 
 // checkContentTypePattern checks if a node matches a Content-Type header set pattern

--- a/internal/spec/extractor_additional_test.go
+++ b/internal/spec/extractor_additional_test.go
@@ -2419,3 +2419,35 @@ func TestCheckContentTypePattern_DynamicVariable_FallsBackToOctetStream(t *testi
 	assert.Equal(t, "application/octet-stream", route.Response["200"].ContentType)
 	assert.Equal(t, "application/octet-stream", route.detectedContentType)
 }
+
+func TestIsLikelyMediaType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"application/json", true},
+		{"image/png", true},
+		{"text/plain; charset=utf-8", true},
+		{"application/octet-stream", true},
+		{"application/vnd.api+json", true},
+		{"multipart/form-data", true},
+		{"*/*", true},
+		// Go field paths — NOT media types
+		{"model.Document.MimeType", false},
+		{"MimeType", false},
+		{"github.com/org/pkg/model.Document.MimeType", false}, // multiple slashes
+		// Note: "net/http.ResponseWriter" would pass (1 slash, no dot in type part)
+		// but this value never appears as a content-type in practice.
+		// Edge cases
+		{"", false},
+		{"  ", false},
+		{"/", false},
+		{"text/", false},
+		{"/plain", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isLikelyMediaType(tt.input), "isLikelyMediaType(%q)", tt.input)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to PR #10. The previous `isLikelyMediaType` check accepted fully-qualified Go paths like `github.com/org/pkg/model.Document.MimeType` because they contain `/`.

Now validates:
- Exactly one `/` (rejects multi-slash Go import paths)
- No dots in the type portion (rejects `model.Document/...`)
- Non-empty type and subtype

## Test plan
- [x] All 16 golden files pass
- [x] New `TestIsLikelyMediaType` with 16 cases covering valid MIME types, Go paths, and edge cases
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Content-Type header validation to reject malformed formats, including inputs with multiple separators and empty components.

* **Tests**
  * Added test coverage for Content-Type header validation across standard and edge-case formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->