### PR TITLE
feat: JSON DTO format inference + requestBody.required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ specs/
 .specify/
 testdata/error_helpers/error_helpers
 testdata/form_value_var/form_value_var
+testdata/json_dto/json_dto

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as res
 - Type mappings for `time.Time`, `uuid.UUID`, and custom types
 - Converter-typed params: `idStr := c.Param("id"); strconv.Atoi(idStr)` → `integer`; `strconv.ParseBool` → `boolean`; `strconv.ParseFloat` → `number`; `uuid.Parse` → `string/uuid`. Works for both inline (`strconv.Atoi(r.FormValue("x"))`) and var-bound (`if v := r.FormValue("x"); v != "" { strconv.ParseBool(v) }`) idioms, including shadowed variables in separate `if`-init scopes
 - `r.FormFile("upload")` → form parameter with `string`/`binary` schema
+- JSON-DTO field flow inference: when a decoded body's field is later passed to a converter (`uuid.Parse(body.SourceID)`, including pointer-deref `uuid.Parse(*body.TagsetID)`), apispec back-propagates the converter's schema (e.g. `format: uuid`) onto the struct field
+- Explicit per-field overrides via the `apispec:"format=uuid,type=string"` struct tag — covers fields the flow analysis can't reach (e.g. UUIDs that are read but never parsed in the handler, or `format: date-time` / `format: email` hints)
+- `requestBody.required: true` is emitted automatically when a handler reads the body via `json.Decode`, `json.Unmarshal`, `c.Bind`, `c.BodyParser`, etc.
 
 **Output Quality**
 - Deterministic YAML/JSON — sorted map keys, identical output across runs, safe for CI diffing

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -231,6 +231,7 @@ func TestE2E_JSONDto_FormatAndRequiredInference(t *testing.T) {
 		},
 	}
 
+	require.NotNil(t, result.Components, "components missing")
 	for typeName, fields := range cases {
 		schema := result.Components.Schemas[typeName]
 		require.NotNil(t, schema, "schema %s missing", typeName)

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -49,6 +49,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "nested_http", inputDir: "../../testdata/nested_http", configFn: spec.DefaultHTTPConfig},
 		{name: "error_helpers", inputDir: "../../testdata/error_helpers", configFn: spec.DefaultChiConfig},
 		{name: "form_value_var", inputDir: "../../testdata/form_value_var", configFn: spec.DefaultChiConfig},
+		{name: "json_dto", inputDir: "../../testdata/json_dto", configFn: spec.DefaultChiConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {
@@ -190,6 +191,55 @@ func TestE2E_FormValueVar_AllPatternsExtracted(t *testing.T) {
 		require.NotNil(t, s, "schema missing for %q", name)
 		assert.Equal(t, want.Type, s.Type, "wrong type for %q", name)
 		assert.Equal(t, want.Format, s.Format, "wrong format for %q", name)
+	}
+}
+
+// TestE2E_JSONDto_FormatAndRequiredInference asserts the json_dto fixture's
+// JSON request/response contract: requestBody.required is true, fields
+// consumed by uuid.Parse get format=uuid via flow analysis, fields tagged
+// with apispec:"format=..." get the tagged format, and pointer-derefed
+// converter calls (`uuid.Parse(*body.TagsetID)`) reach the field schema.
+func TestE2E_JSONDto_FormatAndRequiredInference(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/json_dto", spec.DefaultChiConfig())
+	eng := NewEngine(cfg)
+	result, err := eng.GenerateOpenAPI()
+	require.NoError(t, err)
+
+	pi, ok := result.Paths["/documents/copy"]
+	require.True(t, ok)
+	require.NotNil(t, pi.Post)
+	require.NotNil(t, pi.Post.RequestBody)
+	assert.True(t, pi.Post.RequestBody.Required, "requestBody must be marked required")
+
+	type want struct{ Type, Format string }
+	cases := map[string]map[string]want{
+		"json_dto.CopyDocumentRequest": {
+			// Flow-inferred via uuid.Parse(body.X) calls in the handler.
+			"sourceId":            {Type: "string", Format: "uuid"},
+			"destinationBucketId": {Type: "string", Format: "uuid"},
+			"authorizationId":     {Type: "string", Format: "uuid"},
+			// Pointer-derefed: uuid.Parse(*body.TagsetID).
+			"tagsetId": {Type: "string", Format: "uuid"},
+			// Struct-tag driven (no converter call).
+			"externalId": {Type: "string", Format: "uuid"},
+			"expiresAt":  {Type: "string", Format: "date-time"},
+		},
+		"json_dto.CopyDocumentResponse": {
+			"id":         {Type: "string", Format: "uuid"},
+			"createdAt":  {Type: "string", Format: "date-time"},
+			"ownerEmail": {Type: "string", Format: "email"},
+		},
+	}
+
+	for typeName, fields := range cases {
+		schema := result.Components.Schemas[typeName]
+		require.NotNil(t, schema, "schema %s missing", typeName)
+		for prop, w := range fields {
+			ps := schema.Properties[prop]
+			require.NotNil(t, ps, "property %s.%s missing", typeName, prop)
+			assert.Equal(t, w.Type, ps.Type, "%s.%s type", typeName, prop)
+			assert.Equal(t, w.Format, ps.Format, "%s.%s format", typeName, prop)
+		}
 	}
 }
 

--- a/internal/spec/decode_target_test.go
+++ b/internal/spec/decode_target_test.go
@@ -1,0 +1,59 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+func TestDecodeTargetVarName_Ident(t *testing.T) {
+	meta := newTestMeta()
+	arg := makeIdentArg(meta, "body", "main")
+	assert.Equal(t, "body", decodeTargetVarName(arg))
+}
+
+func TestDecodeTargetVarName_AddressOf(t *testing.T) {
+	// `&body` — the dominant idiom for json.Decode/json.Unmarshal targets.
+	meta := newTestMeta()
+	inner := makeIdentArg(meta, "body", "main")
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindUnary)
+	arg.X = inner
+	arg.SetValue("&")
+	assert.Equal(t, "body", decodeTargetVarName(arg))
+}
+
+func TestDecodeTargetVarName_StarDeref(t *testing.T) {
+	// `*body` — uncommon as a Decode target, but the helper handles it
+	// symmetrically with KindUnary so var-name extraction stays predictable.
+	meta := newTestMeta()
+	inner := makeIdentArg(meta, "body", "main")
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindStar)
+	arg.X = inner
+	assert.Equal(t, "body", decodeTargetVarName(arg))
+}
+
+func TestDecodeTargetVarName_NotAVar(t *testing.T) {
+	// Literal, raw, or complex expressions don't yield a target var — flow
+	// inference simply doesn't apply, so the helper returns "".
+	meta := newTestMeta()
+	assert.Empty(t, decodeTargetVarName(makeLiteralArg(meta, "{}")))
+	assert.Empty(t, decodeTargetVarName(nil))
+
+	// Unary on something that isn't an ident — e.g., `&someFunc()`.
+	bareUnary := makeCallArg(meta)
+	bareUnary.SetKind(metadata.KindUnary)
+	bareUnary.SetValue("&")
+	bareUnary.X = makeLiteralArg(meta, "{}")
+	assert.Empty(t, decodeTargetVarName(bareUnary))
+}
+
+func TestDecodeTargetVarName_UnaryWithoutInner(t *testing.T) {
+	meta := newTestMeta()
+	bare := makeCallArg(meta)
+	bare.SetKind(metadata.KindUnary)
+	assert.Empty(t, decodeTargetVarName(bare))
+}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -152,6 +152,19 @@ type RequestInfo struct {
 	ContentType string
 	BodyType    string
 	Schema      *Schema
+
+	// Required indicates whether the OpenAPI requestBody.required flag should be
+	// set. When a request-body pattern matches (json.Decode, c.Bind, etc.) the
+	// body must arrive populated — handlers that decode it are deterministic
+	// 400s on empty input — so the matcher sets this true.
+	Required bool
+
+	// DecodeTargetVar is the local variable name the request body decodes
+	// into (e.g., `body` in `json.NewDecoder(r.Body).Decode(&body)`). Used
+	// to drive field-level converter inference: any later access to
+	// `<DecodeTargetVar>.<FieldName>` consumed by a known converter back-
+	// propagates schema type/format onto that struct field.
+	DecodeTargetVar string
 }
 
 // ResponseInfo represents response information

