### PR TITLE
fix: extract var-bound r.FormValue + r.FormFile + converter-typed params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ CLAUDE.md
 specs/
 .specify/
 testdata/error_helpers/error_helpers
+testdata/form_value_var/form_value_var

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ That's it. The tool detects your framework, finds all routes, resolves handler t
 
 | Framework | Routes | Params | Request Body | Responses | Mounting/Groups |
 |-----------|--------|--------|-------------|-----------|-----------------|
-| **Chi** | Full | `chi.URLParam`, render pkg | `json.Decode`, `render.DecodeJSON` | `json.Encode`, `render.JSON`, `w.Write` | `Mount`, `Group` |
+| **Chi** | Full | `chi.URLParam`, `r.FormValue`, `r.FormFile`, render pkg | `json.Decode`, `render.DecodeJSON` | `json.Encode`, `render.JSON`, `w.Write` | `Mount`, `Group` |
 | **Gin** | Full | `c.Param`, `c.Query` | `ShouldBindJSON`, `BindJSON` | `c.JSON`, `c.String`, `c.Data` | `Group` |
-| **Echo** | Full | `c.Param`, `c.QueryParam` | `c.Bind` | `c.JSON`, `c.String`, `c.Blob` | `Group` |
-| **Fiber** | Full | `c.Params`, `c.Query` | `c.BodyParser` | `c.JSON`, `c.Status().JSON` | `Mount`, `Group` |
+| **Echo** | Full | `c.Param`, `c.QueryParam`, `r.FormValue`, `r.FormFile` | `c.Bind` | `c.JSON`, `c.String`, `c.Blob` | `Group` |
+| **Fiber** | Full | `c.Params`, `c.Query`, `c.FormValue`, `c.FormFile` | `c.BodyParser` | `c.JSON`, `c.Status().JSON` | `Mount`, `Group` |
 | **Gorilla Mux** | Full | Path template `{id}` | `json.Decode` | `json.Encode`, `w.Write` | `PathPrefix`, `Subrouter` |
-| **net/http** | Basic | Path template | `json.Decode` | `json.Encode`, `w.Write`, `http.Error` | Nested `ServeMux` |
+| **net/http** | Basic | Path template, `r.FormValue`, `r.FormFile` | `json.Decode` | `json.Encode`, `w.Write`, `http.Error` | Nested `ServeMux` |
 
 Projects using **multiple frameworks** simultaneously are fully supported — all routes from all detected frameworks appear in the spec.
 
@@ -73,6 +73,8 @@ All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as res
 - Validator `dive` tag: `validate:"dive,email"` on `[]string` → items schema has `format: email`
 - `Mux.Vars()` map index expressions → path parameter names
 - Type mappings for `time.Time`, `uuid.UUID`, and custom types
