### PR TITLE
feat: extract Go doc comments as OpenAPI summary/description

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/tools v0.43.0
+	golang.org/x/tools v0.44.0
 	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -13,7 +13,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/tools/go/expect v0.1.0-deprecated // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
-golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
-golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
 golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -111,18 +111,19 @@ func schemasEqual(a, b *Schema) bool {
 
 // RouteInfo represents extracted route information
 type RouteInfo struct {
-	Path      string
-	MountPath string
-	Method    string
-	Handler   string
-	Package   string
-	File      string
-	Function  string
-	Summary   string
-	Tags      []string
-	Request   *RequestInfo
-	Response  map[string]*ResponseInfo
-	Params    []Parameter
+	Path        string
+	MountPath   string
+	Method      string
+	Handler     string
+	Package     string
+	File        string
+	Function    string
+	Summary     string
+	Description string
+	Tags        []string
+	Request     *RequestInfo
+	Response    map[string]*ResponseInfo
+	Params      []Parameter
 
 	UsedTypes map[string]*Schema
 	Metadata  *metadata.Metadata
@@ -832,6 +833,7 @@ func (e *Extractor) splitByConditionalMethods(route *RouteInfo) []*RouteInfo {
 			File:                route.File,
 			Function:            route.Function,
 			Summary:             route.Summary,
+			Description:         route.Description,
 			Tags:                route.Tags,
 			Request:             route.Request,
 			Response:            responses,

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -386,6 +386,9 @@ func buildPathsFromRoutes(routes []*RouteInfo, cfg *APISpecConfig) map[string]Pa
 		if route.Summary != "" {
 			summary = route.Summary // Override/config takes precedence
 		}
+		if route.Description != "" {
+			description = route.Description // Override/config takes precedence
+		}
 
 		operation := &Operation{
 			OperationID: operationID,
@@ -2158,13 +2161,16 @@ func parseArraySize(sizeStr string) *int {
 // and splits it into summary (first sentence) and description (full text).
 // Returns empty strings if no comment is found.
 func extractDocComment(route *RouteInfo) (summary, description string) {
-	if route.Metadata == nil || route.Metadata.StringPool == nil {
+	if route == nil || route.Metadata == nil || route.Metadata.StringPool == nil {
 		return "", ""
 	}
 
-	// Extract the bare function name from the route function path
+	// Extract the bare function name and package from the route function path.
+	// route.Function is e.g. "myapp.UserHandler.GetUser" or "myapp.GetUser"
 	funcName := route.Function
+	pkgPrefix := ""
 	if idx := strings.LastIndex(funcName, "."); idx >= 0 {
+		pkgPrefix = funcName[:idx]
 		funcName = funcName[idx+1:]
 	}
 	// Strip position suffix if present (e.g., "FuncLit:file.go:10")
@@ -2172,7 +2178,24 @@ func extractDocComment(route *RouteInfo) (summary, description string) {
 		funcName = funcName[:idx]
 	}
 
-	// Search for the function in metadata packages
+	// First pass: try to match by package to avoid cross-package collisions
+	if pkgPrefix != "" {
+		for pkgName, pkg := range route.Metadata.Packages {
+			if !strings.HasSuffix(pkgPrefix, pkgName) && !strings.HasSuffix(pkgName, pkgPrefix) {
+				continue
+			}
+			for _, file := range pkg.Files {
+				if fn, exists := file.Functions[funcName]; exists {
+					comment := route.Metadata.StringPool.GetString(fn.Comments)
+					if comment != "" {
+						return splitDocComment(comment)
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: search all packages (for cases where package prefix doesn't match)
 	for _, pkg := range route.Metadata.Packages {
 		for _, file := range pkg.Files {
 			if fn, exists := file.Functions[funcName]; exists {

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -2160,15 +2160,22 @@ func parseArraySize(sizeStr string) *int {
 // extractDocComment looks up the handler function's doc comment from metadata
 // and splits it into summary (first sentence) and description (full text).
 // Returns empty strings if no comment is found.
-func extractDocComment(route *RouteInfo) (summary, description string) {
-	if route == nil || route.Metadata == nil || route.Metadata.StringPool == nil {
-		return "", ""
+// lookupFuncComment searches a package for a function's doc comment.
+func lookupFuncComment(pkg *metadata.Package, funcName string, sp *metadata.StringPool) (string, string) {
+	for _, file := range pkg.Files {
+		if fn, exists := file.Functions[funcName]; exists {
+			if comment := sp.GetString(fn.Comments); comment != "" {
+				return splitDocComment(comment)
+			}
+		}
 	}
+	return "", ""
+}
 
-	// Extract the bare function name and package from the route function path.
-	// route.Function is e.g. "myapp.UserHandler.GetUser" or "myapp.GetUser"
-	funcName := route.Function
-	pkgPrefix := ""
+// parseFuncNameAndPackage extracts the bare function name and package prefix
+// from a route function path like "myapp.UserHandler.GetUser".
+func parseFuncNameAndPackage(function string) (funcName, pkgPrefix string) {
+	funcName = function
 	if idx := strings.LastIndex(funcName, "."); idx >= 0 {
 		pkgPrefix = funcName[:idx]
 		funcName = funcName[idx+1:]
@@ -2177,34 +2184,43 @@ func extractDocComment(route *RouteInfo) (summary, description string) {
 	if idx := strings.Index(funcName, ":"); idx >= 0 {
 		funcName = funcName[:idx]
 	}
+	return funcName, pkgPrefix
+}
 
-	// First pass: try to match by package to avoid cross-package collisions
+func extractDocComment(route *RouteInfo) (summary, description string) {
+	if route == nil || route.Metadata == nil || route.Metadata.StringPool == nil {
+		return "", ""
+	}
+
+	funcName, pkgPrefix := parseFuncNameAndPackage(route.Function)
+	sp := route.Metadata.StringPool
+
+	// First pass: use route.Package if available (most precise).
+	if route.Package != "" {
+		if pkg, ok := route.Metadata.Packages[route.Package]; ok {
+			if s, d := lookupFuncComment(pkg, funcName, sp); s != "" || d != "" {
+				return s, d
+			}
+		}
+	}
+
+	// Second pass: match by pkgPrefix suffix against metadata package keys.
+	// Handles cases like pkgPrefix="users.UserHandler" matching package "users".
 	if pkgPrefix != "" {
 		for pkgName, pkg := range route.Metadata.Packages {
 			if !strings.HasSuffix(pkgPrefix, pkgName) && !strings.HasSuffix(pkgName, pkgPrefix) {
 				continue
 			}
-			for _, file := range pkg.Files {
-				if fn, exists := file.Functions[funcName]; exists {
-					comment := route.Metadata.StringPool.GetString(fn.Comments)
-					if comment != "" {
-						return splitDocComment(comment)
-					}
-				}
+			if s, d := lookupFuncComment(pkg, funcName, sp); s != "" || d != "" {
+				return s, d
 			}
 		}
 	}
 
 	// Fallback: search all packages (for cases where package prefix doesn't match)
 	for _, pkg := range route.Metadata.Packages {
-		for _, file := range pkg.Files {
-			if fn, exists := file.Functions[funcName]; exists {
-				comment := route.Metadata.StringPool.GetString(fn.Comments)
-				if comment == "" {
-					continue
-				}
-				return splitDocComment(comment)
-			}
+		if s, d := lookupFuncComment(pkg, funcName, sp); s != "" || d != "" {
+			return s, d
 		}
 	}
 	return "", ""

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -381,9 +381,16 @@ func buildPathsFromRoutes(routes []*RouteInfo, cfg *APISpecConfig) map[string]Pa
 			operationID = shortenOperationID(operationID)
 		}
 
+		// Extract summary and description from handler function's doc comment.
+		summary, description := extractDocComment(route)
+		if route.Summary != "" {
+			summary = route.Summary // Override/config takes precedence
+		}
+
 		operation := &Operation{
 			OperationID: operationID,
-			Summary:     route.Summary,
+			Summary:     summary,
+			Description: description,
 			Tags:        route.Tags,
 		}
 
@@ -2145,4 +2152,68 @@ func parseArraySize(sizeStr string) *int {
 
 	// If it's not a number, return nil (no size constraint)
 	return nil
+}
+
+// extractDocComment looks up the handler function's doc comment from metadata
+// and splits it into summary (first sentence) and description (full text).
+// Returns empty strings if no comment is found.
+func extractDocComment(route *RouteInfo) (summary, description string) {
+	if route.Metadata == nil || route.Metadata.StringPool == nil {
+		return "", ""
+	}
+
+	// Extract the bare function name from the route function path
+	funcName := route.Function
+	if idx := strings.LastIndex(funcName, "."); idx >= 0 {
+		funcName = funcName[idx+1:]
+	}
+	// Strip position suffix if present (e.g., "FuncLit:file.go:10")
+	if idx := strings.Index(funcName, ":"); idx >= 0 {
+		funcName = funcName[:idx]
+	}
+
+	// Search for the function in metadata packages
+	for _, pkg := range route.Metadata.Packages {
+		for _, file := range pkg.Files {
+			if fn, exists := file.Functions[funcName]; exists {
+				comment := route.Metadata.StringPool.GetString(fn.Comments)
+				if comment == "" {
+					continue
+				}
+				return splitDocComment(comment)
+			}
+		}
+	}
+	return "", ""
+}
+
+// splitDocComment splits a Go doc comment into summary and description.
+// Summary is the first sentence (up to the first ". " or ".\n" or the whole
+// text if no sentence boundary). Description is the full comment text.
+// If the comment is a single sentence, description is left empty to avoid
+// duplication in the OpenAPI output.
+func splitDocComment(comment string) (summary, description string) {
+	comment = strings.TrimSpace(comment)
+	if comment == "" {
+		return "", ""
+	}
+
+	// Find the first sentence boundary
+	summary = comment
+	for i, r := range comment {
+		if r == '.' && i+1 < len(comment) {
+			next := comment[i+1]
+			if next == ' ' || next == '\n' || next == '\r' {
+				summary = comment[:i+1]
+				break
+			}
+		}
+	}
+
+	// If the summary IS the full comment (single sentence), don't duplicate
+	if strings.TrimSpace(strings.TrimSuffix(summary, ".")) == strings.TrimSpace(strings.TrimSuffix(comment, ".")) {
+		return summary, ""
+	}
+
+	return summary, comment
 }

--- a/internal/spec/mapper_doccomment_test.go
+++ b/internal/spec/mapper_doccomment_test.go
@@ -1,0 +1,177 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+func TestSplitDocComment_SingleSentence(t *testing.T) {
+	summary, desc := splitDocComment("GetUser returns a user by ID.")
+	assert.Equal(t, "GetUser returns a user by ID.", summary)
+	assert.Empty(t, desc, "single sentence should not duplicate as description")
+}
+
+func TestSplitDocComment_MultipleSentences(t *testing.T) {
+	summary, desc := splitDocComment("GetUser returns a user by ID. It requires authentication and checks permissions.")
+	assert.Equal(t, "GetUser returns a user by ID.", summary)
+	assert.Equal(t, "GetUser returns a user by ID. It requires authentication and checks permissions.", desc)
+}
+
+func TestSplitDocComment_MultiLine(t *testing.T) {
+	comment := "GetUser returns a user by ID.\nIt requires authentication."
+	summary, desc := splitDocComment(comment)
+	assert.Equal(t, "GetUser returns a user by ID.", summary)
+	assert.Equal(t, comment, desc)
+}
+
+func TestSplitDocComment_Empty(t *testing.T) {
+	summary, desc := splitDocComment("")
+	assert.Empty(t, summary)
+	assert.Empty(t, desc)
+}
+
+func TestSplitDocComment_Whitespace(t *testing.T) {
+	summary, desc := splitDocComment("  ")
+	assert.Empty(t, summary)
+	assert.Empty(t, desc)
+}
+
+func TestSplitDocComment_NoPeriod(t *testing.T) {
+	summary, desc := splitDocComment("Returns a user by ID")
+	assert.Equal(t, "Returns a user by ID", summary)
+	assert.Empty(t, desc)
+}
+
+func TestSplitDocComment_PeriodAtEnd(t *testing.T) {
+	summary, desc := splitDocComment("Returns a user by ID.")
+	assert.Equal(t, "Returns a user by ID.", summary)
+	assert.Empty(t, desc)
+}
+
+func TestSplitDocComment_URLInComment(t *testing.T) {
+	// URLs contain dots but shouldn't be treated as sentence boundaries
+	comment := "See https://example.com/docs for details. More info here."
+	summary, desc := splitDocComment(comment)
+	assert.Equal(t, "See https://example.com/docs for details.", summary)
+	assert.Equal(t, comment, desc)
+}
+
+func TestExtractDocComment_Found(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"myapp": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Functions: map[string]*metadata.Function{
+							"GetUser": {
+								Name:     sp.Get("GetUser"),
+								Comments: sp.Get("GetUser returns a user by ID. It checks permissions."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := &RouteInfo{
+		Function: "myapp.GetUser",
+		Metadata: meta,
+	}
+
+	summary, desc := extractDocComment(route)
+	assert.Equal(t, "GetUser returns a user by ID.", summary)
+	assert.Contains(t, desc, "It checks permissions.")
+}
+
+func TestExtractDocComment_NotFound(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages:   map[string]*metadata.Package{},
+	}
+
+	route := &RouteInfo{
+		Function: "myapp.UnknownFunc",
+		Metadata: meta,
+	}
+
+	summary, desc := extractDocComment(route)
+	assert.Empty(t, summary)
+	assert.Empty(t, desc)
+}
+
+func TestExtractDocComment_NilMetadata(t *testing.T) {
+	route := &RouteInfo{
+		Function: "myapp.GetUser",
+		Metadata: nil,
+	}
+
+	summary, desc := extractDocComment(route)
+	assert.Empty(t, summary)
+	assert.Empty(t, desc)
+}
+
+func TestExtractDocComment_EmptyComment(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"myapp": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Functions: map[string]*metadata.Function{
+							"GetUser": {
+								Name:     sp.Get("GetUser"),
+								Comments: sp.Get(""), // empty comment
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := &RouteInfo{
+		Function: "myapp.GetUser",
+		Metadata: meta,
+	}
+
+	summary, desc := extractDocComment(route)
+	assert.Empty(t, summary)
+	assert.Empty(t, desc)
+}
+
+func TestExtractDocComment_ReceiverMethod(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"handlers": {
+				Files: map[string]*metadata.File{
+					"user.go": {
+						Functions: map[string]*metadata.Function{
+							"GetUser": {
+								Name:     sp.Get("GetUser"),
+								Comments: sp.Get("GetUser fetches a user."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := &RouteInfo{
+		Function: "handlers.UserHandler.GetUser",
+		Metadata: meta,
+	}
+
+	summary, _ := extractDocComment(route)
+	assert.Equal(t, "GetUser fetches a user.", summary)
+}

--- a/internal/spec/mapper_doccomment_test.go
+++ b/internal/spec/mapper_doccomment_test.go
@@ -175,3 +175,150 @@ func TestExtractDocComment_ReceiverMethod(t *testing.T) {
 	summary, _ := extractDocComment(route)
 	assert.Equal(t, "GetUser fetches a user.", summary)
 }
+
+func TestExtractDocComment_NilRoute(_ *testing.T) {
+	// Should not panic
+	extractDocComment(nil)
+}
+
+func TestExtractDocComment_PackageScopedLookup(t *testing.T) {
+	// Two packages with same function name but different comments
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"users": {
+				Files: map[string]*metadata.File{
+					"handler.go": {
+						Functions: map[string]*metadata.Function{
+							"Create": {
+								Name:     sp.Get("Create"),
+								Comments: sp.Get("Create registers a new user."),
+							},
+						},
+					},
+				},
+			},
+			"items": {
+				Files: map[string]*metadata.File{
+					"handler.go": {
+						Functions: map[string]*metadata.Function{
+							"Create": {
+								Name:     sp.Get("Create"),
+								Comments: sp.Get("Create adds a new item."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Should match the correct package
+	route := &RouteInfo{Function: "users.Create", Metadata: meta}
+	summary, _ := extractDocComment(route)
+	assert.Equal(t, "Create registers a new user.", summary)
+
+	route2 := &RouteInfo{Function: "items.Create", Metadata: meta}
+	summary2, _ := extractDocComment(route2)
+	assert.Equal(t, "Create adds a new item.", summary2)
+}
+
+func TestExtractDocComment_FallbackWhenPackageDoesntMatch(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"myapp": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Functions: map[string]*metadata.Function{
+							"Serve": {
+								Name:     sp.Get("Serve"),
+								Comments: sp.Get("Serve starts the server."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Package prefix doesn't match any metadata package — falls back to global search
+	route := &RouteInfo{Function: "unknown.Serve", Metadata: meta}
+	summary, _ := extractDocComment(route)
+	assert.Equal(t, "Serve starts the server.", summary)
+}
+
+func TestExtractDocComment_DescriptionOverrideTakesPrecedence(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"myapp": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Functions: map[string]*metadata.Function{
+							"GetUser": {
+								Name:     sp.Get("GetUser"),
+								Comments: sp.Get("GetUser returns a user. It checks permissions."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := &RouteInfo{
+		Function:    "myapp.GetUser",
+		Description: "Custom description from config override.",
+		Metadata:    meta,
+	}
+
+	// Simulate what the mapper does
+	summary, description := extractDocComment(route)
+	if route.Summary != "" {
+		summary = route.Summary
+	}
+	if route.Description != "" {
+		description = route.Description
+	}
+
+	assert.Equal(t, "GetUser returns a user.", summary)
+	assert.Equal(t, "Custom description from config override.", description)
+}
+
+func TestExtractDocComment_SummaryOverrideTakesPrecedence(t *testing.T) {
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"myapp": {
+				Files: map[string]*metadata.File{
+					"main.go": {
+						Functions: map[string]*metadata.Function{
+							"GetUser": {
+								Name:     sp.Get("GetUser"),
+								Comments: sp.Get("GetUser returns a user."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := &RouteInfo{
+		Function: "myapp.GetUser",
+		Summary:  "Custom summary from config.",
+		Metadata: meta,
+	}
+
+	summary, _ := extractDocComment(route)
+	if route.Summary != "" {
+		summary = route.Summary
+	}
+
+	assert.Equal(t, "Custom summary from config.", summary)
+}

--- a/testdata/chi/expected_openapi.json
+++ b/testdata/chi/expected_openapi.json
@@ -18,6 +18,7 @@
         "tags": [
           "/payment"
         ],
+        "summary": "ProcessPayment processes a payment request.",
         "operationId": "payment.ProcessPayment",
         "responses": {
           "200": {
@@ -41,6 +42,7 @@
         "tags": [
           "/payment"
         ],
+        "summary": "GetStripePublicKey returns the Stripe public key for the payment system.",
         "operationId": "payment.GetStripePublicKey",
         "responses": {
           "200": {

--- a/testdata/chi/expected_openapi_legacy.json
+++ b/testdata/chi/expected_openapi_legacy.json
@@ -18,6 +18,7 @@
         "tags": [
           "/payment"
         ],
+        "summary": "ProcessPayment processes a payment request.",
         "operationId": "github.com/antst/go-apispec/testdata/chi/payment.ProcessPayment",
         "responses": {
           "200": {
@@ -41,6 +42,7 @@
         "tags": [
           "/payment"
         ],
+        "summary": "GetStripePublicKey returns the Stripe public key for the payment system.",
         "operationId": "github.com/antst/go-apispec/testdata/chi/payment.GetStripePublicKey",
         "responses": {
           "200": {

--- a/testdata/echo/expected_openapi.json
+++ b/testdata/echo/expected_openapi.json
@@ -15,6 +15,7 @@
   "paths": {
     "/api/info": {
       "get": {
+        "summary": "getAPIInfo returns information about the API.",
         "operationId": "echo.getAPIInfo",
         "responses": {
           "200": {
@@ -35,6 +36,7 @@
     },
     "/health": {
       "get": {
+        "summary": "healthCheck returns the health status of the API.",
         "operationId": "echo.healthCheck",
         "responses": {
           "200": {

--- a/testdata/echo/expected_openapi_legacy.json
+++ b/testdata/echo/expected_openapi_legacy.json
@@ -15,6 +15,7 @@
   "paths": {
     "/api/info": {
       "get": {
+        "summary": "getAPIInfo returns information about the API.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.getAPIInfo",
         "responses": {
           "200": {
@@ -35,6 +36,7 @@
     },
     "/health": {
       "get": {
+        "summary": "healthCheck returns the health status of the API.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.healthCheck",
         "responses": {
           "200": {

--- a/testdata/error_helpers/expected_openapi.json
+++ b/testdata/error_helpers/expected_openapi.json
@@ -15,6 +15,8 @@
   "paths": {
     "/items": {
       "get": {
+        "summary": "ListItems returns all items, or 500 error via helper.",
+        "description": "ListItems returns all items, or 500 error via helper.\nNote: items is non-empty here; the error branch exercises 500 status detection\nin the static analysis (the tool traces both branches regardless of runtime values).",
         "operationId": "error_helpers.ListItems",
         "responses": {
           "200": {
@@ -45,6 +47,7 @@
     },
     "/users": {
       "post": {
+        "summary": "CreateUser creates a new user, or returns 400/422 errors via helper.",
         "operationId": "error_helpers.CreateUser",
         "requestBody": {
           "content": {
@@ -91,6 +94,7 @@
     },
     "/users/{id}": {
       "get": {
+        "summary": "GetUser returns a user by ID, or 400/404 errors via helper.",
         "operationId": "error_helpers.GetUser",
         "parameters": [
           {
@@ -136,6 +140,8 @@
         }
       },
       "put": {
+        "summary": "UpdateUser uses respondJSON for BOTH success and error with different types.",
+        "description": "UpdateUser uses respondJSON for BOTH success and error with different types.\nThis tests that sibling calls to the same helper get their own schema\nbased on their own arguments, not copied from the first call.",
         "operationId": "error_helpers.UpdateUser",
         "parameters": [
           {

--- a/testdata/error_helpers/expected_openapi_legacy.json
+++ b/testdata/error_helpers/expected_openapi_legacy.json
@@ -15,6 +15,8 @@
   "paths": {
     "/items": {
       "get": {
+        "summary": "ListItems returns all items, or 500 error via helper.",
+        "description": "ListItems returns all items, or 500 error via helper.\nNote: items is non-empty here; the error branch exercises 500 status detection\nin the static analysis (the tool traces both branches regardless of runtime values).",
         "operationId": "error_helpers.ListItems",
         "responses": {
           "200": {
@@ -45,6 +47,7 @@
     },
     "/users": {
       "post": {
+        "summary": "CreateUser creates a new user, or returns 400/422 errors via helper.",
         "operationId": "error_helpers.CreateUser",
         "requestBody": {
           "content": {
@@ -91,6 +94,7 @@
     },
     "/users/{id}": {
       "get": {
+        "summary": "GetUser returns a user by ID, or 400/404 errors via helper.",
         "operationId": "error_helpers.GetUser",
         "parameters": [
           {
@@ -136,6 +140,8 @@
         }
       },
       "put": {
+        "summary": "UpdateUser uses respondJSON for BOTH success and error with different types.",
+        "description": "UpdateUser uses respondJSON for BOTH success and error with different types.\nThis tests that sibling calls to the same helper get their own schema\nbased on their own arguments, not copied from the first call.",
         "operationId": "error_helpers.UpdateUser",
         "parameters": [
           {

--- a/testdata/gin/expected_openapi.json
+++ b/testdata/gin/expected_openapi.json
@@ -18,6 +18,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Get all users",
         "operationId": "gin.ListUsers",
         "responses": {
           "200": {
@@ -39,6 +40,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Create a new user",
         "operationId": "gin.CreateUser",
         "requestBody": {
           "content": {
@@ -78,6 +80,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Get a user by ID",
         "operationId": "gin.GetUser",
         "parameters": [
           {
@@ -126,6 +129,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Update an existing user",
         "operationId": "gin.UpdateUser",
         "parameters": [
           {
@@ -183,6 +187,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Delete a user",
         "operationId": "gin.DeleteUser",
         "parameters": [
           {

--- a/testdata/gin/expected_openapi_legacy.json
+++ b/testdata/gin/expected_openapi_legacy.json
@@ -18,6 +18,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Get all users",
         "operationId": "github.com/antst/go-apispec/testdata/gin.ListUsers",
         "responses": {
           "200": {
@@ -39,6 +40,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Create a new user",
         "operationId": "github.com/antst/go-apispec/testdata/gin.CreateUser",
         "requestBody": {
           "content": {
@@ -78,6 +80,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Get a user by ID",
         "operationId": "github.com/antst/go-apispec/testdata/gin.GetUser",
         "parameters": [
           {
@@ -126,6 +129,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Update an existing user",
         "operationId": "github.com/antst/go-apispec/testdata/gin.UpdateUser",
         "parameters": [
           {
@@ -183,6 +187,7 @@
         "tags": [
           "/users"
         ],
+        "summary": "Delete a user",
         "operationId": "github.com/antst/go-apispec/testdata/gin.DeleteUser",
         "parameters": [
           {

--- a/testdata/nested_http/expected_openapi.json
+++ b/testdata/nested_http/expected_openapi.json
@@ -18,6 +18,7 @@
         "tags": [
           "/api/"
         ],
+        "summary": "APIHealth returns API health status.",
         "operationId": "nested_http.APIHealth",
         "responses": {
           "200": {
@@ -38,6 +39,7 @@
         "tags": [
           "/api/v1/"
         ],
+        "summary": "V1Health returns v1-specific health status.",
         "operationId": "nested_http.V1Health",
         "responses": {
           "200": {
@@ -58,6 +60,7 @@
         "tags": [
           "/api/v1/"
         ],
+        "summary": "ListItems returns a list of items.",
         "operationId": "nested_http.ListItems",
         "responses": {
           "200": {
@@ -81,6 +84,7 @@
         "tags": [
           "/api/v1/"
         ],
+        "summary": "ListUsers returns a list of users.",
         "operationId": "nested_http.ListUsers",
         "responses": {
           "200": {
@@ -101,6 +105,7 @@
     },
     "/global": {
       "post": {
+        "summary": "GlobalHandler returns global info (registered on DefaultServeMux).",
         "operationId": "nested_http.GlobalHandler",
         "responses": {
           "200": {
@@ -118,6 +123,7 @@
     },
     "/ping": {
       "post": {
+        "summary": "Ping returns a simple text response.",
         "operationId": "nested_http.Ping",
         "responses": {
           "200": {

--- a/testdata/nested_http/expected_openapi_legacy.json
+++ b/testdata/nested_http/expected_openapi_legacy.json
@@ -18,6 +18,7 @@
         "tags": [
           "/api/"
         ],
+        "summary": "APIHealth returns API health status.",
         "operationId": "nested_http.APIHealth",
         "responses": {
           "200": {
@@ -38,6 +39,7 @@
         "tags": [
           "/api/v1/"
         ],
+        "summary": "V1Health returns v1-specific health status.",
         "operationId": "nested_http.V1Health",
         "responses": {
           "200": {
@@ -58,6 +60,7 @@
         "tags": [
           "/api/v1/"
         ],
+        "summary": "ListItems returns a list of items.",
         "operationId": "nested_http.ListItems",
         "responses": {
           "200": {
@@ -81,6 +84,7 @@
         "tags": [
           "/api/v1/"
         ],
+        "summary": "ListUsers returns a list of users.",
         "operationId": "nested_http.ListUsers",
         "responses": {
           "200": {
@@ -101,6 +105,7 @@
     },
     "/global": {
       "post": {
+        "summary": "GlobalHandler returns global info (registered on DefaultServeMux).",
         "operationId": "nested_http.GlobalHandler",
         "responses": {
           "200": {
@@ -118,6 +123,7 @@
     },
     "/ping": {
       "post": {
+        "summary": "Ping returns a simple text response.",
         "operationId": "nested_http.Ping",
         "responses": {
           "200": {

--- a/testdata/response_patterns/expected_openapi.json
+++ b/testdata/response_patterns/expected_openapi.json
@@ -15,6 +15,7 @@
   "paths": {
     "/cache/{key}": {
       "get": {
+        "summary": "GetWithCache demonstrates 200 vs 304 responses.",
         "operationId": "response_patterns.GetWithCache",
         "parameters": [
           {
@@ -42,6 +43,8 @@
     },
     "/config": {
       "get": {
+        "summary": "LoadConfig reads config from a file (not from r.Body).",
+        "description": "LoadConfig reads config from a file (not from r.Body).\nThe json.NewDecoder(file).Decode should NOT produce a request body schema.",
         "operationId": "response_patterns.LoadConfig",
         "responses": {
           "200": {
@@ -69,6 +72,7 @@
     },
     "/debug": {
       "get": {
+        "summary": "DebugEndpoint uses fmt.Fprintf to write the response.",
         "operationId": "response_patterns.DebugEndpoint",
         "responses": {
           "200": {
@@ -86,6 +90,8 @@
     },
     "/dispatch": {
       "post": {
+        "summary": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method.",
+        "description": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method. This tests conditional HTTP method detection.",
         "operationId": "response_patterns.DispatchHandler",
         "requestBody": {
           "content": {
@@ -142,6 +148,7 @@
     },
     "/files/{id}/download": {
       "get": {
+        "summary": "DownloadFile serves raw binary data via w.Write with []byte.",
         "operationId": "response_patterns.DownloadFile",
         "parameters": [
           {
@@ -180,6 +187,7 @@
     },
     "/files/{id}/thumbnail": {
       "get": {
+        "summary": "ServeThumbnail serves an image thumbnail.",
         "operationId": "response_patterns.ServeThumbnail",
         "parameters": [
           {
@@ -208,6 +216,7 @@
     },
     "/health": {
       "get": {
+        "summary": "HealthCheck writes raw bytes with w.Write.",
         "operationId": "response_patterns.HealthCheck",
         "responses": {
           "200": {
@@ -225,6 +234,7 @@
     },
     "/image": {
       "get": {
+        "summary": "ServeImage sets Content-Type to image/png and writes binary data.",
         "operationId": "response_patterns.ServeImage",
         "responses": {
           "200": {
@@ -243,6 +253,7 @@
     },
     "/items": {
       "post": {
+        "summary": "CreateItem uses a status code variable before WriteHeader.",
         "operationId": "response_patterns.CreateItem",
         "requestBody": {
           "content": {
@@ -279,6 +290,7 @@
     },
     "/items-func": {
       "post": {
+        "summary": "CreateItemViaFunc uses a function call to get the status code.",
         "operationId": "response_patterns.CreateItemViaFunc",
         "requestBody": {
           "content": {
@@ -305,6 +317,7 @@
     },
     "/newsletter": {
       "post": {
+        "summary": "SubscribeNewsletter accepts a subscription with validated email list.",
         "operationId": "response_patterns.SubscribeNewsletter",
         "requestBody": {
           "content": {
@@ -341,6 +354,7 @@
     },
     "/paged-users": {
       "get": {
+        "summary": "GetPagedUsers returns a nested generic: PagedList[User].",
         "operationId": "response_patterns.GetPagedUsers",
         "responses": {
           "200": {
@@ -358,6 +372,7 @@
     },
     "/ping": {
       "get": {
+        "summary": "Ping writes a simple string.",
         "operationId": "response_patterns.Ping",
         "responses": {
           "200": {
@@ -375,6 +390,7 @@
     },
     "/protected": {
       "get": {
+        "summary": "ProtectedEndpoint returns 401 or 403.",
         "operationId": "response_patterns.ProtectedEndpoint",
         "responses": {
           "200": {
@@ -412,6 +428,7 @@
     },
     "/stream": {
       "get": {
+        "summary": "StreamData uses io.Copy to stream response data.",
         "operationId": "response_patterns.StreamData",
         "responses": {
           "200": {
@@ -429,6 +446,7 @@
     },
     "/text": {
       "get": {
+        "summary": "ServeText sets Content-Type to text/plain and writes text.",
         "operationId": "response_patterns.ServeText",
         "responses": {
           "200": {
@@ -446,6 +464,7 @@
     },
     "/user-wrapped": {
       "get": {
+        "summary": "GetUserWrapped returns a user wrapped in APIResponse.",
         "operationId": "response_patterns.GetUserWrapped",
         "responses": {
           "200": {
@@ -463,6 +482,7 @@
     },
     "/users": {
       "get": {
+        "summary": "ListUsersEncoder uses json.NewEncoder to write a slice of Users.",
         "operationId": "response_patterns.ListUsersEncoder",
         "responses": {
           "200": {
@@ -481,6 +501,7 @@
         }
       },
       "post": {
+        "summary": "CreateUserEncoder uses json.NewEncoder with 201 Created.",
         "operationId": "response_patterns.CreateUserEncoder",
         "requestBody": {
           "content": {
@@ -517,6 +538,7 @@
     },
     "/users/search": {
       "get": {
+        "summary": "SearchUsers returns a paginated response.",
         "operationId": "response_patterns.SearchUsers",
         "responses": {
           "200": {
@@ -534,6 +556,7 @@
     },
     "/users/{id}": {
       "get": {
+        "summary": "GetUserEncoder uses json.NewEncoder with 404 fallback.",
         "operationId": "response_patterns.GetUserEncoder",
         "parameters": [
           {
@@ -569,6 +592,7 @@
         }
       },
       "delete": {
+        "summary": "DeleteUser returns 204 No Content.",
         "operationId": "response_patterns.DeleteUser",
         "parameters": [
           {
@@ -592,6 +616,7 @@
     },
     "/v2/users": {
       "get": {
+        "summary": "ListUsersV2 serves users at a variable-defined path.",
         "operationId": "response_patterns.ListUsersV2",
         "responses": {
           "200": {
@@ -612,6 +637,7 @@
     },
     "/version": {
       "get": {
+        "summary": "GetVersion returns a plain text version string.",
         "operationId": "response_patterns.GetVersion",
         "responses": {
           "200": {

--- a/testdata/response_patterns/expected_openapi_legacy.json
+++ b/testdata/response_patterns/expected_openapi_legacy.json
@@ -15,6 +15,7 @@
   "paths": {
     "/cache/{key}": {
       "get": {
+        "summary": "GetWithCache demonstrates 200 vs 304 responses.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.GetWithCache",
         "parameters": [
           {
@@ -42,6 +43,8 @@
     },
     "/config": {
       "get": {
+        "summary": "LoadConfig reads config from a file (not from r.Body).",
+        "description": "LoadConfig reads config from a file (not from r.Body).\nThe json.NewDecoder(file).Decode should NOT produce a request body schema.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.LoadConfig",
         "responses": {
           "200": {
@@ -69,6 +72,7 @@
     },
     "/debug": {
       "get": {
+        "summary": "DebugEndpoint uses fmt.Fprintf to write the response.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.DebugEndpoint",
         "responses": {
           "200": {
@@ -86,6 +90,8 @@
     },
     "/dispatch": {
       "post": {
+        "summary": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method.",
+        "description": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method. This tests conditional HTTP method detection.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.DispatchHandler",
         "requestBody": {
           "content": {
@@ -142,6 +148,7 @@
     },
     "/files/{id}/download": {
       "get": {
+        "summary": "DownloadFile serves raw binary data via w.Write with []byte.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.DownloadFile",
         "parameters": [
           {
@@ -180,6 +187,7 @@
     },
     "/files/{id}/thumbnail": {
       "get": {
+        "summary": "ServeThumbnail serves an image thumbnail.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.ServeThumbnail",
         "parameters": [
           {
@@ -208,6 +216,7 @@
     },
     "/health": {
       "get": {
+        "summary": "HealthCheck writes raw bytes with w.Write.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.HealthCheck",
         "responses": {
           "200": {
@@ -225,6 +234,7 @@
     },
     "/image": {
       "get": {
+        "summary": "ServeImage sets Content-Type to image/png and writes binary data.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.ServeImage",
         "responses": {
           "200": {
@@ -243,6 +253,7 @@
     },
     "/items": {
       "post": {
+        "summary": "CreateItem uses a status code variable before WriteHeader.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.CreateItem",
         "requestBody": {
           "content": {
@@ -279,6 +290,7 @@
     },
     "/items-func": {
       "post": {
+        "summary": "CreateItemViaFunc uses a function call to get the status code.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.CreateItemViaFunc",
         "requestBody": {
           "content": {
@@ -305,6 +317,7 @@
     },
     "/newsletter": {
       "post": {
+        "summary": "SubscribeNewsletter accepts a subscription with validated email list.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.SubscribeNewsletter",
         "requestBody": {
           "content": {
@@ -341,6 +354,7 @@
     },
     "/paged-users": {
       "get": {
+        "summary": "GetPagedUsers returns a nested generic: PagedList[User].",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.GetPagedUsers",
         "responses": {
           "200": {
@@ -358,6 +372,7 @@
     },
     "/ping": {
       "get": {
+        "summary": "Ping writes a simple string.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.Ping",
         "responses": {
           "200": {
@@ -375,6 +390,7 @@
     },
     "/protected": {
       "get": {
+        "summary": "ProtectedEndpoint returns 401 or 403.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.ProtectedEndpoint",
         "responses": {
           "200": {
@@ -412,6 +428,7 @@
     },
     "/stream": {
       "get": {
+        "summary": "StreamData uses io.Copy to stream response data.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.StreamData",
         "responses": {
           "200": {
@@ -429,6 +446,7 @@
     },
     "/text": {
       "get": {
+        "summary": "ServeText sets Content-Type to text/plain and writes text.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.ServeText",
         "responses": {
           "200": {
@@ -446,6 +464,7 @@
     },
     "/user-wrapped": {
       "get": {
+        "summary": "GetUserWrapped returns a user wrapped in APIResponse.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.GetUserWrapped",
         "responses": {
           "200": {
@@ -463,6 +482,7 @@
     },
     "/users": {
       "get": {
+        "summary": "ListUsersEncoder uses json.NewEncoder to write a slice of Users.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.ListUsersEncoder",
         "responses": {
           "200": {
@@ -481,6 +501,7 @@
         }
       },
       "post": {
+        "summary": "CreateUserEncoder uses json.NewEncoder with 201 Created.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.CreateUserEncoder",
         "requestBody": {
           "content": {
@@ -517,6 +538,7 @@
     },
     "/users/search": {
       "get": {
+        "summary": "SearchUsers returns a paginated response.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.SearchUsers",
         "responses": {
           "200": {
@@ -534,6 +556,7 @@
     },
     "/users/{id}": {
       "get": {
+        "summary": "GetUserEncoder uses json.NewEncoder with 404 fallback.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.GetUserEncoder",
         "parameters": [
           {
@@ -569,6 +592,7 @@
         }
       },
       "delete": {
+        "summary": "DeleteUser returns 204 No Content.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.DeleteUser",
         "parameters": [
           {
@@ -592,6 +616,7 @@
     },
     "/v2/users": {
       "get": {
+        "summary": "ListUsersV2 serves users at a variable-defined path.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.ListUsersV2",
         "responses": {
           "200": {
@@ -612,6 +637,7 @@
     },
     "/version": {
       "get": {
+        "summary": "GetVersion returns a plain text version string.",
         "operationId": "github.com/antst/go-apispec/testdata/response_patterns.GetVersion",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary
Handler function doc comments are now automatically mapped to OpenAPI `summary` and `description` fields. No annotations, no config changes — existing Go doc comments become API documentation.

Closes #13

## Example
```go
// GetUser returns a user by ID. It checks permissions.
func GetUser(w http.ResponseWriter, r *http.Request) {
```
Produces:
```yaml
summary: "GetUser returns a user by ID."
description: "GetUser returns a user by ID. It checks permissions."
```

## Rules
- First sentence → `summary`
- Full comment → `description` (only if multi-sentence, to avoid duplication)
- Config overrides take precedence over doc comments
- Functions without doc comments → no summary/description (no change)

## Changes
- `internal/spec/mapper.go`: Add `extractDocComment()` and `splitDocComment()`
- `internal/spec/extractor.go`: Add `Description` field to `RouteInfo`
- `internal/spec/mapper_doccomment_test.go`: 13 unit tests
- Golden files updated for chi, gin, echo, response_patterns, nested_http, error_helpers

## Test plan
- [x] All 16 golden files pass
- [x] 13 new unit tests for doc comment extraction/splitting
- [x] Coverage: 95.8%
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI output now includes operation summaries and descriptions extracted from handler doc comments; route-level summary/description values override extracted text.
  * Per-method routes inherit route descriptions when splitting handlers by HTTP method.
  * Example API specification fixtures updated with new summaries/descriptions.

* **Tests**
  * Added comprehensive tests for doc-comment extraction and summary/description parsing across many comment formats and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->