### PR TITLE
docs: update README with v0.4.4-v0.4.7 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as res
 
 **Response Detection**
 - Content-Type inference from `w.Header().Set("Content-Type", "image/png")`
+- Dynamic content-type fallback: `w.Header().Set("Content-Type", doc.MimeType)` → `application/octet-stream` (variable MIME types don't leak Go field paths into the spec)
 - `WriteHeader(201)` + `json.Encode(user)` merged into a single 201 response with schema
+- Error helper functions: `writeJSONError(w, http.StatusBadRequest, "msg")` → 400 response with ErrorResponse schema, traced through function parameters via ParamArgMap
+- Multiple calls to same helper: `writeJSONError(w, 400, ...)` + `writeJSONError(w, 404, ...)` → both status codes captured with correct schemas
 - Status code variable resolution: `status := http.StatusCreated; w.WriteHeader(status)` → 201
 - Cross-function status codes: `w.WriteHeader(getStatus())` where `getStatus()` returns a constant
 - Multiple response types for the same status code → `oneOf` schema
@@ -53,10 +56,17 @@ All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as res
 **Type Resolution**
 - Generic struct instantiation: `APIResponse[User]` → schema with `Data: $ref User`
 - Interface resolution: handlers registered via interface → concrete implementation schemas
+- `interface{}` parameter resolution: `respondJSON(w, 201, user)` where `data` is `interface{}` → resolves to concrete `User` type from the caller's argument
 - Conditional HTTP methods via CFG: `switch r.Method { case "GET": ... case "POST": ... }` → separate operations
 - Route path variables: `path := "/users"; r.GET(path, h)` → resolves variable to literal path
 - Decode receiver tracing: `json.NewDecoder(file).Decode(&cfg)` not misclassified as request body
 - io.Copy source tracing: `io.Copy(w, strings.NewReader(...))` → `type: string`; `io.Copy(w, file)` → `format: binary`
+
+**Documentation Extraction**
+- Go doc comments on handler functions → OpenAPI `summary` and `description`
+- First sentence → `summary`, full comment → `description` (single-sentence comments don't duplicate)
+- No annotations needed — existing Go doc comments just work
+- Config overrides take precedence over doc comments
 
 **Schema Inference**
 - Required fields from `json:",omitempty"` absence and `binding:"required"` tags


### PR DESCRIPTION
## Summary
Update README Features section with capabilities added in v0.4.4-v0.4.7:

**Response Detection** (new bullets):
- Error helper function detection via ParamArgMap
- Multiple status codes from same helper
- Dynamic content-type fallback to `application/octet-stream`

**Type Resolution** (new bullet):
- `interface{}` parameter resolution from caller arguments

**Documentation Extraction** (new section):
- Go doc comments → OpenAPI summary/description

No code changes — README only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced Content-Type inference with MIME-type fallback now documented
* Error-response tracing with JSON error calls and status-code schema mapping documented
* Interface parameter resolution in response generation documented
* Added guidance on extracting Go handler comments into OpenAPI summaries and descriptions, including config override precedence rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->