+- Converter-typed params: `idStr := c.Param("id"); strconv.Atoi(idStr)` → `integer`; `strconv.ParseBool` → `boolean`; `strconv.ParseFloat` → `number`; `uuid.Parse` → `string/uuid`. Works for both inline (`strconv.Atoi(r.FormValue("x"))`) and var-bound (`if v := r.FormValue("x"); v != "" { strconv.ParseBool(v) }`) idioms, including shadowed variables in separate `if`-init scopes
+- `r.FormFile("upload")` → form parameter with `string`/`binary` schema
 
 **Output Quality**
 - Deterministic YAML/JSON — sorted map keys, identical output across runs, safe for CI diffing

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -174,6 +174,7 @@ func TestE2E_FormValueVar_AllPatternsExtracted(t *testing.T) {
 
 	expected := map[string]struct{ Type, Format string }{
 		"storageBucketId":   {Type: "integer"},                  // inline strconv.Atoi
+		"allowedMimeTypes":  {Type: "string"},                   // var-bound strings.Split — non-converter consumer must NOT cross into shadowed-v scopes
 		"temporaryLocation": {Type: "boolean"},                  // var-bound strconv.ParseBool
 		"maxFileSize":       {Type: "integer"},                  // var-bound strconv.Atoi (shadowed v)
 		"displayName":       {Type: "string"},                   // no converter — string fallback

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -179,6 +179,8 @@ func TestE2E_FormValueVar_AllPatternsExtracted(t *testing.T) {
 		"displayName":       {Type: "string"},                   // no converter — string fallback
 		"file":              {Type: "string", Format: "binary"}, // FormFile
 	}
+	assert.Equal(t, len(expected), len(got), "unexpected form params: have %v, want %v",
+		paramNames(pi.Post.Parameters), keysOf(expected))
 	for name, want := range expected {
 		s, ok := got[name]
 		if !assert.True(t, ok, "missing form param %q (have %v)", name, paramNames(pi.Post.Parameters)) {
@@ -194,6 +196,14 @@ func paramNames(ps []intspec.Parameter) []string {
 	out := make([]string, 0, len(ps))
 	for _, p := range ps {
 		out = append(out, p.Name)
+	}
+	return out
+}
+
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
 	}
 	return out
 }

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -48,6 +48,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "response_patterns", inputDir: "../../testdata/response_patterns", configFn: spec.DefaultChiConfig},
 		{name: "nested_http", inputDir: "../../testdata/nested_http", configFn: spec.DefaultHTTPConfig},
 		{name: "error_helpers", inputDir: "../../testdata/error_helpers", configFn: spec.DefaultChiConfig},
+		{name: "form_value_var", inputDir: "../../testdata/form_value_var", configFn: spec.DefaultChiConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {
@@ -146,6 +147,55 @@ func collectSchemaRefs(s *spec.Schema) []string {
 		refs = append(refs, collectSchemaRefs(child)...)
 	}
 	return refs
+}
+
+// TestE2E_FormValueVar_AllPatternsExtracted asserts that r.FormValue calls
+// reach the spec regardless of how the result is consumed (inline, var+guard,
+// direct string usage), and that r.FormFile produces a binary form parameter.
+//
+// Regression test for the bug where the tracker dedup at the caller-side edge
+// loop dropped every var-bound r.FormValue call once any inline r.FormValue
+// existed in the same handler.
+func TestE2E_FormValueVar_AllPatternsExtracted(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/form_value_var", spec.DefaultChiConfig())
+	eng := NewEngine(cfg)
+	result, err := eng.GenerateOpenAPI()
+	require.NoError(t, err)
+
+	pi, ok := result.Paths["/upload"]
+	require.True(t, ok, "expected /upload path; got: %v", pathKeys(result))
+	require.NotNil(t, pi.Post)
+
+	got := map[string]*spec.Schema{}
+	for _, p := range pi.Post.Parameters {
+		require.Equal(t, "form", p.In, "param %q should be in=form", p.Name)
+		got[p.Name] = p.Schema
+	}
+
+	expected := map[string]struct{ Type, Format string }{
+		"storageBucketId":   {Type: "integer"},                  // inline strconv.Atoi
+		"temporaryLocation": {Type: "boolean"},                  // var-bound strconv.ParseBool
+		"maxFileSize":       {Type: "integer"},                  // var-bound strconv.Atoi (shadowed v)
+		"displayName":       {Type: "string"},                   // no converter — string fallback
+		"file":              {Type: "string", Format: "binary"}, // FormFile
+	}
+	for name, want := range expected {
+		s, ok := got[name]
+		if !assert.True(t, ok, "missing form param %q (have %v)", name, paramNames(pi.Post.Parameters)) {
+			continue
+		}
+		require.NotNil(t, s, "schema missing for %q", name)
+		assert.Equal(t, want.Type, s.Type, "wrong type for %q", name)
+		assert.Equal(t, want.Format, s.Format, "wrong format for %q", name)
+	}
+}
+
+func paramNames(ps []intspec.Parameter) []string {
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, p.Name)
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -136,6 +136,12 @@ type ParamPattern struct {
 	// Extraction hints
 	TypeFromArg bool `yaml:"typeFromArg,omitempty"` // Extract type from argument
 	Deref       bool `yaml:"deref,omitempty"`       // Dereference pointer types
+
+	// Default schema hints used when TypeFromArg is false. Useful for calls
+	// like r.FormFile(name) where the schema is fixed (string/binary) regardless
+	// of how the result is consumed.
+	DefaultType   string `yaml:"defaultType,omitempty"`
+	DefaultFormat string `yaml:"defaultFormat,omitempty"`
 }
 
 // MountPattern defines how to extract mount/subrouter information
@@ -588,6 +594,11 @@ func DefaultChiConfig() *APISpecConfig {
 				{BasePattern: BasePattern{CallRegex: "^FormValue$"}, ParamIn: "form",
 					ParamArgIndex: 0,
 				},
+				{BasePattern: BasePattern{CallRegex: "^FormFile$"}, ParamIn: "form",
+					ParamArgIndex: 0,
+					DefaultType:   "string",
+					DefaultFormat: "binary",
+				},
 				{BasePattern: BasePattern{CallRegex: "^Get$",
 
 					RecvType: "net/url.Values"}, ParamIn: "query",
@@ -740,6 +751,11 @@ func DefaultEchoConfig() *APISpecConfig {
 				},
 				{BasePattern: BasePattern{CallRegex: "^FormValue$"}, ParamIn: "form",
 					ParamArgIndex: 0,
+				},
+				{BasePattern: BasePattern{CallRegex: "^FormFile$"}, ParamIn: "form",
+					ParamArgIndex: 0,
+					DefaultType:   "string",
+					DefaultFormat: "binary",
 				},
 				{BasePattern: BasePattern{CallRegex: "^Cookie$"}, ParamIn: "cookie",
 					ParamArgIndex: 0,
@@ -897,6 +913,13 @@ func DefaultFiberConfig() *APISpecConfig {
 
 					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`}, ParamIn: "form",
 					ParamArgIndex: 0,
+				},
+				{BasePattern: BasePattern{CallRegex: "^FormFile$",
+
+					RecvTypeRegex: `^github\.com/gofiber/fiber(/v\d)?\.\*Ctx$`}, ParamIn: "form",
+					ParamArgIndex: 0,
+					DefaultType:   "string",
+					DefaultFormat: "binary",
 				},
 				{BasePattern: BasePattern{CallRegex: "^Cookies$",
 
@@ -1352,6 +1375,11 @@ func DefaultHTTPConfig() *APISpecConfig {
 			ParamPatterns: []ParamPattern{
 				{BasePattern: BasePattern{CallRegex: "^FormValue$"}, ParamIn: "form",
 					ParamArgIndex: 0,
+				},
+				{BasePattern: BasePattern{CallRegex: "^FormFile$"}, ParamIn: "form",
+					ParamArgIndex: 0,
+					DefaultType:   "string",
+					DefaultFormat: "binary",
 				},
 				{BasePattern: BasePattern{CallRegex: "^Get$"}, ParamIn: "header",
 					ParamArgIndex: 0,

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1546,9 +1546,23 @@ func (p *ParamPatternMatcherImpl) ExtractParam(node TrackerNodeInterface, route 
 		param.Schema = schema
 	}
 
+	// When the pattern doesn't pin a schema (no TypeFromArg, no DefaultType),
+	// try to infer one from the converter applied to the parameter value
+	// (e.g. strconv.Atoi → integer, strconv.ParseBool → boolean). DefaultType
+	// takes precedence so callers like FormFile keep their fixed schema.
+	if param.Schema == nil && p.pattern.DefaultType == "" {
+		if inferred := inferParamConverterSchema(node, route); inferred != nil {
+			param.Schema = inferred
+		}
+	}
+
 	// Ensure all parameters have a schema - default to string if none specified
 	if param.Schema == nil {
-		param.Schema = &Schema{Type: "string"}
+		schemaType := "string"
+		if p.pattern.DefaultType != "" {
+			schemaType = p.pattern.DefaultType
+		}
+		param.Schema = &Schema{Type: schemaType, Format: p.pattern.DefaultFormat}
 	}
 
 	// Ensure path parameters are always required

--- a/internal/spec/extractor_coverage_test.go
+++ b/internal/spec/extractor_coverage_test.go
@@ -1157,6 +1157,39 @@ func TestParamPatternMatcher_ExtractParam_Basic(t *testing.T) {
 	assert.Equal(t, "string", param.Schema.Type) // default schema
 }
 
+func TestParamPatternMatcher_ExtractParam_FormFile_BinarySchema(t *testing.T) {
+	meta := newTestMeta()
+	cfg := &APISpecConfig{}
+	contextProvider := NewContextProvider(meta)
+	schemaMapper := NewSchemaMapper(cfg)
+
+	paramNameArg := makeLiteralArg(meta, "upload")
+	edge := makeEdge(meta, "handler", "main", "FormFile", "net/http", []*metadata.CallArgument{paramNameArg})
+	node := makeTrackerNode(&edge)
+
+	matcher := &ParamPatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			contextProvider: contextProvider,
+			cfg:             cfg,
+			schemaMapper:    schemaMapper,
+		},
+		pattern: ParamPattern{
+			ParamIn:       "form",
+			ParamArgIndex: 0,
+			DefaultType:   "string",
+			DefaultFormat: "binary",
+		},
+	}
+
+	param := matcher.ExtractParam(node, NewRouteInfo())
+	require.NotNil(t, param)
+	assert.Equal(t, "upload", param.Name)
+	assert.Equal(t, "form", param.In)
+	require.NotNil(t, param.Schema)
+	assert.Equal(t, "string", param.Schema.Type)
+	assert.Equal(t, "binary", param.Schema.Format)
+}
+
 func TestParamPatternMatcher_ExtractParam_QueryParam(t *testing.T) {
 	meta := newTestMeta()
 	cfg := &APISpecConfig{}

--- a/internal/spec/param_converter.go
+++ b/internal/spec/param_converter.go
@@ -113,8 +113,11 @@ func varBoundConverter(edge *metadata.CallGraphEdge, meta *metadata.Metadata) *p
 	}
 
 	parentLine := positionLine(stringFromPool(meta, edge.Position))
-	bestLine := -1
-	var best *paramConverter
+	var (
+		best        *paramConverter
+		bestLine    int             // 0 == no best yet
+		bestUnknown *paramConverter // fallback when every match has unknown position
+	)
 
 	for _, sib := range siblings {
 		if sib == edge {
@@ -134,12 +137,24 @@ func varBoundConverter(edge *metadata.CallGraphEdge, meta *metadata.Metadata) *p
 		if parentLine > 0 && sibLine > 0 && sibLine < parentLine {
 			continue
 		}
+		if sibLine <= 0 {
+			// No position info — keep as a last-resort fallback so a single
+			// unknown-line sibling doesn't block a later sibling with a valid
+			// line from being selected.
+			if bestUnknown == nil {
+				bestUnknown = c
+			}
+			continue
+		}
 		if best == nil || sibLine < bestLine {
 			best = c
 			bestLine = sibLine
 		}
 	}
-	return best
+	if best != nil {
+		return best
+	}
+	return bestUnknown
 }
 
 // edgeArgUsesVariable reports whether any direct argument of the edge is an

--- a/internal/spec/param_converter.go
+++ b/internal/spec/param_converter.go
@@ -101,8 +101,13 @@ func inlineConverter(node TrackerNodeInterface, meta *metadata.Metadata) *paramC
 }
 
 // varBoundConverter detects the "v := call(...); converter(v)" idiom by
-// scanning sibling caller-side edges for the first consumer of the bound
-// variable that matches a known converter.
+// finding the closest forward consumer of the bound variable. Inference
+// fires only when *that* consumer is a known converter — otherwise we
+// fall through to the default schema, even if some later sibling edge
+// happens to be a converter. Skipping past the first consumer is unsafe
+// because the bound variable's scope often ends before the next sibling
+// (e.g. if-init scoping with shadowed `v` reused in unrelated converter
+// blocks elsewhere in the same function).
 func varBoundConverter(edge *metadata.CallGraphEdge, meta *metadata.Metadata) *paramConverter {
 	if edge.CalleeRecvVarName == "" {
 		return nil
@@ -114,9 +119,9 @@ func varBoundConverter(edge *metadata.CallGraphEdge, meta *metadata.Metadata) *p
 
 	parentLine := positionLine(stringFromPool(meta, edge.Position))
 	var (
-		best        *paramConverter
-		bestLine    int             // 0 == no best yet
-		bestUnknown *paramConverter // fallback when every match has unknown position
+		closestKnown   *metadata.CallGraphEdge // closest forward consumer with a known line
+		closestLine    int                     // 0 == no known-line consumer found yet
+		closestUnknown *metadata.CallGraphEdge // fallback if every consumer has an unknown line
 	)
 
 	for _, sib := range siblings {
@@ -126,35 +131,33 @@ func varBoundConverter(edge *metadata.CallGraphEdge, meta *metadata.Metadata) *p
 		if !edgeArgUsesVariable(sib, edge.CalleeRecvVarName) {
 			continue
 		}
-		c := lookupParamConverter(stringFromPool(meta, sib.Callee.Pkg), stringFromPool(meta, sib.Callee.Name))
-		if c == nil {
-			continue
-		}
 		sibLine := positionLine(stringFromPool(meta, sib.Position))
-		// Prefer the closest consumer at or after the parameter call to keep
-		// shadowed variables (`v` reused in different if-init scopes) bound to
-		// the right converter.
 		if parentLine > 0 && sibLine > 0 && sibLine < parentLine {
 			continue
 		}
 		if sibLine <= 0 {
-			// No position info — keep as a last-resort fallback so a single
-			// unknown-line sibling doesn't block a later sibling with a valid
-			// line from being selected.
-			if bestUnknown == nil {
-				bestUnknown = c
+			if closestUnknown == nil {
+				closestUnknown = sib
 			}
 			continue
 		}
-		if best == nil || sibLine < bestLine {
-			best = c
-			bestLine = sibLine
+		if closestKnown == nil || sibLine < closestLine {
+			closestKnown = sib
+			closestLine = sibLine
 		}
 	}
-	if best != nil {
-		return best
+
+	closest := closestKnown
+	if closest == nil {
+		closest = closestUnknown
 	}
-	return bestUnknown
+	if closest == nil {
+		return nil
+	}
+	return lookupParamConverter(
+		stringFromPool(meta, closest.Callee.Pkg),
+		stringFromPool(meta, closest.Callee.Name),
+	)
 }
 
 // edgeArgUsesVariable reports whether any direct argument of the edge is an

--- a/internal/spec/param_converter.go
+++ b/internal/spec/param_converter.go
@@ -1,0 +1,189 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// paramConverter describes the OpenAPI schema produced by a known converter
+// applied to the result of a parameter-extraction call (e.g. r.FormValue).
+type paramConverter struct {
+	Type   string
+	Format string
+}
+
+// paramConverters maps "<callee-pkg>.<callee-name>" to the schema it implies
+// when applied to a parameter value. Lookup keys are the same form as
+// edge.Callee.Pkg + "." + edge.Callee.Name. Values are intentionally minimal
+// so the map stays the single source of truth — extending it covers any new
+// converter we want to recognise.
+var paramConverters = map[string]paramConverter{
+	"strconv.Atoi":                      {Type: "integer"},
+	"strconv.ParseInt":                  {Type: "integer"},
+	"strconv.ParseUint":                 {Type: "integer"},
+	"strconv.ParseBool":                 {Type: "boolean"},
+	"strconv.ParseFloat":                {Type: "number"},
+	"github.com/google/uuid.Parse":      {Type: "string", Format: "uuid"},
+	"github.com/google/uuid.MustParse":  {Type: "string", Format: "uuid"},
+	"github.com/google/uuid.FromString": {Type: "string", Format: "uuid"},
+}
+
+// lookupParamConverter returns the converter schema for a callee identified
+// by its package path and name, or nil when no converter matches.
+func lookupParamConverter(pkg, name string) *paramConverter {
+	if name == "" {
+		return nil
+	}
+	if pkg != "" {
+		if c, ok := paramConverters[pkg+"."+name]; ok {
+			return &c
+		}
+	}
+	return nil
+}
+
+// inferParamConverterSchema returns a Schema inferred from a known converter
+// applied to the parameter value, or nil when no inference applies.
+//
+// Two consumption patterns are recognised:
+//
+//  1. Inline — the parameter call is the direct argument of the converter
+//     (e.g. strconv.Atoi(r.FormValue("x"))). The tracker tree links the
+//     parameter node as an arg-child of the converter node, so the converter
+//     edge sits one level up.
+//
+//  2. Var-bound — the parameter result is bound to a local variable and
+//     consumed later (e.g. v := r.FormValue("x"); strconv.ParseBool(v)).
+//     The tracker tree gives no direct link, so we scan caller-side edges
+//     for the next consumer of that variable in source order.
+func inferParamConverterSchema(node TrackerNodeInterface, route *RouteInfo) *Schema {
+	if node == nil || route == nil || route.Metadata == nil {
+		return nil
+	}
+	edge := node.GetEdge()
+	if edge == nil {
+		return nil
+	}
+
+	if c := inlineConverter(node, route.Metadata); c != nil {
+		return schemaFromConverter(c)
+	}
+	if c := varBoundConverter(edge, route.Metadata); c != nil {
+		return schemaFromConverter(c)
+	}
+	return nil
+}
+
+// inlineConverter detects the "converter(call(...))" idiom by inspecting the
+// parameter node's tracker parent.
+func inlineConverter(node TrackerNodeInterface, meta *metadata.Metadata) *paramConverter {
+	parent := node.GetParent()
+	if parent == nil {
+		return nil
+	}
+	parentEdge := parent.GetEdge()
+	if parentEdge == nil {
+		return nil
+	}
+	pkg := stringFromPool(meta, parentEdge.Callee.Pkg)
+	name := stringFromPool(meta, parentEdge.Callee.Name)
+	return lookupParamConverter(pkg, name)
+}
+
+// varBoundConverter detects the "v := call(...); converter(v)" idiom by
+// scanning sibling caller-side edges for the first consumer of the bound
+// variable that matches a known converter.
+func varBoundConverter(edge *metadata.CallGraphEdge, meta *metadata.Metadata) *paramConverter {
+	if edge.CalleeRecvVarName == "" {
+		return nil
+	}
+	siblings := meta.Callers[edge.Caller.BaseID()]
+	if len(siblings) == 0 {
+		return nil
+	}
+
+	parentLine := positionLine(stringFromPool(meta, edge.Position))
+	bestLine := -1
+	var best *paramConverter
+
+	for _, sib := range siblings {
+		if sib == edge {
+			continue
+		}
+		if !edgeArgUsesVariable(sib, edge.CalleeRecvVarName) {
+			continue
+		}
+		c := lookupParamConverter(stringFromPool(meta, sib.Callee.Pkg), stringFromPool(meta, sib.Callee.Name))
+		if c == nil {
+			continue
+		}
+		sibLine := positionLine(stringFromPool(meta, sib.Position))
+		// Prefer the closest consumer at or after the parameter call to keep
+		// shadowed variables (`v` reused in different if-init scopes) bound to
+		// the right converter.
+		if parentLine > 0 && sibLine > 0 && sibLine < parentLine {
+			continue
+		}
+		if best == nil || sibLine < bestLine {
+			best = c
+			bestLine = sibLine
+		}
+	}
+	return best
+}
+
+// edgeArgUsesVariable reports whether any direct argument of the edge is an
+// identifier referring to the named variable.
+func edgeArgUsesVariable(edge *metadata.CallGraphEdge, varName string) bool {
+	for _, arg := range edge.Args {
+		if arg == nil {
+			continue
+		}
+		if arg.GetKind() == metadata.KindIdent && arg.GetName() == varName {
+			return true
+		}
+	}
+	return false
+}
+
+// positionLine extracts the line number from a "file:line:col" position
+// string. Returns 0 when the string isn't in that form.
+func positionLine(pos string) int {
+	if pos == "" {
+		return 0
+	}
+	// Position format: "file:line:col" — split from the right so file paths
+	// containing ':' don't trip up the lookup.
+	parts := strings.Split(pos, ":")
+	if len(parts) < 2 {
+		return 0
+	}
+	line, err := strconv.Atoi(parts[len(parts)-2])
+	if err != nil {
+		return 0
+	}
+	return line
+}
+
+// stringFromPool resolves a StringPool index, returning "" when meta or the
+// pool is nil.
+func stringFromPool(m *metadata.Metadata, idx int) string {
+	if m == nil || m.StringPool == nil {
+		return ""
+	}
+	return m.StringPool.GetString(idx)
+}
+
+func schemaFromConverter(c *paramConverter) *Schema {
+	return &Schema{Type: c.Type, Format: c.Format}
+}

--- a/internal/spec/param_converter.go
+++ b/internal/spec/param_converter.go
@@ -40,14 +40,18 @@ var paramConverters = map[string]paramConverter{
 
 // lookupParamConverter returns the converter schema for a callee identified
 // by its package path and name, or nil when no converter matches.
+//
+// A non-empty pkg is required: matching by short name alone would mean a
+// user-defined "Atoi" or "ParseBool" function (in any package) gets typed as
+// integer/boolean, which is wrong. The map keys deliberately include the
+// fully-qualified package path so only stdlib (and well-known third-party)
+// converters trigger inference.
 func lookupParamConverter(pkg, name string) *paramConverter {
-	if name == "" {
+	if name == "" || pkg == "" {
 		return nil
 	}
-	if pkg != "" {
-		if c, ok := paramConverters[pkg+"."+name]; ok {
-			return &c
-		}
+	if c, ok := paramConverters[pkg+"."+name]; ok {
+		return &c
 	}
 	return nil
 }

--- a/internal/spec/param_converter_test.go
+++ b/internal/spec/param_converter_test.go
@@ -1,0 +1,190 @@
+package spec
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+func TestLookupParamConverter_Known(t *testing.T) {
+	cases := []struct {
+		pkg, name string
+		want      paramConverter
+	}{
+		{"strconv", "Atoi", paramConverter{Type: "integer"}},
+		{"strconv", "ParseBool", paramConverter{Type: "boolean"}},
+		{"strconv", "ParseFloat", paramConverter{Type: "number"}},
+		{"github.com/google/uuid", "Parse", paramConverter{Type: "string", Format: "uuid"}},
+	}
+	for _, tc := range cases {
+		c := lookupParamConverter(tc.pkg, tc.name)
+		require.NotNil(t, c, "expected match for %s.%s", tc.pkg, tc.name)
+		assert.Equal(t, tc.want, *c)
+	}
+}
+
+func TestLookupParamConverter_Unknown(t *testing.T) {
+	assert.Nil(t, lookupParamConverter("strings", "TrimSpace"))
+	assert.Nil(t, lookupParamConverter("", "Atoi"))
+	assert.Nil(t, lookupParamConverter("strconv", ""))
+}
+
+func TestPositionLine(t *testing.T) {
+	cases := map[string]int{
+		"":                      0,
+		"main.go":               0,
+		"main.go:42:7":          42,
+		"/abs/path/foo.go:10:1": 10,
+		"sub/handler.go:1:1":    1,
+		"weird:notanumber:1":    0,
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, positionLine(in), "input=%q", in)
+	}
+}
+
+func TestEdgeArgUsesVariable(t *testing.T) {
+	meta := newTestMeta()
+
+	identV := makeIdentArg(meta, "v", "string")
+	identOther := makeIdentArg(meta, "other", "string")
+	literal := makeLiteralArg(meta, "lit")
+
+	edge := makeEdge(meta, "Caller", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{identV, identOther, literal})
+
+	assert.True(t, edgeArgUsesVariable(&edge, "v"))
+	assert.True(t, edgeArgUsesVariable(&edge, "other"))
+	assert.False(t, edgeArgUsesVariable(&edge, "missing"))
+	assert.False(t, edgeArgUsesVariable(&edge, ""))
+}
+
+func TestSchemaFromConverter(t *testing.T) {
+	s := schemaFromConverter(&paramConverter{Type: "integer"})
+	require.NotNil(t, s)
+	assert.Equal(t, "integer", s.Type)
+	assert.Empty(t, s.Format)
+
+	s = schemaFromConverter(&paramConverter{Type: "string", Format: "uuid"})
+	assert.Equal(t, "string", s.Type)
+	assert.Equal(t, "uuid", s.Format)
+}
+
+func TestInlineConverter_NoParent(t *testing.T) {
+	meta := newTestMeta()
+	edge := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	node := makeTrackerNode(&edge)
+	assert.Nil(t, inlineConverter(node, meta))
+}
+
+func TestInlineConverter_KnownParent(t *testing.T) {
+	meta := newTestMeta()
+
+	parentEdge := makeEdge(meta, "Upload", "main", "Atoi", "strconv", nil)
+	childEdge := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+
+	parent := makeTrackerNode(&parentEdge)
+	child := makeTrackerNode(&childEdge)
+	child.Parent = parent
+
+	c := inlineConverter(child, meta)
+	require.NotNil(t, c)
+	assert.Equal(t, "integer", c.Type)
+}
+
+func TestInlineConverter_UnknownParent(t *testing.T) {
+	meta := newTestMeta()
+
+	parentEdge := makeEdge(meta, "Upload", "main", "TrimSpace", "strings", nil)
+	childEdge := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+
+	parent := makeTrackerNode(&parentEdge)
+	child := makeTrackerNode(&childEdge)
+	child.Parent = parent
+
+	assert.Nil(t, inlineConverter(child, meta))
+}
+
+func TestVarBoundConverter_PicksClosestForwardConsumer(t *testing.T) {
+	// Simulate two FormValue calls bound to a shadowed `v`, each followed by
+	// a different converter — Atoi (line 53) and ParseBool (line 41) — to make
+	// sure the selector picks the converter at-or-after the FormValue's line.
+	meta := newTestMeta()
+	siblings := []*metadata.CallGraphEdge{}
+
+	makeFormValue := func(line int) *metadata.CallGraphEdge {
+		e := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+		e.CalleeRecvVarName = "v"
+		e.Position = meta.StringPool.Get(formatLine(line))
+		siblings = append(siblings, &e)
+		return &e
+	}
+	makeConsumer := func(callee, pkg string, line int) *metadata.CallGraphEdge {
+		e := makeEdge(meta, "Upload", "main", callee, pkg,
+			[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+		e.Position = meta.StringPool.Get(formatLine(line))
+		siblings = append(siblings, &e)
+		return &e
+	}
+
+	fvBool := makeFormValue(40)
+	makeConsumer("ParseBool", "strconv", 41)
+	fvInt := makeFormValue(52)
+	makeConsumer("Atoi", "strconv", 53)
+
+	// Wire the caller index by hand — newTestMeta keeps Callers nil.
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fvBool.Caller.BaseID(): siblings,
+	}
+
+	c := varBoundConverter(fvBool, meta)
+	require.NotNil(t, c)
+	assert.Equal(t, "boolean", c.Type, "FormValue at line 40 should pair with ParseBool at line 41")
+
+	c = varBoundConverter(fvInt, meta)
+	require.NotNil(t, c)
+	assert.Equal(t, "integer", c.Type, "FormValue at line 52 should pair with Atoi at line 53, not ParseBool at 41")
+}
+
+func TestVarBoundConverter_NoConsumerOrUnknown(t *testing.T) {
+	meta := newTestMeta()
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "displayName"
+	fv.Position = meta.StringPool.Get("main.go:60:2")
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {&fv},
+	}
+	assert.Nil(t, varBoundConverter(&fv, meta), "no consumer → no inference")
+
+	// Consumer exists but isn't a known converter
+	noisy := makeEdge(meta, "Upload", "main", "TrimSpace", "strings",
+		[]*metadata.CallArgument{makeIdentArg(meta, "displayName", "string")})
+	noisy.Position = meta.StringPool.Get("main.go:61:2")
+	meta.Callers[fv.Caller.BaseID()] = []*metadata.CallGraphEdge{&fv, &noisy}
+	assert.Nil(t, varBoundConverter(&fv, meta), "non-converter consumer → no inference")
+}
+
+func TestVarBoundConverter_SkipsCallsWithoutBoundVar(t *testing.T) {
+	meta := newTestMeta()
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	// no CalleeRecvVarName — caller used the result inline, not bound to a var
+	assert.Nil(t, varBoundConverter(&fv, meta))
+}
+
+func TestInferParamConverterSchema_NilGuards(t *testing.T) {
+	// Various nil guards keep the helper from panicking when called from the
+	// matcher with a partly-initialised route.
+	assert.Nil(t, inferParamConverterSchema(nil, &RouteInfo{}))
+	assert.Nil(t, inferParamConverterSchema(&TrackerNode{}, nil))
+	assert.Nil(t, inferParamConverterSchema(&TrackerNode{}, &RouteInfo{}))
+}
+
+// formatLine builds a "file:line:col" string suitable for positionLine.
+func formatLine(line int) string {
+	// Using a fixed file/col keeps the tests focused on line ordering.
+	return "main.go:" + strconv.Itoa(line) + ":1"
+}

--- a/internal/spec/param_converter_test.go
+++ b/internal/spec/param_converter_test.go
@@ -231,6 +231,32 @@ func TestVarBoundConverter_PreferKnownPositionOverUnknown(t *testing.T) {
 	assert.Equal(t, "integer", c.Type, "should prefer known-position Atoi over unknown-position ParseBool")
 }
 
+func TestVarBoundConverter_MultipleUnknownPositions_PicksFirst(t *testing.T) {
+	// When several consumers all lack position metadata, fall back to the
+	// first one in iteration order. meta.Callers slices are populated in
+	// AST-walk order (source order), so this gives a deterministic answer.
+	meta := newTestMeta()
+
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "v"
+	fv.Position = meta.StringPool.Get(formatLine(40))
+
+	// Two consumers, both with no Position set. The first one in slice
+	// order wins regardless of which is the "real" pairing.
+	first := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+	second := makeEdge(meta, "Upload", "main", "Atoi", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {&fv, &first, &second},
+	}
+
+	c := varBoundConverter(&fv, meta)
+	require.NotNil(t, c)
+	assert.Equal(t, "boolean", c.Type, "first unknown-position consumer wins (slice order)")
+}
+
 func TestVarBoundConverter_FallsBackToUnknownPosition(t *testing.T) {
 	// When EVERY converter sibling has unknown position, return one of them
 	// rather than nil — the alternative would be silently dropping the type.

--- a/internal/spec/param_converter_test.go
+++ b/internal/spec/param_converter_test.go
@@ -230,9 +230,101 @@ func TestVarBoundConverter_SkipsCallsWithoutBoundVar(t *testing.T) {
 func TestInferParamConverterSchema_NilGuards(t *testing.T) {
 	// Various nil guards keep the helper from panicking when called from the
 	// matcher with a partly-initialised route.
-	assert.Nil(t, inferParamConverterSchema(nil, &RouteInfo{}))
+	meta := newTestMeta()
+	assert.Nil(t, inferParamConverterSchema(nil, &RouteInfo{Metadata: meta}))
 	assert.Nil(t, inferParamConverterSchema(&TrackerNode{}, nil))
-	assert.Nil(t, inferParamConverterSchema(&TrackerNode{}, &RouteInfo{}))
+	assert.Nil(t, inferParamConverterSchema(&TrackerNode{}, &RouteInfo{}), "route.Metadata is nil")
+	// Node with no edge — short-circuit before we touch any metadata fields.
+	assert.Nil(t, inferParamConverterSchema(&TrackerNode{}, &RouteInfo{Metadata: meta}))
+}
+
+func TestInferParamConverterSchema_InlineMatch(t *testing.T) {
+	// Dispatcher: an inline parent that's a known converter wins over the
+	// var-bound branch and produces the converter's schema.
+	meta := newTestMeta()
+	parentEdge := makeEdge(meta, "Upload", "main", "Atoi", "strconv", nil)
+	childEdge := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	parent := makeTrackerNode(&parentEdge)
+	child := makeTrackerNode(&childEdge)
+	child.Parent = parent
+
+	got := inferParamConverterSchema(child, &RouteInfo{Metadata: meta})
+	require.NotNil(t, got)
+	assert.Equal(t, "integer", got.Type)
+}
+
+func TestInferParamConverterSchema_VarBoundMatch(t *testing.T) {
+	// Dispatcher: no inline match, but a var-bound consumer is a known
+	// converter — schema still gets inferred via the second branch.
+	meta := newTestMeta()
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "v"
+	fv.Position = meta.StringPool.Get(formatLine(10))
+
+	consumer := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+	consumer.Position = meta.StringPool.Get(formatLine(11))
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {&fv, &consumer},
+	}
+
+	got := inferParamConverterSchema(makeTrackerNode(&fv), &RouteInfo{Metadata: meta})
+	require.NotNil(t, got)
+	assert.Equal(t, "boolean", got.Type)
+}
+
+func TestInferParamConverterSchema_NoMatch(t *testing.T) {
+	// Dispatcher: neither inline nor var-bound matches a known converter —
+	// the helper returns nil so the caller falls back to the default schema.
+	meta := newTestMeta()
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	assert.Nil(t, inferParamConverterSchema(makeTrackerNode(&fv), &RouteInfo{Metadata: meta}))
+}
+
+func TestInlineConverter_ParentWithoutEdge(t *testing.T) {
+	// A parent tracker node without a CallGraphEdge should yield nil rather
+	// than dereferencing the nil edge.
+	meta := newTestMeta()
+	childEdge := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	parent := &TrackerNode{} // no edge
+	child := makeTrackerNode(&childEdge)
+	child.Parent = parent
+	assert.Nil(t, inlineConverter(child, meta))
+}
+
+func TestVarBoundConverter_EmptySiblings(t *testing.T) {
+	// meta.Callers entry exists but is empty — early return without scanning.
+	meta := newTestMeta()
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "v"
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {},
+	}
+	assert.Nil(t, varBoundConverter(&fv, meta))
+}
+
+func TestEdgeArgUsesVariable_NilArg(t *testing.T) {
+	// A nil entry in the slice is skipped instead of panicking.
+	meta := newTestMeta()
+	edge := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{nil, makeIdentArg(meta, "v", "string")})
+	assert.True(t, edgeArgUsesVariable(&edge, "v"))
+
+	onlyNil := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{nil, nil})
+	assert.False(t, edgeArgUsesVariable(&onlyNil, "v"))
+}
+
+func TestStringFromPool_NilGuards(t *testing.T) {
+	// nil meta and nil StringPool both yield "" rather than panicking.
+	assert.Equal(t, "", stringFromPool(nil, 0))
+	assert.Equal(t, "", stringFromPool(&metadata.Metadata{}, 0))
+
+	// Sanity: with a real pool, the index is resolved.
+	meta := newTestMeta()
+	idx := meta.StringPool.Get("hello")
+	assert.Equal(t, "hello", stringFromPool(meta, idx))
 }
 
 // formatLine builds a "file:line:col" string suitable for positionLine.

--- a/internal/spec/param_converter_test.go
+++ b/internal/spec/param_converter_test.go
@@ -170,6 +170,38 @@ func TestVarBoundConverter_NoConsumerOrUnknown(t *testing.T) {
 	assert.Nil(t, varBoundConverter(&fv, meta), "non-converter consumer → no inference")
 }
 
+func TestVarBoundConverter_NonConverterConsumerStopsInference(t *testing.T) {
+	// Regression: when the closest forward consumer of the bound variable is
+	// NOT a converter (e.g. strings.Split), inference must stop and fall
+	// through to the default schema. Skipping past the non-converter would
+	// leak a converter from a later, unrelated shadowed-`v` scope into this
+	// scope's parameter — the bug reported against the strings.Split idiom.
+	meta := newTestMeta()
+
+	// FormValue at line 40, bound to v.
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "v"
+	fv.Position = meta.StringPool.Get(formatLine(40))
+
+	// Closest forward consumer at line 41: strings.Split (non-converter).
+	split := makeEdge(meta, "Upload", "main", "Split", "strings",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+	split.Position = meta.StringPool.Get(formatLine(41))
+
+	// Later sibling at line 51 in a different (shadowed) `v` scope: ParseBool.
+	// Without the fix this is what the old logic erroneously selected.
+	parseBool := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+	parseBool.Position = meta.StringPool.Get(formatLine(51))
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {&fv, &split, &parseBool},
+	}
+
+	assert.Nil(t, varBoundConverter(&fv, meta),
+		"closest forward consumer is non-converter — must not jump past it to a later converter in a different scope")
+}
+
 func TestVarBoundConverter_PreferKnownPositionOverUnknown(t *testing.T) {
 	// When metadata lacks position info on one consumer (sibLine == 0), a
 	// later valid-position consumer must still win — otherwise the first

--- a/internal/spec/param_converter_test.go
+++ b/internal/spec/param_converter_test.go
@@ -16,6 +16,8 @@ func TestLookupParamConverter_Known(t *testing.T) {
 		want      paramConverter
 	}{
 		{"strconv", "Atoi", paramConverter{Type: "integer"}},
+		{"strconv", "ParseInt", paramConverter{Type: "integer"}},
+		{"strconv", "ParseUint", paramConverter{Type: "integer"}},
 		{"strconv", "ParseBool", paramConverter{Type: "boolean"}},
 		{"strconv", "ParseFloat", paramConverter{Type: "number"}},
 		{"github.com/google/uuid", "Parse", paramConverter{Type: "string", Format: "uuid"}},
@@ -166,6 +168,56 @@ func TestVarBoundConverter_NoConsumerOrUnknown(t *testing.T) {
 	noisy.Position = meta.StringPool.Get("main.go:61:2")
 	meta.Callers[fv.Caller.BaseID()] = []*metadata.CallGraphEdge{&fv, &noisy}
 	assert.Nil(t, varBoundConverter(&fv, meta), "non-converter consumer → no inference")
+}
+
+func TestVarBoundConverter_PreferKnownPositionOverUnknown(t *testing.T) {
+	// When metadata lacks position info on one consumer (sibLine == 0), a
+	// later valid-position consumer must still win — otherwise the first
+	// unknown-position sibling would lock in and block real matches.
+	meta := newTestMeta()
+
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "v"
+	fv.Position = meta.StringPool.Get(formatLine(40))
+
+	// Iteration order is preserved in a slice, so put the unknown-position
+	// sibling first to exercise the fallback path explicitly.
+	unknown := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+	// no Position set — positionLine returns 0
+
+	known := makeEdge(meta, "Upload", "main", "Atoi", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+	known.Position = meta.StringPool.Get(formatLine(41))
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {&fv, &unknown, &known},
+	}
+
+	c := varBoundConverter(&fv, meta)
+	require.NotNil(t, c)
+	assert.Equal(t, "integer", c.Type, "should prefer known-position Atoi over unknown-position ParseBool")
+}
+
+func TestVarBoundConverter_FallsBackToUnknownPosition(t *testing.T) {
+	// When EVERY converter sibling has unknown position, return one of them
+	// rather than nil — the alternative would be silently dropping the type.
+	meta := newTestMeta()
+
+	fv := makeEdge(meta, "Upload", "main", "FormValue", "net/http", nil)
+	fv.CalleeRecvVarName = "v"
+	fv.Position = meta.StringPool.Get(formatLine(40))
+
+	noPos := makeEdge(meta, "Upload", "main", "ParseBool", "strconv",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		fv.Caller.BaseID(): {&fv, &noPos},
+	}
+
+	c := varBoundConverter(&fv, meta)
+	require.NotNil(t, c)
+	assert.Equal(t, "boolean", c.Type)
 }
 
 func TestVarBoundConverter_SkipsCallsWithoutBoundVar(t *testing.T) {

--- a/internal/spec/tracker.go
+++ b/internal/spec/tracker.go
@@ -1341,7 +1341,22 @@ func NewTrackerNode(tree *TrackerTree, meta *metadata.Metadata, parentID, id str
 				continue
 			}
 
-			_, existsInArgs := meta.Args[metadata.StripToBase(calleeID)]
+			// Skip a caller-side edge only when this exact call site already
+			// appears as an inline argument of another edge — otherwise distinct
+			// var-bound calls to the same function get dropped because they share
+			// the base ID with an unrelated inline call elsewhere in the body.
+			existsInArgs := false
+			for _, parentEdge := range meta.Args[metadata.StripToBase(calleeID)] {
+				for _, arg := range parentEdge.Args {
+					if arg.ID() == calleeID {
+						existsInArgs = true
+						break
+					}
+				}
+				if existsInArgs {
+					break
+				}
+			}
 
 			if edge.Callee.ID() == edge.Caller.ID() || getString(meta, edge.Callee.Name) == "nil" || existsInArgs {
 				// Skip this child as it's already present in arguments

--- a/testdata/echo/expected_openapi.json
+++ b/testdata/echo/expected_openapi.json
@@ -143,7 +143,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -194,7 +194,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -264,7 +264,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],

--- a/testdata/echo/expected_openapi_legacy.json
+++ b/testdata/echo/expected_openapi_legacy.json
@@ -143,7 +143,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -194,7 +194,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -264,7 +264,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],

--- a/testdata/fiber/expected_openapi.json
+++ b/testdata/fiber/expected_openapi.json
@@ -159,7 +159,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -269,7 +269,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -317,7 +317,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -374,7 +374,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],

--- a/testdata/fiber/expected_openapi_legacy.json
+++ b/testdata/fiber/expected_openapi_legacy.json
@@ -159,7 +159,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -269,7 +269,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -317,7 +317,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -374,7 +374,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],

--- a/testdata/form_value_var/expected_openapi.json
+++ b/testdata/form_value_var/expected_openapi.json
@@ -27,6 +27,13 @@
             }
           },
           {
+            "name": "allowedMimeTypes",
+            "in": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "temporaryLocation",
             "in": "form",
             "schema": {

--- a/testdata/form_value_var/expected_openapi.json
+++ b/testdata/form_value_var/expected_openapi.json
@@ -1,0 +1,99 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/upload": {
+      "post": {
+        "summary": "Upload accepts a multipart-form POST and reads several fields, each via a\ndifferent idiom.",
+        "description": "Upload accepts a multipart-form POST and reads several fields, each via a\ndifferent idiom. Every field is part of the public API contract and should\nappear as a form parameter in the generated spec.",
+        "operationId": "form_value_var.Upload",
+        "parameters": [
+          {
+            "name": "storageBucketId",
+            "in": "form",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "temporaryLocation",
+            "in": "form",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "maxFileSize",
+            "in": "form",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "displayName",
+            "in": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file",
+            "in": "form",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/form_value_var.UploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "form_value_var.UploadResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/form_value_var/expected_openapi_legacy.json
+++ b/testdata/form_value_var/expected_openapi_legacy.json
@@ -27,6 +27,13 @@
             }
           },
           {
+            "name": "allowedMimeTypes",
+            "in": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "temporaryLocation",
             "in": "form",
             "schema": {

--- a/testdata/form_value_var/expected_openapi_legacy.json
+++ b/testdata/form_value_var/expected_openapi_legacy.json
@@ -1,0 +1,99 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/upload": {
+      "post": {
+        "summary": "Upload accepts a multipart-form POST and reads several fields, each via a\ndifferent idiom.",
+        "description": "Upload accepts a multipart-form POST and reads several fields, each via a\ndifferent idiom. Every field is part of the public API contract and should\nappear as a form parameter in the generated spec.",
+        "operationId": "form_value_var.Upload",
+        "parameters": [
+          {
+            "name": "storageBucketId",
+            "in": "form",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "temporaryLocation",
+            "in": "form",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "maxFileSize",
+            "in": "form",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "displayName",
+            "in": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file",
+            "in": "form",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/form_value_var.UploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "form_value_var.UploadResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/form_value_var/go.mod
+++ b/testdata/form_value_var/go.mod
@@ -1,0 +1,5 @@
+module form_value_var
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.2.5

--- a/testdata/form_value_var/go.sum
+++ b/testdata/form_value_var/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/testdata/form_value_var/main.go
+++ b/testdata/form_value_var/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -35,7 +36,22 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = storageBucketID
 
-	// Pattern 2: var + guard + ParseBool — should be detected.
+	// Pattern 2: var + guard + non-converter consumer (strings.Split) —
+	// the wire-format value is a string. Even though `v` is reused as the
+	// receiver in *later* if-init scopes that DO use converters, downstream
+	// string-manipulation calls in this scope must not contaminate the
+	// inferred schema with a converter from another scope.
+	var allowedMimeTypes []string
+	if v := r.FormValue("allowedMimeTypes"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				allowedMimeTypes = append(allowedMimeTypes, trimmed)
+			}
+		}
+	}
+	_ = allowedMimeTypes
+
+	// Pattern 3: var + guard + ParseBool — should be detected.
 	temporaryLocation := false
 	if v := r.FormValue("temporaryLocation"); v != "" {
 		parsed, perr := strconv.ParseBool(v)
@@ -47,7 +63,7 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = temporaryLocation
 
-	// Pattern 3: var + guard + Atoi — should be detected.
+	// Pattern 4: var + guard + Atoi — should be detected.
 	maxFileSize := 0
 	if v := r.FormValue("maxFileSize"); v != "" {
 		parsed, perr := strconv.Atoi(v)
@@ -59,14 +75,14 @@ func Upload(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = maxFileSize
 
-	// Pattern 4: direct string usage after non-empty check — should be detected.
+	// Pattern 5: direct string usage after non-empty check — should be detected.
 	displayName := r.FormValue("displayName")
 	if displayName == "" {
 		http.Error(w, "displayName is required", http.StatusBadRequest)
 		return
 	}
 
-	// Pattern 5: r.FormFile multipart part — should be detected as form file.
+	// Pattern 6: r.FormFile multipart part — should be detected as form file.
 	file, header, ferr := r.FormFile("file")
 	if ferr != nil {
 		http.Error(w, "missing file", http.StatusBadRequest)

--- a/testdata/form_value_var/main.go
+++ b/testdata/form_value_var/main.go
@@ -1,0 +1,81 @@
+// Package main demonstrates multipart form handlers that read form values
+// through different idioms — inline conversion, var+guard+converter, direct
+// string usage after a non-empty check, and r.FormFile parts.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// UploadResponse describes the result of an upload request.
+type UploadResponse struct {
+	OK bool `json:"ok"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Post("/upload", Upload)
+	http.ListenAndServe(":3000", r)
+}
+
+// Upload accepts a multipart-form POST and reads several fields, each via a
+// different idiom. Every field is part of the public API contract and should
+// appear as a form parameter in the generated spec.
+func Upload(w http.ResponseWriter, r *http.Request) {
+	// Pattern 1: inline + typed converter — currently detected.
+	storageBucketID, err := strconv.Atoi(r.FormValue("storageBucketId"))
+	if err != nil {
+		http.Error(w, "invalid storageBucketId", http.StatusBadRequest)
+		return
+	}
+	_ = storageBucketID
+
+	// Pattern 2: var + guard + ParseBool — should be detected.
+	temporaryLocation := false
+	if v := r.FormValue("temporaryLocation"); v != "" {
+		parsed, perr := strconv.ParseBool(v)
+		if perr != nil {
+			http.Error(w, "invalid temporaryLocation", http.StatusBadRequest)
+			return
+		}
+		temporaryLocation = parsed
+	}
+	_ = temporaryLocation
+
+	// Pattern 3: var + guard + Atoi — should be detected.
+	maxFileSize := 0
+	if v := r.FormValue("maxFileSize"); v != "" {
+		parsed, perr := strconv.Atoi(v)
+		if perr != nil || parsed < 0 {
+			http.Error(w, "invalid maxFileSize", http.StatusBadRequest)
+			return
+		}
+		maxFileSize = parsed
+	}
+	_ = maxFileSize
+
+	// Pattern 4: direct string usage after non-empty check — should be detected.
+	displayName := r.FormValue("displayName")
+	if displayName == "" {
+		http.Error(w, "displayName is required", http.StatusBadRequest)
+		return
+	}
+
+	// Pattern 5: r.FormFile multipart part — should be detected as form file.
+	file, header, ferr := r.FormFile("file")
+	if ferr != nil {
+		http.Error(w, "missing file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	_ = header
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(UploadResponse{OK: true})
+	_ = fmt.Sprint(displayName)
+}

--- a/testdata/gin/expected_openapi.json
+++ b/testdata/gin/expected_openapi.json
@@ -88,7 +88,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -137,7 +137,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -195,7 +195,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],

--- a/testdata/gin/expected_openapi_legacy.json
+++ b/testdata/gin/expected_openapi_legacy.json
@@ -88,7 +88,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -137,7 +137,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -195,7 +195,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],


### PR DESCRIPTION
## Summary

Fixes a parameter-extraction blind spot reported against multipart Chi handlers (and any framework using the FormValue idiom): once any inline `r.FormValue(...)` call existed in a handler, every var-bound `r.FormValue(...)` call in the same body was silently dropped from the spec.

- **Tracker dedup root cause** (`internal/spec/tracker.go`): the caller-side child loop deduped by base ID, so it skipped *all* caller-side edges to a function once *any* edge anywhere had any call to that function as an inline arg. Now position-aware: a caller-side edge is skipped only when *this exact call site* appears as an arg of another edge.
- **r.FormFile detection**: new `^FormFile$` `ParamPattern` for chi/echo/fiber/http with new `DefaultType`/`DefaultFormat` fields, producing `string + binary` form parameters.
- **Converter-aware schema typing** (`internal/spec/param_converter.go`): new helper recognises `strconv.Atoi`/`ParseInt`/`ParseUint` → integer, `ParseBool` → boolean, `ParseFloat` → number, `uuid.Parse` → string/uuid. Two paths: inline (walks tracker parent) and var-bound (scans sibling caller edges, line-position closest forward consumer wins so shadowed `v` in different `if`-init scopes binds to the right converter). Skipped when `DefaultType` is set so FormFile keeps its binary schema.

## Pre-existing goldens

- **Updated** (legitimate `string → integer` improvements where source has `strconv.Atoi(idStr)`): `gin`, `echo`, `fiber` (3+3+4 path params, default + legacy each).
- **Unchanged** (verified against source — no converter on the param): `chi`, `mux`, `error_helpers`, `response_patterns`, `nested_http`.
- **Added**: `testdata/form_value_var/` covers all five idioms from the bug report (inline, var+guard+ParseBool, var+guard+Atoi, direct string usage, FormFile).

## Test plan
- [x] `go test ./...` — full suite passes
- [x] `make lint` — clean
- [x] New unit tests in `internal/spec/param_converter_test.go` covering lookup, position parsing, arg-var matching, both inference paths, no-converter fallback, nil guards, shadowed-variable disambiguation
- [x] New e2e test `TestE2E_FormValueVar_AllPatternsExtracted` asserts the 5 expected schema types
- [x] Existing goldens reviewed line-by-line before regenerating; only intended changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent parameter type inference for form submissions based on conversion functions used in handler code.

* **Bug Fixes**
  * Corrected OpenAPI schema types for ID path parameters from string to integer across multiple framework examples.
  * Improved form file parameter schema generation with proper binary type mapping.

* **Tests**
  * Added comprehensive test coverage for parameter converter schema inference and form file parameter handling.
  * Added new test fixtures validating multipart form parameter extraction and type resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->