--- a/internal/spec/field_inference.go
+++ b/internal/spec/field_inference.go
@@ -46,6 +46,16 @@ func applyJSONFieldConverterFormats(targetVar, bodyType string, callerBaseID str
 
 	siblings := route.Metadata.Callers[callerBaseID]
 	for _, sib := range siblings {
+		// The converter lookup depends only on the callee — resolve once per
+		// sibling rather than re-looking-up for each arg. Cuts pool reads
+		// when the same call has many args (rare for converters but free).
+		c := lookupParamConverter(
+			stringFromPool(route.Metadata, sib.Callee.Pkg),
+			stringFromPool(route.Metadata, sib.Callee.Name),
+		)
+		if c == nil {
+			continue
+		}
 		for _, arg := range sib.Args {
 			fieldGoName := selectorFieldOnTarget(arg, targetVar)
 			if fieldGoName == "" {
@@ -57,13 +67,6 @@ func applyJSONFieldConverterFormats(targetVar, bodyType string, callerBaseID str
 			}
 			prop, ok := structSchema.Properties[jsonName]
 			if !ok || prop == nil {
-				continue
-			}
-			c := lookupParamConverter(
-				stringFromPool(route.Metadata, sib.Callee.Pkg),
-				stringFromPool(route.Metadata, sib.Callee.Name),
-			)
-			if c == nil {
 				continue
 			}
 			// Don't clobber an explicit format — flow inference is best-effort

--- a/internal/spec/field_inference.go
+++ b/internal/spec/field_inference.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"strings"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// applyJSONFieldConverterFormats back-propagates converter-derived OpenAPI
+// schema formats onto a request-body struct's fields.
+//
+// For every edge in the same handler that consumes `<targetVar>.<fieldName>`
+// (directly or behind a unary/star), we look up the callee in
+// paramConverters and write its type/format onto the matching property of
+// the struct schema. The struct's JSON-tag derived property names are
+// resolved from the metadata so the inference doesn't depend on field-name
+// casing conventions.
+//
+// Tag-driven overrides (`apispec:"format=..."`) take precedence over flow
+// inference: applyAPISpecTag runs after this and overwrites whatever flow
+// analysis wrote.
+func applyJSONFieldConverterFormats(targetVar, bodyType string, callerBaseID string, route *RouteInfo) {
+	if targetVar == "" || bodyType == "" || route == nil || route.Metadata == nil {
+		return
+	}
+	structSchema := route.UsedTypes[bodyType]
+	if structSchema == nil || structSchema.Properties == nil {
+		return
+	}
+
+	// Map from Go field name to (JSON name, schema-property pointer). When the
+	// JSON tag is missing, fall back to the Go field name — the schema
+	// generator does the same.
+	fields := lookupStructFields(bodyType, route.Metadata)
+	if len(fields) == 0 {
+		return
+	}
+
+	siblings := route.Metadata.Callers[callerBaseID]
+	for _, sib := range siblings {
+		for _, arg := range sib.Args {
+			fieldGoName := selectorFieldOnTarget(arg, targetVar)
+			if fieldGoName == "" {
+				continue
+			}
+			jsonName, ok := fields[fieldGoName]
+			if !ok {
+				continue
+			}
+			prop, ok := structSchema.Properties[jsonName]
+			if !ok || prop == nil {
+				continue
+			}
+			c := lookupParamConverter(
+				stringFromPool(route.Metadata, sib.Callee.Pkg),
+				stringFromPool(route.Metadata, sib.Callee.Name),
+			)
+			if c == nil {
+				continue
+			}
+			// Don't clobber an explicit format — flow inference is best-effort
+			// and a previous edge in this loop, the validator tag pass, or a
+			// nested-type pass might have set something more specific.
+			if prop.Format == "" {
+				prop.Format = c.Format
+			}
+			if c.Type != "" && (prop.Type == "" || prop.Type == "string") {
+				// Converters that change the wire type (Atoi → integer) only
+				// apply when the JSON field is currently typed as string —
+				// otherwise the explicit struct-field type wins.
+				prop.Type = c.Type
+			}
+		}
+	}
+}
+
+// selectorFieldOnTarget returns the field name of `<targetVar>.<field>`
+// when the argument is exactly that selector (or one wrapped in a single
+// unary/star, which covers `*body.field` for pointer fields). Returns ""
+// for any other shape so callers fall through.
+func selectorFieldOnTarget(arg *metadata.CallArgument, targetVar string) string {
+	if arg == nil {
+		return ""
+	}
+	switch arg.GetKind() {
+	case metadata.KindUnary, metadata.KindStar:
+		if arg.X == nil {
+			return ""
+		}
+		return selectorFieldOnTarget(arg.X, targetVar)
+	case metadata.KindSelector:
+		if arg.X == nil || arg.Sel == nil {
+			return ""
+		}
+		if arg.X.GetKind() != metadata.KindIdent || arg.X.GetName() != targetVar {
+			return ""
+		}
+		return arg.Sel.GetName()
+	}
+	return ""
+}
+
+// lookupStructFields returns a Go-field-name → JSON-name map for a struct
+// referenced by its fully-qualified type name (e.g.,
+// "json_dto.CopyDocumentRequest"). Returns nil if the type can't be found.
+func lookupStructFields(bodyType string, meta *metadata.Metadata) map[string]string {
+	if meta == nil {
+		return nil
+	}
+	parts := TypeParts(strings.TrimPrefix(bodyType, "*"))
+	if parts.PkgName == "" || parts.TypeName == "" {
+		return nil
+	}
+	pkg, ok := meta.Packages[parts.PkgName]
+	if !ok {
+		return nil
+	}
+	for _, file := range pkg.Files {
+		typ, ok := file.Types[parts.TypeName]
+		if !ok {
+			continue
+		}
+		out := make(map[string]string, len(typ.Fields))
+		for _, field := range typ.Fields {
+			goName := stringFromPool(meta, field.Name)
+			if goName == "" {
+				continue
+			}
+			tag := stringFromPool(meta, field.Tag)
+			jsonName := extractJSONName(tag)
+			if jsonName == "" {
+				jsonName = goName
+			}
+			out[goName] = jsonName
+		}
+		return out
+	}
+	return nil
+}

--- a/internal/spec/field_inference_test.go
+++ b/internal/spec/field_inference_test.go
@@ -51,6 +51,19 @@ func TestSelectorFieldOnTarget_DereferencedPointer(t *testing.T) {
 	assert.Equal(t, "TagsetID", selectorFieldOnTarget(arg, "body"))
 }
 
+func TestSelectorFieldOnTarget_KindStar(t *testing.T) {
+	// metadata.KindStar is distinct from KindUnary — the recursion handles
+	// both, but only the unary path is covered above. This locks the star
+	// branch (e.g. when an AST node is built directly as *ast.StarExpr
+	// rather than *ast.UnaryExpr).
+	meta := newTestMeta()
+	inner := mkSelArgPtr(meta, "body", "TagsetID")
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindStar)
+	arg.X = inner
+	assert.Equal(t, "TagsetID", selectorFieldOnTarget(arg, "body"))
+}
+
 func TestSelectorFieldOnTarget_AddressOf(t *testing.T) {
 	// `&body.Field` — uncommon as a converter arg but still a valid selector
 	// shape. The unary unwrap should handle it.

--- a/internal/spec/field_inference_test.go
+++ b/internal/spec/field_inference_test.go
@@ -1,0 +1,574 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// mkSelArgPtr builds a CallArgument representing `<recvVar>.<field>` for
+// use in field-inference tests. It mirrors how metadata.go builds selector
+// arguments from ast.SelectorExpr.
+func mkSelArgPtr(meta *metadata.Metadata, recvVar, field string) *metadata.CallArgument {
+	x := makeCallArg(meta)
+	x.SetKind(metadata.KindIdent)
+	x.SetName(recvVar)
+
+	sel := makeCallArg(meta)
+	sel.SetKind(metadata.KindIdent)
+	sel.SetName(field)
+
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindSelector)
+	arg.X = x
+	arg.Sel = sel
+	return arg
+}
+
+// wrapUnary wraps an inner CallArgument as `*<inner>` (KindUnary "*"), which
+// is how the metadata represents pointer dereference like `*body.Field`.
+func wrapUnary(meta *metadata.Metadata, inner *metadata.CallArgument, op string) *metadata.CallArgument {
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindUnary)
+	arg.X = inner
+	arg.SetValue(op)
+	return arg
+}
+
+func TestSelectorFieldOnTarget_DirectSelector(t *testing.T) {
+	meta := newTestMeta()
+	arg := mkSelArgPtr(meta, "body", "SourceID")
+	assert.Equal(t, "SourceID", selectorFieldOnTarget(arg, "body"))
+}
+
+func TestSelectorFieldOnTarget_DereferencedPointer(t *testing.T) {
+	meta := newTestMeta()
+	inner := mkSelArgPtr(meta, "body", "TagsetID")
+	arg := wrapUnary(meta, inner, "*")
+	assert.Equal(t, "TagsetID", selectorFieldOnTarget(arg, "body"))
+}
+
+func TestSelectorFieldOnTarget_AddressOf(t *testing.T) {
+	// `&body.Field` — uncommon as a converter arg but still a valid selector
+	// shape. The unary unwrap should handle it.
+	meta := newTestMeta()
+	inner := mkSelArgPtr(meta, "body", "ID")
+	arg := wrapUnary(meta, inner, "&")
+	assert.Equal(t, "ID", selectorFieldOnTarget(arg, "body"))
+}
+
+func TestSelectorFieldOnTarget_DifferentVar(t *testing.T) {
+	meta := newTestMeta()
+	arg := mkSelArgPtr(meta, "other", "SourceID")
+	assert.Empty(t, selectorFieldOnTarget(arg, "body"))
+}
+
+func TestSelectorFieldOnTarget_NotASelector(t *testing.T) {
+	meta := newTestMeta()
+	ident := makeIdentArg(meta, "body", "")
+	assert.Empty(t, selectorFieldOnTarget(ident, "body"))
+	literal := makeLiteralArg(meta, "x")
+	assert.Empty(t, selectorFieldOnTarget(literal, "body"))
+}
+
+func TestSelectorFieldOnTarget_NilGuards(t *testing.T) {
+	assert.Empty(t, selectorFieldOnTarget(nil, "body"))
+	meta := newTestMeta()
+	bare := makeCallArg(meta)
+	bare.SetKind(metadata.KindSelector) // no X / Sel
+	assert.Empty(t, selectorFieldOnTarget(bare, "body"))
+	bareUnary := makeCallArg(meta)
+	bareUnary.SetKind(metadata.KindUnary) // no X
+	assert.Empty(t, selectorFieldOnTarget(bareUnary, "body"))
+	// Selector whose X isn't an ident — e.g. `pkg.Const.Field` — must not match.
+	meta2 := newTestMeta()
+	innerSel := mkSelArgPtr(meta2, "pkg", "Const")
+	wrapped := makeCallArg(meta2)
+	wrapped.SetKind(metadata.KindSelector)
+	wrapped.X = innerSel
+	wrapped.Sel = makeIdentArg(meta2, "Field", "")
+	assert.Empty(t, selectorFieldOnTarget(wrapped, "body"))
+}
+
+func TestLookupStructFields_NotFound(t *testing.T) {
+	meta := newTestMeta()
+	assert.Nil(t, lookupStructFields("missing.Type", meta))
+	assert.Nil(t, lookupStructFields("just-a-name", meta), "unparseable type → nil")
+}
+
+func TestLookupStructFields_NilGuards(t *testing.T) {
+	assert.Nil(t, lookupStructFields("pkg.Type", nil))
+}
+
+func TestLookupStructFields_TypeInOnlyOneOfMultipleFiles(t *testing.T) {
+	// Two files in the same package; the requested type lives in the
+	// second. The helper has to keep scanning past the empty file rather
+	// than returning early.
+	meta := newTestMeta()
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"a.go": {Types: map[string]*metadata.Type{"OtherType": {}}},
+				"b.go": {Types: map[string]*metadata.Type{
+					"Req": {
+						Name:   meta.StringPool.Get("Req"),
+						Fields: []metadata.Field{{Name: meta.StringPool.Get("ID")}},
+					},
+				}},
+			},
+		},
+	}
+	got := lookupStructFields("pkg.Req", meta)
+	require.Len(t, got, 1)
+	assert.Equal(t, "ID", got["ID"])
+}
+
+func TestLookupStructFields_TypeMissingInAllFiles(t *testing.T) {
+	// Package exists but the type doesn't live in any of its files.
+	meta := newTestMeta()
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"a.go": {Types: map[string]*metadata.Type{"OtherType": {}}},
+				"b.go": {Types: map[string]*metadata.Type{"YetAnother": {}}},
+			},
+		},
+	}
+	assert.Nil(t, lookupStructFields("pkg.Req", meta))
+}
+
+func TestLookupStructFields_FieldWithEmptyName_Skipped(t *testing.T) {
+	// Defensive: a field whose Name index resolves to "" is skipped rather
+	// than producing an empty-string key in the result.
+	meta := newTestMeta()
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {Types: map[string]*metadata.Type{
+					"Req": {
+						Name: meta.StringPool.Get("Req"),
+						Fields: []metadata.Field{
+							{Name: -1}, // -1 → "" out of the StringPool
+							{Name: meta.StringPool.Get("Real")},
+						},
+					},
+				}},
+			},
+		},
+	}
+	got := lookupStructFields("pkg.Req", meta)
+	require.Len(t, got, 1)
+	_, hasEmpty := got[""]
+	assert.False(t, hasEmpty, "empty Go field name must not appear in the map")
+	assert.Equal(t, "Real", got["Real"])
+}
+
+func TestLookupStructFields_FoundUsesJSONNameWhenPresent(t *testing.T) {
+	meta := newTestMeta()
+	tagSourceID := meta.StringPool.Get(`json:"sourceId"`)
+	tagPlain := meta.StringPool.Get("")
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name: meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{
+								{Name: meta.StringPool.Get("SourceID"), Tag: tagSourceID},
+								{Name: meta.StringPool.Get("Untagged"), Tag: tagPlain},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := lookupStructFields("pkg.Req", meta)
+	require.Len(t, got, 2)
+	assert.Equal(t, "sourceId", got["SourceID"], "json tag → used")
+	assert.Equal(t, "Untagged", got["Untagged"], "no tag → Go name")
+}
+
+func TestApplyJSONFieldConverterFormats_HappyPath(t *testing.T) {
+	// Build a mini call graph: Copy(body) → uuid.Parse(body.SourceID) and
+	// strings.TrimSpace(body.DisplayName). The converter run should set
+	// format=uuid on sourceId and leave displayName alone.
+	meta := newTestMeta()
+	sourceTag := meta.StringPool.Get(`json:"sourceId"`)
+	displayTag := meta.StringPool.Get(`json:"displayName"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name: meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{
+								{Name: meta.StringPool.Get("SourceID"), Tag: sourceTag},
+								{Name: meta.StringPool.Get("DisplayName"), Tag: displayTag},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converterEdge := makeEdge(meta, "Copy", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "SourceID")})
+	noisyEdge := makeEdge(meta, "Copy", "pkg", "TrimSpace", "strings",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "DisplayName")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		converterEdge.Caller.BaseID(): {&converterEdge, &noisyEdge},
+	}
+
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {
+				Type: "object",
+				Properties: map[string]*Schema{
+					"sourceId":    {Type: "string"},
+					"displayName": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	applyJSONFieldConverterFormats("body", "pkg.Req", converterEdge.Caller.BaseID(), route)
+
+	src := route.UsedTypes["pkg.Req"].Properties["sourceId"]
+	disp := route.UsedTypes["pkg.Req"].Properties["displayName"]
+	assert.Equal(t, "string", src.Type)
+	assert.Equal(t, "uuid", src.Format, "uuid.Parse(body.SourceID) → format=uuid")
+	assert.Equal(t, "string", disp.Type)
+	assert.Empty(t, disp.Format, "non-converter consumer must not set a format")
+}
+
+func TestApplyJSONFieldConverterFormats_FieldMapsToMissingProperty(t *testing.T) {
+	// Field exists on the Go struct (so lookupStructFields returns it) but the
+	// schema's Properties map doesn't have a matching entry — possible when
+	// the schema was generated with a stale snapshot or partially trimmed.
+	// The helper must skip rather than create a property out of thin air.
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"id"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {Types: map[string]*metadata.Type{
+					"Req": {
+						Name:   meta.StringPool.Get("Req"),
+						Fields: []metadata.Field{{Name: meta.StringPool.Get("ID"), Tag: tag}},
+					},
+				}},
+			},
+		},
+	}
+	edge := makeEdge(meta, "Handler", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "ID")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {Type: "object", Properties: map[string]*Schema{}}, // empty
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Empty(t, route.UsedTypes["pkg.Req"].Properties,
+		"missing property must not be created by inference")
+}
+
+func TestApplyJSONFieldConverterFormats_NilProperty(t *testing.T) {
+	// Properties map has the key but the value is nil (defensive: callers
+	// shouldn't normally insert nil, but the helper guards against it).
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"id"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {Types: map[string]*metadata.Type{
+					"Req": {
+						Name:   meta.StringPool.Get("Req"),
+						Fields: []metadata.Field{{Name: meta.StringPool.Get("ID"), Tag: tag}},
+					},
+				}},
+			},
+		},
+	}
+	edge := makeEdge(meta, "Handler", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "ID")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {Type: "object", Properties: map[string]*Schema{"id": nil}},
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Nil(t, route.UsedTypes["pkg.Req"].Properties["id"],
+		"nil property must remain nil — never instantiate")
+}
+
+func TestApplyJSONFieldConverterFormats_ZeroFieldsStruct(t *testing.T) {
+	// Struct exists in metadata but has no fields — early return without
+	// scanning any caller edges.
+	meta := newTestMeta()
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Empty": {Name: meta.StringPool.Get("Empty")},
+					},
+				},
+			},
+		},
+	}
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Empty": {Type: "object", Properties: map[string]*Schema{}},
+		},
+	}
+	// Should not panic and should be a no-op.
+	applyJSONFieldConverterFormats("body", "pkg.Empty", "pkg.Caller", route)
+	assert.Empty(t, route.UsedTypes["pkg.Empty"].Properties)
+}
+
+func TestApplyJSONFieldConverterFormats_SkipsNonSelectorArgs(t *testing.T) {
+	// Mix of literal/ident args interleaved with the selector — the literals
+	// must be skipped without affecting iteration.
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"id"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name:   meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{{Name: meta.StringPool.Get("ID"), Tag: tag}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	edge := makeEdge(meta, "Handler", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{
+			makeLiteralArg(meta, "ignored"),
+			makeIdentArg(meta, "v", "string"), // ident, not a selector
+			mkSelArgPtr(meta, "body", "ID"),
+		})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {
+				Type: "object",
+				Properties: map[string]*Schema{
+					"id": {Type: "string"},
+				},
+			},
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["id"].Format)
+}
+
+func TestApplyJSONFieldConverterFormats_FieldNotInStruct(t *testing.T) {
+	// `body.UnknownField` consumed by a converter — but UnknownField isn't
+	// declared on the struct (e.g. typo or refactor leftover). The helper
+	// must skip it rather than mutating an unrelated property.
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"id"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name:   meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{{Name: meta.StringPool.Get("ID"), Tag: tag}},
+						},
+					},
+				},
+			},
+		},
+	}
+	edge := makeEdge(meta, "Handler", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "Phantom")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {
+				Type: "object",
+				Properties: map[string]*Schema{
+					"id": {Type: "string"},
+				},
+			},
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Empty(t, route.UsedTypes["pkg.Req"].Properties["id"].Format,
+		"unrelated field reference must not change any property")
+}
+
+func TestApplyJSONFieldConverterFormats_NoOpGuards(_ *testing.T) {
+	meta := newTestMeta()
+	emptyRoute := &RouteInfo{Metadata: meta, UsedTypes: map[string]*Schema{}}
+
+	// Each guard returns silently — the assertion is "no panic".
+	applyJSONFieldConverterFormats("", "pkg.Req", "x", emptyRoute)
+	applyJSONFieldConverterFormats("body", "", "x", emptyRoute)
+	applyJSONFieldConverterFormats("body", "pkg.Req", "x", nil)
+	applyJSONFieldConverterFormats("body", "pkg.Req", "x", &RouteInfo{})    // nil meta
+	applyJSONFieldConverterFormats("body", "pkg.Req", "x", emptyRoute)      // schema absent
+	applyJSONFieldConverterFormats("body", "missing.Type", "x", &RouteInfo{ // schema present, type metadata absent
+		Metadata:  meta,
+		UsedTypes: map[string]*Schema{"missing.Type": {Type: "object", Properties: map[string]*Schema{}}},
+	})
+}
+
+func TestApplyJSONFieldConverterFormats_DoesNotClobberExistingFormat(t *testing.T) {
+	// If a property already carries a more-specific format (set by a
+	// validator tag or a previous pass), flow inference must not overwrite it.
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"id"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name:   meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{{Name: meta.StringPool.Get("ID"), Tag: tag}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	edge := makeEdge(meta, "Copy", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "ID")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {
+				Type: "object",
+				Properties: map[string]*Schema{
+					"id": {Type: "string", Format: "byte"},
+				},
+			},
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Equal(t, "byte", route.UsedTypes["pkg.Req"].Properties["id"].Format,
+		"existing format must not be overwritten by flow inference")
+}
+
+func TestApplyJSONFieldConverterFormats_PreservesExistingNonStringType(t *testing.T) {
+	// If a property's type is already non-string (e.g., integer set by a
+	// previous pass), flow inference must not change it just because the
+	// converter would pick a different type.
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"count"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name:   meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{{Name: meta.StringPool.Get("Count"), Tag: tag}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Pretend someone passes body.Count to ParseBool — converter says boolean,
+	// but the property was already typed as integer (which we trust more).
+	edge := makeEdge(meta, "Handler", "pkg", "ParseBool", "strconv",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "Count")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {
+				Type: "object",
+				Properties: map[string]*Schema{
+					"count": {Type: "integer"},
+				},
+			},
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Equal(t, "integer", route.UsedTypes["pkg.Req"].Properties["count"].Type,
+		"non-string existing type wins over converter inference")
+}
+
+func TestApplyJSONFieldConverterFormats_HandlesPointerDeref(t *testing.T) {
+	// uuid.Parse(*body.OptionalID) is the common pattern for optional UUID
+	// pointer fields. The dereference shouldn't break the selector match.
+	meta := newTestMeta()
+	tag := meta.StringPool.Get(`json:"optionalId,omitempty"`)
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {
+			Files: map[string]*metadata.File{
+				"f.go": {
+					Types: map[string]*metadata.Type{
+						"Req": {
+							Name:   meta.StringPool.Get("Req"),
+							Fields: []metadata.Field{{Name: meta.StringPool.Get("OptionalID"), Tag: tag}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	deref := wrapUnary(meta, mkSelArgPtr(meta, "body", "OptionalID"), "*")
+	edge := makeEdge(meta, "Handler", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{deref})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		edge.Caller.BaseID(): {&edge},
+	}
+
+	route := &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {
+				Type: "object",
+				Properties: map[string]*Schema{
+					"optionalId": {Type: "string"},
+				},
+			},
+		},
+	}
+	applyJSONFieldConverterFormats("body", "pkg.Req", edge.Caller.BaseID(), route)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["optionalId"].Format)
+}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -405,6 +405,7 @@ func buildPathsFromRoutes(routes []*RouteInfo, cfg *APISpecConfig) map[string]Pa
 						Schema: route.Request.Schema,
 					},
 				},
+				Required: route.Request.Required,
 			}
 		}
 
@@ -1041,6 +1042,10 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 				schema.Required = append(schema.Required, fieldName)
 			}
 		}
+
+		// `apispec:"..."` is the user's explicit override — applied last so it
+		// wins over both validator constraints and Go-type-derived defaults.
+		applyAPISpecTag(fieldSchema, parseAPISpecTag(getStringFromPool(meta, field.Tag)))
 
 		// Detect and apply enum values from constants if no enum was specified in tags
 		// Only apply enum detection for custom types (not built-in types)

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -528,6 +528,7 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 		}
 
 		reqInfo.BodyType = preprocessingBodyType(bodyType)
+		reqInfo.DecodeTargetVar = decodeTargetVarName(arg)
 		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
 		reqInfo.Schema = schema
 	}
@@ -536,7 +537,45 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 		return nil
 	}
 
+	// A handler reading the body via Decode/Bind/etc. is committed to receiving
+	// it — empty input fails decoding or returns a zero-valued struct that the
+	// handler then 400s on. Marking required:true reflects that contract.
+	reqInfo.Required = true
+
+	// Walk the rest of the handler for `<targetVar>.<field>` accesses fed into
+	// known converters and back-propagate their schema formats onto the struct
+	// fields. Cheap (we already have the call graph indexed by caller) and
+	// strictly additive — never erases existing information.
+	if reqInfo.DecodeTargetVar != "" && route.Metadata != nil {
+		applyJSONFieldConverterFormats(
+			reqInfo.DecodeTargetVar,
+			reqInfo.BodyType,
+			edge.Caller.BaseID(),
+			route,
+		)
+	}
+
 	return reqInfo
+}
+
+// decodeTargetVarName returns the local variable name that the decode call's
+// type-arg refers to (e.g., "body" in `Decode(&body)` or `Decode(body)`).
+// Empty when the argument isn't a simple variable reference (literal, call
+// expression, complex expression).
+func decodeTargetVarName(arg *metadata.CallArgument) string {
+	if arg == nil {
+		return ""
+	}
+	switch arg.GetKind() {
+	case metadata.KindIdent:
+		return arg.GetName()
+	case metadata.KindUnary, metadata.KindStar:
+		// `&body` / `*body` — unwrap one level.
+		if arg.X != nil && arg.X.GetKind() == metadata.KindIdent {
+			return arg.X.GetName()
+		}
+	}
+	return ""
 }
 
 // Helper methods for BasePatternMatcher

--- a/internal/spec/struct_tag.go
+++ b/internal/spec/struct_tag.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"reflect"
+	"strings"
+)
+
+// apispecTagKey is the struct-tag key apispec recognises for OpenAPI schema
+// hints that flow analysis can't infer (e.g. UUID-typed string fields that
+// are never passed to uuid.Parse, or fields that hold an RFC3339 timestamp
+// without a runtime parser call).
+const apispecTagKey = "apispec"
+
+// apispecTag captures the OpenAPI schema overrides declared in an
+// `apispec:"..."` struct tag. Empty fields mean "no override" rather than
+// "blank value" — applyAPISpecTag only writes non-empty entries onto the
+// schema so it never erases existing data.
+type apispecTag struct {
+	Type   string
+	Format string
+}
+
+// parseAPISpecTag returns the apispec tag declared on a struct field, or nil
+// when the tag is absent or has no recognised keys.
+//
+// The wire format is the standard Go struct-tag convention used by
+// encoding/json, validate, etc.: `apispec:"key=value,key=value"`. Recognised
+// keys: `format`, `type`. Unknown keys are silently ignored so users can
+// embed third-party hints in the same tag without breaking apispec.
+func parseAPISpecTag(rawTag string) *apispecTag {
+	if rawTag == "" {
+		return nil
+	}
+	value := reflect.StructTag(rawTag).Get(apispecTagKey)
+	if value == "" {
+		return nil
+	}
+
+	t := &apispecTag{}
+	for _, part := range strings.Split(value, ",") {
+		key, val, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		if val == "" {
+			continue
+		}
+		switch key {
+		case "format":
+			t.Format = val
+		case "type":
+			t.Type = val
+		}
+	}
+	if t.Type == "" && t.Format == "" {
+		return nil
+	}
+	return t
+}
+
+// applyAPISpecTag overwrites the schema's type/format from the tag. Tag
+// declarations are user-explicit and therefore the strongest signal — they
+// win over flow inference, validation tags, and Go-type-derived defaults.
+func applyAPISpecTag(schema *Schema, t *apispecTag) {
+	if schema == nil || t == nil {
+		return
+	}
+	if t.Type != "" {
+		schema.Type = t.Type
+	}
+	if t.Format != "" {
+		schema.Format = t.Format
+	}
+}

--- a/internal/spec/struct_tag_test.go
+++ b/internal/spec/struct_tag_test.go
@@ -1,0 +1,91 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPISpecTag_FormatOnly(t *testing.T) {
+	tag := parseAPISpecTag(`json:"sourceId" apispec:"format=uuid"`)
+	require.NotNil(t, tag)
+	assert.Equal(t, "uuid", tag.Format)
+	assert.Empty(t, tag.Type)
+}
+
+func TestParseAPISpecTag_TypeOnly(t *testing.T) {
+	tag := parseAPISpecTag(`apispec:"type=integer"`)
+	require.NotNil(t, tag)
+	assert.Equal(t, "integer", tag.Type)
+	assert.Empty(t, tag.Format)
+}
+
+func TestParseAPISpecTag_TypeAndFormat(t *testing.T) {
+	tag := parseAPISpecTag(`apispec:"type=integer,format=int64"`)
+	require.NotNil(t, tag)
+	assert.Equal(t, "integer", tag.Type)
+	assert.Equal(t, "int64", tag.Format)
+}
+
+func TestParseAPISpecTag_UnknownKeysIgnored(t *testing.T) {
+	// Unknown keys mixed in with recognised ones don't break parsing — the
+	// known keys still apply. Lets users embed third-party hints alongside.
+	tag := parseAPISpecTag(`apispec:"format=uuid,unknown=foo,deprecated=true"`)
+	require.NotNil(t, tag)
+	assert.Equal(t, "uuid", tag.Format)
+}
+
+func TestParseAPISpecTag_AllUnknown_NilResult(t *testing.T) {
+	// When every key is unknown there's nothing to apply — return nil so
+	// callers can short-circuit without checking each field.
+	tag := parseAPISpecTag(`apispec:"unknown=value"`)
+	assert.Nil(t, tag)
+}
+
+func TestParseAPISpecTag_EmptyValue_Skipped(t *testing.T) {
+	tag := parseAPISpecTag(`apispec:"format="`)
+	assert.Nil(t, tag, "empty value should not be set")
+}
+
+func TestParseAPISpecTag_MalformedPart_Skipped(t *testing.T) {
+	// Parts without an `=` are silently skipped, not treated as bool flags.
+	tag := parseAPISpecTag(`apispec:"format=uuid,bareflag"`)
+	require.NotNil(t, tag)
+	assert.Equal(t, "uuid", tag.Format)
+}
+
+func TestParseAPISpecTag_NoTag(t *testing.T) {
+	assert.Nil(t, parseAPISpecTag(""))
+	assert.Nil(t, parseAPISpecTag(`json:"only"`))
+}
+
+func TestParseAPISpecTag_WhitespaceTolerated(t *testing.T) {
+	tag := parseAPISpecTag(`apispec:" format = uuid , type = string "`)
+	require.NotNil(t, tag)
+	assert.Equal(t, "uuid", tag.Format)
+	assert.Equal(t, "string", tag.Type)
+}
+
+func TestApplyAPISpecTag_OverwritesTypeAndFormat(t *testing.T) {
+	s := &Schema{Type: "string"}
+	applyAPISpecTag(s, &apispecTag{Type: "integer", Format: "int64"})
+	assert.Equal(t, "integer", s.Type)
+	assert.Equal(t, "int64", s.Format)
+}
+
+func TestApplyAPISpecTag_OnlyFormat_TypePreserved(t *testing.T) {
+	// Tags that set only `format` must not erase the existing type.
+	s := &Schema{Type: "string", Format: "byte"}
+	applyAPISpecTag(s, &apispecTag{Format: "uuid"})
+	assert.Equal(t, "string", s.Type)
+	assert.Equal(t, "uuid", s.Format)
+}
+
+func TestApplyAPISpecTag_NilGuards(t *testing.T) {
+	applyAPISpecTag(nil, &apispecTag{Format: "uuid"}) // shouldn't panic
+	applyAPISpecTag(&Schema{}, nil)                   // shouldn't panic
+	s := &Schema{Type: "string"}
+	applyAPISpecTag(s, nil)
+	assert.Equal(t, "string", s.Type, "nil tag → no change")
+}

--- a/testdata/chi/expected_openapi.json
+++ b/testdata/chi/expected_openapi.json
@@ -95,7 +95,8 @@
                 "$ref": "#/components/schemas/products.CreateProductRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -185,7 +186,8 @@
                 "$ref": "#/components/schemas/users.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/chi/expected_openapi_legacy.json
+++ b/testdata/chi/expected_openapi_legacy.json
@@ -95,7 +95,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_chi_products.CreateProductRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -185,7 +186,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_chi_users.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/echo/expected_openapi.json
+++ b/testdata/echo/expected_openapi.json
@@ -89,7 +89,8 @@
                 "$ref": "#/components/schemas/echo.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -205,7 +206,8 @@
                 "$ref": "#/components/schemas/echo.UpdateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/echo/expected_openapi_legacy.json
+++ b/testdata/echo/expected_openapi_legacy.json
@@ -89,7 +89,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_echo.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -205,7 +206,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_echo.UpdateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/error_helpers/expected_openapi.json
+++ b/testdata/error_helpers/expected_openapi.json
@@ -56,7 +56,8 @@
                 "$ref": "#/components/schemas/error_helpers.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -160,7 +161,8 @@
                 "$ref": "#/components/schemas/error_helpers.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/error_helpers/expected_openapi_legacy.json
+++ b/testdata/error_helpers/expected_openapi_legacy.json
@@ -56,7 +56,8 @@
                 "$ref": "#/components/schemas/error_helpers.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -160,7 +161,8 @@
                 "$ref": "#/components/schemas/error_helpers.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/fiber/expected_openapi.json
+++ b/testdata/fiber/expected_openapi.json
@@ -121,7 +121,8 @@
                 "$ref": "#/components/schemas/products.CreateProductRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -231,7 +232,8 @@
                 "$ref": "#/components/schemas/users.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -328,7 +330,8 @@
                 "$ref": "#/components/schemas/users.UpdateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/fiber/expected_openapi_legacy.json
+++ b/testdata/fiber/expected_openapi_legacy.json
@@ -121,7 +121,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_fiber_products.CreateProductRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -231,7 +232,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_fiber_users.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -328,7 +330,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_fiber_users.UpdateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/gin/expected_openapi.json
+++ b/testdata/gin/expected_openapi.json
@@ -49,7 +49,8 @@
                 "$ref": "#/components/schemas/gin.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -148,7 +149,8 @@
                 "$ref": "#/components/schemas/gin.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/gin/expected_openapi_legacy.json
+++ b/testdata/gin/expected_openapi_legacy.json
@@ -49,7 +49,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_gin.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -148,7 +149,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_gin.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/json_dto/expected_openapi.json
+++ b/testdata/json_dto/expected_openapi.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/copy": {
+      "post": {
+        "summary": "Copy decodes the request body and validates every flow-inferred field.",
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/json_dto.CopyDocumentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "externalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tagsetId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId",
+          "authorizationId",
+          "externalId",
+          "expiresAt"
+        ]
+      },
+      "json_dto.CopyDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ownerEmail": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "ownerEmail"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/json_dto/expected_openapi_legacy.json
+++ b/testdata/json_dto/expected_openapi_legacy.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/copy": {
+      "post": {
+        "summary": "Copy decodes the request body and validates every flow-inferred field.",
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/json_dto.CopyDocumentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "externalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tagsetId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId",
+          "authorizationId",
+          "externalId",
+          "expiresAt"
+        ]
+      },
+      "json_dto.CopyDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ownerEmail": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "ownerEmail"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/json_dto/go.mod
+++ b/testdata/json_dto/go.mod
@@ -1,0 +1,8 @@
+module json_dto
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
+)

--- a/testdata/json_dto/go.sum
+++ b/testdata/json_dto/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/json_dto/main.go
+++ b/testdata/json_dto/main.go
@@ -1,0 +1,93 @@
+// Package main exercises JSON request-body inference: requestBody.required
+// emission and per-field schema typing for fields whose JSON value is later
+// fed through a known converter (uuid.Parse, time.Parse, etc.) in the same
+// handler. Includes a struct-tag fallback for cases the flow analysis can't
+// catch.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// CopyDocumentRequest is a typical multi-UUID-field request body. The fields
+// are declared `string` because the wire format is JSON-string, but the
+// handler validates each as a UUID via uuid.Parse — flow analysis should
+// back-propagate format: uuid to the schema field.
+type CopyDocumentRequest struct {
+	SourceID            string  `json:"sourceId"`
+	DestinationBucketID string  `json:"destinationBucketId"`
+	AuthorizationID     string  `json:"authorizationId"`
+	TagsetID            *string `json:"tagsetId,omitempty"`
+
+	// Field never consumed by a converter — flow analysis can't help here, so
+	// the user opts in via the apispec struct tag.
+	ExternalID string `json:"externalId" apispec:"format=uuid"`
+
+	// Mixed-format example: tag overrides the schema when the runtime
+	// validation isn't a uuid.Parse-style call (here, it's just used as a
+	// timestamp string downstream).
+	ExpiresAt string `json:"expiresAt" apispec:"format=date-time"`
+}
+
+// CopyDocumentResponse is returned on success. None of these fields are
+// converter-validated server-side, so we use the apispec tag to pin them.
+type CopyDocumentResponse struct {
+	ID         string `json:"id" apispec:"format=uuid"`
+	CreatedAt  string `json:"createdAt" apispec:"format=date-time"`
+	OwnerEmail string `json:"ownerEmail" apispec:"format=email"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Post("/documents/copy", Copy)
+	http.ListenAndServe(":3000", r)
+}
+
+// Copy decodes the request body and validates every flow-inferred field.
+func Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	// Three uuid.Parse calls on body fields — flow analysis must wire each
+	// field back to format: uuid.
+	sourceID, err := uuid.Parse(body.SourceID)
+	if err != nil {
+		http.Error(w, "invalid sourceId", http.StatusBadRequest)
+		return
+	}
+	destID, err := uuid.Parse(body.DestinationBucketID)
+	if err != nil {
+		http.Error(w, "invalid destinationBucketId", http.StatusBadRequest)
+		return
+	}
+	authID, err := uuid.Parse(body.AuthorizationID)
+	if err != nil {
+		http.Error(w, "invalid authorizationId", http.StatusBadRequest)
+		return
+	}
+	_, _, _ = sourceID, destID, authID
+
+	// Optional pointer field — skipped if nil; if set, parsed.
+	if body.TagsetID != nil {
+		if _, err := uuid.Parse(*body.TagsetID); err != nil {
+			http.Error(w, "invalid tagsetId", http.StatusBadRequest)
+			return
+		}
+	}
+
+	resp := CopyDocumentResponse{
+		ID:         uuid.NewString(),
+		CreatedAt:  time.Now().Format(time.RFC3339),
+		OwnerEmail: "owner@example.com",
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/testdata/mux/expected_openapi.json
+++ b/testdata/mux/expected_openapi.json
@@ -61,7 +61,8 @@
                 "$ref": "#/components/schemas/mux.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -122,7 +123,8 @@
                 "$ref": "#/components/schemas/mux.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/mux/expected_openapi_legacy.json
+++ b/testdata/mux/expected_openapi_legacy.json
@@ -61,7 +61,8 @@
                 "$ref": "#/components/schemas/testdata_mux.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -122,7 +123,8 @@
                 "$ref": "#/components/schemas/testdata_mux.CreateUserRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/testdata/response_patterns/expected_openapi.json
+++ b/testdata/response_patterns/expected_openapi.json
@@ -100,7 +100,8 @@
                 "$ref": "#/components/schemas/response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -262,7 +263,8 @@
                 "$ref": "#/components/schemas/response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -299,7 +301,8 @@
                 "$ref": "#/components/schemas/response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -326,7 +329,8 @@
                 "$ref": "#/components/schemas/response_patterns.NewsletterSubscription"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -510,7 +514,8 @@
                 "$ref": "#/components/schemas/response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {

--- a/testdata/response_patterns/expected_openapi_legacy.json
+++ b/testdata/response_patterns/expected_openapi_legacy.json
@@ -100,7 +100,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -262,7 +263,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -299,7 +301,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -326,7 +329,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.NewsletterSubscription"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -510,7 +514,8 @@
                 "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {


### PR DESCRIPTION
## Summary

Two related gaps in JSON request/response inference reported against v0.4.8 (alkem-io/file-service-go).

**Limitation 1 — `format: uuid` not derived for JSON fields.** A struct field declared `string` with handler-side `uuid.Parse(body.X)` validation was emitted as plain `type: string`, leaving generated client SDKs to type every UUID as an opaque string.

**Limitation 2 — `requestBody.required` always omitted.** Handlers that decode via `json.Decode`/`c.Bind`/etc. are committed to receiving the body, but the spec advertised it as optional.

## Resolution

- **`requestBody.required: true`** auto-emitted whenever a request-body pattern fires (Decode/Bind/Unmarshal/BodyParser/etc.). Reflects what every decode-or-400 handler enforces.
- **Two layers for field schemas**, in priority order:
  - **`apispec:"format=uuid,type=string"` struct tag** — explicit, opt-in, generalises to `format=email`, `format=date-time`, `type=integer`. Strongest signal, wins over flow inference and Go-type-derived defaults.
  - **Flow inference** — when a decoded body's field appears as a converter argument anywhere in the same handler (including pointer-deref `uuid.Parse(*body.TagsetID)`), the converter's schema (e.g. `format: uuid`) is back-propagated to the matching property. Reuses the existing `paramConverters` map (single source of truth) so adding a new converter remains a one-liner.

The flow path is strictly additive: it never overwrites an existing `format` and only changes a `string` `type` when the converter disagrees — explicit struct-field types win.

## Test infrastructure

- New `testdata/json_dto/` fixture exercises every code path: 4 flow-inferred UUIDs (one via pointer deref), 2 tag-driven request fields (`apispec:"format=uuid"`, `apispec:"format=date-time"`), 3 tag-driven response fields, plus implicit `requestBody.required: true`.
- 17 new unit tests on the helpers (`parseAPISpecTag`, `applyAPISpecTag`, `selectorFieldOnTarget`, `lookupStructFields`, `applyJSONFieldConverterFormats`, `decodeTargetVarName`) — each at 100% function coverage.
- `TestE2E_JSONDto_FormatAndRequiredInference` locks the fixture's full contract.

## Pre-existing goldens

All decode-or-bind handlers now correctly include `"required": true` on their requestBody. Audited diffs for chi/gin/echo/fiber/mux/error_helpers/response_patterns: every change is the same single-field addition, no other movement. nested_http and form_value_var goldens unchanged.

## Test plan
- [x] `go test ./...` — full suite green
- [x] `make lint` — clean
- [x] Coverage: `internal/spec` 94.5% overall; new files 100% per function
- [x] Goldens diffed line-by-line before regen — no stray changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added struct tag `apispec` to explicitly override OpenAPI schema `type` and `format`
  * Implemented JSON field schema inference from parameter converters with back-propagation to decoded struct fields
  * Automatic `requestBody.required: true` emission for JSON binding/decoding operations

* **Documentation**
  * Updated README with new schema inference behaviors and struct tag support

* **Tests**
  * Added comprehensive test coverage for field inference, struct tag parsing, and OpenAPI generation

* **Chores**
  * Updated OpenAPI test fixtures to include request body required flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->