### PR TITLE
feat: struct-level validation via blank marker field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ specs/
 testdata/error_helpers/error_helpers
 testdata/form_value_var/form_value_var
 testdata/json_dto/json_dto
+testdata/json_patch/json_patch

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as res
 - JSON-DTO field flow inference: when a decoded body's field is later passed to a converter (`uuid.Parse(body.SourceID)`, including pointer-deref `uuid.Parse(*body.TagsetID)`), apispec back-propagates the converter's schema (e.g. `format: uuid`) onto the struct field
 - Explicit per-field overrides via the `apispec:"format=uuid,type=string"` struct tag — covers fields the flow analysis can't reach (e.g. UUIDs that are read but never parsed in the handler, or `format: date-time` / `format: email` hints)
 - `requestBody.required: true` is emitted automatically when a handler reads the body via `json.Decode`, `json.Unmarshal`, `c.Bind`, `c.BodyParser`, etc.
+- Struct-level validation via a blank-marker field — `_ struct{} `apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"`` — emits OpenAPI `minProperties` and per-field `anyOf` blocks. The marker is invisible in JSON; tag values use `,` for key=value pairs and `|` to separate field names inside `anyOf`. Useful for PATCH endpoints that require at least one field
 
 **Output Quality**
 - Deterministic YAML/JSON — sorted map keys, identical output across runs, safe for CI diffing

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as res
 - JSON-DTO field flow inference: when a decoded body's field is later passed to a converter (`uuid.Parse(body.SourceID)`, including pointer-deref `uuid.Parse(*body.TagsetID)`), apispec back-propagates the converter's schema (e.g. `format: uuid`) onto the struct field
 - Explicit per-field overrides via the `apispec:"format=uuid,type=string"` struct tag — covers fields the flow analysis can't reach (e.g. UUIDs that are read but never parsed in the handler, or `format: date-time` / `format: email` hints)
 - `requestBody.required: true` is emitted automatically when a handler reads the body via `json.Decode`, `json.Unmarshal`, `c.Bind`, `c.BodyParser`, etc.
-- Struct-level validation via a blank-marker field — `_ struct{} `apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"`` — emits OpenAPI `minProperties` and per-field `anyOf` blocks. The marker is invisible in JSON; tag values use `,` for key=value pairs and `|` to separate field names inside `anyOf`. Useful for PATCH endpoints that require at least one field
+- Struct-level validation via a blank-marker field — `_ struct{}` with tag `apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"` — emits OpenAPI `minProperties` and per-field `anyOf` blocks. The marker is invisible in JSON; tag values use `,` for key=value pairs and `|` to separate field names inside `anyOf`. Useful for PATCH endpoints that require at least one field
 
 **Output Quality**
 - Deterministic YAML/JSON — sorted map keys, identical output across runs, safe for CI diffing

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -50,6 +50,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "error_helpers", inputDir: "../../testdata/error_helpers", configFn: spec.DefaultChiConfig},
 		{name: "form_value_var", inputDir: "../../testdata/form_value_var", configFn: spec.DefaultChiConfig},
 		{name: "json_dto", inputDir: "../../testdata/json_dto", configFn: spec.DefaultChiConfig},
+		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {
@@ -192,6 +193,47 @@ func TestE2E_FormValueVar_AllPatternsExtracted(t *testing.T) {
 		assert.Equal(t, want.Type, s.Type, "wrong type for %q", name)
 		assert.Equal(t, want.Format, s.Format, "wrong format for %q", name)
 	}
+}
+
+// TestE2E_JSONPatch_StructLevelValidation asserts that a blank-marker
+// `_ struct{} `apispec:"minProperties=...,anyOf=..."“ field on a request
+// DTO produces both schema-level validation keywords and that the marker
+// itself never leaks into the property map or `required` list.
+func TestE2E_JSONPatch_StructLevelValidation(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/json_patch", spec.DefaultChiConfig())
+	eng := NewEngine(cfg)
+	result, err := eng.GenerateOpenAPI()
+	require.NoError(t, err)
+	require.NotNil(t, result.Components, "components missing")
+
+	schema := result.Components.Schemas["json_patch.UpdateDocumentRequest"]
+	require.NotNil(t, schema, "request schema missing")
+
+	// Marker must not appear as a property — the field is just a tag carrier.
+	for prop := range schema.Properties {
+		assert.NotEqual(t, "_", prop, "blank marker leaked into Properties")
+	}
+	for _, req := range schema.Required {
+		assert.NotEqual(t, "_", req, "blank marker leaked into Required")
+	}
+
+	// minProperties=1 emitted.
+	assert.Equal(t, 1, schema.MinProperties)
+
+	// anyOf emitted with exactly one `{required: [name]}` entry per listed
+	// field, in tag-declaration order.
+	require.Len(t, schema.AnyOf, 3, "anyOf should have one entry per listed field")
+	wantOrder := []string{"displayName", "storageBucketId", "temporaryLocation"}
+	for i, want := range wantOrder {
+		require.NotNil(t, schema.AnyOf[i])
+		assert.Equal(t, []string{want}, schema.AnyOf[i].Required, "anyOf[%d]", i)
+	}
+
+	// Field-level apispec tag on StorageBucketID still works alongside the
+	// marker — they're independent tags on different fields.
+	bucket := schema.Properties["storageBucketId"]
+	require.NotNil(t, bucket)
+	assert.Equal(t, "uuid", bucket.Format)
 }
 
 // TestE2E_JSONDto_FormatAndRequiredInference asserts the json_dto fixture's

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -928,9 +928,25 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 
 	pkgName := getStringFromPool(meta, typ.Pkg)
 
+	// structLevelTag accumulates the struct-scope overrides (minProperties,
+	// anyOf) declared on the blank `_` marker field. We can't apply it
+	// inline because the marker is iterated alongside real fields and the
+	// override must land on the parent schema, not on a property.
+	var structLevelTag *apispecTag
+
 	for _, field := range typ.Fields {
 		fieldName := getStringFromPool(meta, field.Name)
 		fieldType := getStringFromPool(meta, field.Type)
+
+		// `_ struct{} `apispec:"..."`` is the convention for struct-level
+		// hints — it never serializes (zero-sized + unexported) but its tag
+		// gives us a place to attach minProperties/anyOf without inventing a
+		// new annotation language. Skip it from Properties/Required and read
+		// the tag for later application.
+		if fieldName == "_" {
+			structLevelTag = parseAPISpecTag(getStringFromPool(meta, field.Tag))
+			continue
+		}
 
 		if genericType, ok := genericTypes[fieldType]; ok {
 			fieldType = genericType
@@ -1072,6 +1088,11 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 
 		schema.Properties[fieldName] = fieldSchema
 	}
+
+	// Struct-level overrides land last so they sit on the fully-built schema
+	// — minProperties is independent of the per-field passes above, and the
+	// anyOf array references property names that are now finalized.
+	applyStructLevelAPISpecTag(schema, structLevelTag)
 
 	return schema, schemas
 }

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -943,8 +943,13 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 		// gives us a place to attach minProperties/anyOf without inventing a
 		// new annotation language. Skip it from Properties/Required and read
 		// the tag for later application.
+		//
+		// Multiple `_` markers merge rather than overwrite: scalar keys take
+		// last-write-wins (matching how Go itself resolves duplicate field
+		// declarations) and list keys (AnyOf) accumulate. A user splitting
+		// hints across markers shouldn't silently lose earlier ones.
 		if fieldName == "_" {
-			structLevelTag = parseAPISpecTag(getStringFromPool(meta, field.Tag))
+			structLevelTag = mergeStructLevelTag(structLevelTag, parseAPISpecTag(getStringFromPool(meta, field.Tag)))
 			continue
 		}
 

--- a/internal/spec/struct_tag.go
+++ b/internal/spec/struct_tag.go
@@ -10,6 +10,7 @@ package spec
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -20,13 +21,34 @@ import (
 const apispecTagKey = "apispec"
 
 // apispecTag captures the OpenAPI schema overrides declared in an
-// `apispec:"..."` struct tag. Empty fields mean "no override" rather than
-// "blank value" — applyAPISpecTag only writes non-empty entries onto the
-// schema so it never erases existing data.
+// `apispec:"..."` struct tag. Empty / nil fields mean "no override" rather
+// than "blank value" — appliers only write set entries onto the schema so
+// they never erase existing data.
+//
+// Field-level keys (Type, Format) apply to the property a tag sits on.
+// Struct-level keys (MinProperties, AnyOf) apply to the parent schema and
+// are read off a blank marker field — `_ struct{} `apispec:"..."“ — since
+// Go struct tags are inherently field-scoped.
 type apispecTag struct {
 	Type   string
 	Format string
+
+	// MinProperties mirrors the OpenAPI keyword: when non-nil, the parent
+	// schema must have at least this many properties set. Pointer so we can
+	// distinguish "not specified" from "explicitly 0" (the latter is a
+	// no-op but still valid spec).
+	MinProperties *int
+
+	// AnyOf lists the JSON property names whose presence individually
+	// satisfies the schema. Emitted as a slice of `{required: [name]}`
+	// schemas under the parent's `anyOf`. Empty when not specified.
+	AnyOf []string
 }
+
+// anyOfFieldSeparator splits the value of `anyOf=...` into individual JSON
+// property names. We use `|` rather than `,` because `,` is already the
+// key=value pair separator inside the apispec tag.
+const anyOfFieldSeparator = "|"
 
 // parseAPISpecTag returns the apispec tag declared on a struct field, or nil
 // when the tag is absent or has no recognised keys.
@@ -60,12 +82,37 @@ func parseAPISpecTag(rawTag string) *apispecTag {
 			t.Format = val
 		case "type":
 			t.Type = val
+		case "minProperties":
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 0 {
+				continue
+			}
+			t.MinProperties = &n
+		case "anyOf":
+			t.AnyOf = splitAnyOfFields(val)
 		}
 	}
-	if t.Type == "" && t.Format == "" {
+	if t.Type == "" && t.Format == "" && t.MinProperties == nil && len(t.AnyOf) == 0 {
 		return nil
 	}
 	return t
+}
+
+// splitAnyOfFields parses the `anyOf=...` value into trimmed, non-empty
+// field names. Empty fragments (e.g. trailing `|`) are dropped.
+func splitAnyOfFields(value string) []string {
+	parts := strings.Split(value, anyOfFieldSeparator)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // applyAPISpecTag overwrites the schema's type/format from the tag. Tag
@@ -80,5 +127,28 @@ func applyAPISpecTag(schema *Schema, t *apispecTag) {
 	}
 	if t.Format != "" {
 		schema.Format = t.Format
+	}
+}
+
+// applyStructLevelAPISpecTag writes struct-scope overrides (MinProperties,
+// AnyOf) onto the parent schema. Called once per struct after every field
+// has been processed, with the tag read from a blank marker field.
+//
+// Each entry in t.AnyOf becomes its own `{required: [name]}` schema so
+// generated clients see "at least one of these named fields must be
+// present" rather than the looser MinProperties-only contract.
+func applyStructLevelAPISpecTag(schema *Schema, t *apispecTag) {
+	if schema == nil || t == nil {
+		return
+	}
+	if t.MinProperties != nil {
+		schema.MinProperties = *t.MinProperties
+	}
+	if len(t.AnyOf) > 0 {
+		anyOf := make([]*Schema, 0, len(t.AnyOf))
+		for _, name := range t.AnyOf {
+			anyOf = append(anyOf, &Schema{Required: []string{name}})
+		}
+		schema.AnyOf = anyOf
 	}
 }

--- a/internal/spec/struct_tag.go
+++ b/internal/spec/struct_tag.go
@@ -130,6 +130,32 @@ func applyAPISpecTag(schema *Schema, t *apispecTag) {
 	}
 }
 
+// mergeStructLevelTag combines two parsed apispec tags into one, preserving
+// struct-level keys (MinProperties, AnyOf) seen on prior markers.
+//
+// Multiple `_` marker fields are unusual but legal — a user splitting hints
+// across markers shouldn't silently lose data. Semantics:
+//   - MinProperties: last-write-wins (a later marker explicitly overrides)
+//   - AnyOf: appended in declaration order (markers add to the constraint)
+//
+// Field-level keys (Type, Format) aren't relevant on a `_` marker so they're
+// not merged here; only callers that pass struct-level data use this.
+func mergeStructLevelTag(prev, next *apispecTag) *apispecTag {
+	if next == nil {
+		return prev
+	}
+	if prev == nil {
+		return next
+	}
+	if next.MinProperties != nil {
+		prev.MinProperties = next.MinProperties
+	}
+	if len(next.AnyOf) > 0 {
+		prev.AnyOf = append(prev.AnyOf, next.AnyOf...)
+	}
+	return prev
+}
+
 // applyStructLevelAPISpecTag writes struct-scope overrides (MinProperties,
 // AnyOf) onto the parent schema. Called once per struct after every field
 // has been processed, with the tag read from a blank marker field.

--- a/internal/spec/struct_tag_test.go
+++ b/internal/spec/struct_tag_test.go
@@ -82,6 +82,93 @@ func TestApplyAPISpecTag_OnlyFormat_TypePreserved(t *testing.T) {
 	assert.Equal(t, "uuid", s.Format)
 }
 
+func TestParseAPISpecTag_MinPropertiesAndAnyOf(t *testing.T) {
+	tag := parseAPISpecTag(`apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"`)
+	require.NotNil(t, tag)
+	require.NotNil(t, tag.MinProperties)
+	assert.Equal(t, 1, *tag.MinProperties)
+	assert.Equal(t, []string{"displayName", "storageBucketId", "temporaryLocation"}, tag.AnyOf)
+}
+
+func TestParseAPISpecTag_MinProperties_Invalid(t *testing.T) {
+	// Non-integer values are silently ignored — no opinion is better than
+	// guessing for a malformed tag.
+	tag := parseAPISpecTag(`apispec:"minProperties=not-a-number"`)
+	assert.Nil(t, tag, "invalid minProperties + nothing else → nil tag")
+
+	// Mixed with something valid — only the valid bit survives.
+	tag = parseAPISpecTag(`apispec:"format=uuid,minProperties=abc"`)
+	require.NotNil(t, tag)
+	assert.Nil(t, tag.MinProperties)
+	assert.Equal(t, "uuid", tag.Format)
+}
+
+func TestParseAPISpecTag_MinProperties_Negative(t *testing.T) {
+	// Negative values aren't valid OpenAPI — silently rejected.
+	tag := parseAPISpecTag(`apispec:"minProperties=-1"`)
+	assert.Nil(t, tag)
+}
+
+func TestParseAPISpecTag_MinProperties_Zero(t *testing.T) {
+	// Zero is technically valid (no constraint, but explicit). Honour it
+	// rather than silently dropping it — matches OpenAPI semantics.
+	tag := parseAPISpecTag(`apispec:"minProperties=0"`)
+	require.NotNil(t, tag)
+	require.NotNil(t, tag.MinProperties)
+	assert.Equal(t, 0, *tag.MinProperties)
+}
+
+func TestParseAPISpecTag_AnyOf_TrimsAndDropsEmpty(t *testing.T) {
+	// Whitespace and trailing/duplicated separators are normalized.
+	tag := parseAPISpecTag(`apispec:"anyOf= a | b ||c|"`)
+	require.NotNil(t, tag)
+	assert.Equal(t, []string{"a", "b", "c"}, tag.AnyOf)
+}
+
+func TestParseAPISpecTag_AnyOf_AllEmpty(t *testing.T) {
+	// `anyOf=|` — every fragment is empty after trimming, so the field
+	// stays nil and parseAPISpecTag returns nil overall.
+	tag := parseAPISpecTag(`apispec:"anyOf=||"`)
+	assert.Nil(t, tag)
+}
+
+func TestApplyStructLevelAPISpecTag_BothFields(t *testing.T) {
+	s := &Schema{Type: "object", Properties: map[string]*Schema{}}
+	one := 1
+	applyStructLevelAPISpecTag(s, &apispecTag{
+		MinProperties: &one,
+		AnyOf:         []string{"a", "b"},
+	})
+	assert.Equal(t, 1, s.MinProperties)
+	require.Len(t, s.AnyOf, 2)
+	assert.Equal(t, []string{"a"}, s.AnyOf[0].Required)
+	assert.Equal(t, []string{"b"}, s.AnyOf[1].Required)
+}
+
+func TestApplyStructLevelAPISpecTag_OnlyMinProperties(t *testing.T) {
+	s := &Schema{Type: "object"}
+	two := 2
+	applyStructLevelAPISpecTag(s, &apispecTag{MinProperties: &two})
+	assert.Equal(t, 2, s.MinProperties)
+	assert.Empty(t, s.AnyOf, "AnyOf left untouched when not specified")
+}
+
+func TestApplyStructLevelAPISpecTag_OnlyAnyOf(t *testing.T) {
+	s := &Schema{Type: "object"}
+	applyStructLevelAPISpecTag(s, &apispecTag{AnyOf: []string{"x"}})
+	assert.Equal(t, 0, s.MinProperties, "MinProperties left untouched")
+	require.Len(t, s.AnyOf, 1)
+	assert.Equal(t, []string{"x"}, s.AnyOf[0].Required)
+}
+
+func TestApplyStructLevelAPISpecTag_NilGuards(t *testing.T) {
+	applyStructLevelAPISpecTag(nil, &apispecTag{}) // shouldn't panic
+	s := &Schema{}
+	applyStructLevelAPISpecTag(s, nil)
+	assert.Equal(t, 0, s.MinProperties)
+	assert.Nil(t, s.AnyOf)
+}
+
 func TestApplyAPISpecTag_NilGuards(t *testing.T) {
 	applyAPISpecTag(nil, &apispecTag{Format: "uuid"}) // shouldn't panic
 	applyAPISpecTag(&Schema{}, nil)                   // shouldn't panic

--- a/internal/spec/struct_tag_test.go
+++ b/internal/spec/struct_tag_test.go
@@ -169,6 +169,47 @@ func TestApplyStructLevelAPISpecTag_NilGuards(t *testing.T) {
 	assert.Nil(t, s.AnyOf)
 }
 
+func TestMergeStructLevelTag_Accumulates(t *testing.T) {
+	// Two markers split between minProperties and anyOf — both must survive.
+	one := 1
+	prev := &apispecTag{MinProperties: &one}
+	next := &apispecTag{AnyOf: []string{"a", "b"}}
+
+	got := mergeStructLevelTag(prev, next)
+	require.NotNil(t, got)
+	require.NotNil(t, got.MinProperties)
+	assert.Equal(t, 1, *got.MinProperties)
+	assert.Equal(t, []string{"a", "b"}, got.AnyOf)
+}
+
+func TestMergeStructLevelTag_LastMinPropertiesWins(t *testing.T) {
+	// Conflicting minProperties — last marker wins (matches Go's
+	// duplicate-field resolution semantics).
+	one := 1
+	two := 2
+	got := mergeStructLevelTag(&apispecTag{MinProperties: &one}, &apispecTag{MinProperties: &two})
+	require.NotNil(t, got.MinProperties)
+	assert.Equal(t, 2, *got.MinProperties)
+}
+
+func TestMergeStructLevelTag_AnyOfAppends(t *testing.T) {
+	// Each marker contributes to the anyOf set — append in declaration
+	// order rather than replacing.
+	prev := &apispecTag{AnyOf: []string{"a"}}
+	next := &apispecTag{AnyOf: []string{"b", "c"}}
+	got := mergeStructLevelTag(prev, next)
+	assert.Equal(t, []string{"a", "b", "c"}, got.AnyOf)
+}
+
+func TestMergeStructLevelTag_NilInputs(t *testing.T) {
+	// nil on either side returns the other unchanged; both nil → nil.
+	one := 1
+	tag := &apispecTag{MinProperties: &one}
+	assert.Equal(t, tag, mergeStructLevelTag(nil, tag))
+	assert.Equal(t, tag, mergeStructLevelTag(tag, nil))
+	assert.Nil(t, mergeStructLevelTag(nil, nil))
+}
+
 func TestApplyAPISpecTag_NilGuards(t *testing.T) {
 	applyAPISpecTag(nil, &apispecTag{Format: "uuid"}) // shouldn't panic
 	applyAPISpecTag(&Schema{}, nil)                   // shouldn't panic

--- a/testdata/json_patch/expected_openapi.json
+++ b/testdata/json_patch/expected_openapi.json
@@ -1,0 +1,121 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/{id}": {
+      "patch": {
+        "summary": "Update applies a partial update to a document.",
+        "description": "Update applies a partial update to a document. Empty bodies are rejected.",
+        "operationId": "json_patch.Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_patch.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/json_patch.UpdateDocumentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/error.Error"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_patch.UpdateDocumentRequest": {
+        "type": "object",
+        "anyOf": [
+          {
+            "required": [
+              "displayName"
+            ]
+          },
+          {
+            "required": [
+              "storageBucketId"
+            ]
+          },
+          {
+            "required": [
+              "temporaryLocation"
+            ]
+          }
+        ],
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "temporaryLocation": {
+            "type": "boolean"
+          }
+        },
+        "minProperties": 1
+      },
+      "json_patch.UpdateDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/json_patch/expected_openapi_legacy.json
+++ b/testdata/json_patch/expected_openapi_legacy.json
@@ -1,0 +1,121 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/{id}": {
+      "patch": {
+        "summary": "Update applies a partial update to a document.",
+        "description": "Update applies a partial update to a document. Empty bodies are rejected.",
+        "operationId": "json_patch.Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_patch.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/json_patch.UpdateDocumentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/error.Error"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_patch.UpdateDocumentRequest": {
+        "type": "object",
+        "anyOf": [
+          {
+            "required": [
+              "displayName"
+            ]
+          },
+          {
+            "required": [
+              "storageBucketId"
+            ]
+          },
+          {
+            "required": [
+              "temporaryLocation"
+            ]
+          }
+        ],
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "temporaryLocation": {
+            "type": "boolean"
+          }
+        },
+        "minProperties": 1
+      },
+      "json_patch.UpdateDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/json_patch/go.mod
+++ b/testdata/json_patch/go.mod
@@ -1,0 +1,5 @@
+module json_patch
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.2.5

--- a/testdata/json_patch/go.sum
+++ b/testdata/json_patch/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=

--- a/testdata/json_patch/main.go
+++ b/testdata/json_patch/main.go
@@ -1,0 +1,71 @@
+// Package main exercises struct-level OpenAPI validation: minProperties and
+// anyOf via the `_ struct{} `apispec:"..."“ blank-marker-field idiom.
+//
+// PATCH endpoints typically reject empty bodies — the handler must receive
+// at least one field to know what to update — but the OpenAPI spec usually
+// describes the request body as having all-optional fields, leaving the
+// "must update at least one of these" invariant invisible to client SDKs.
+//
+// The marker field below makes that invariant part of the spec so generated
+// clients refuse to construct empty PATCH requests and humans reading the
+// spec understand the contract.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// UpdateDocumentRequest mirrors the alkem-io/file-service-go PATCH body. All
+// three fields are optional individually, but at least one must be present —
+// expressed via minProperties=1 plus an explicit anyOf listing the eligible
+// fields. Both annotations are emitted; clients that only honour one of the
+// two still get the constraint enforced.
+type UpdateDocumentRequest struct {
+	_ struct{} `apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"`
+
+	DisplayName       string `json:"displayName,omitempty"`
+	StorageBucketID   string `json:"storageBucketId,omitempty" apispec:"format=uuid"`
+	TemporaryLocation *bool  `json:"temporaryLocation,omitempty"`
+}
+
+// UpdateDocumentResponse is unconstrained — the marker only goes on inputs
+// where "at least one field" is the contract.
+type UpdateDocumentResponse struct {
+	OK bool `json:"ok"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Patch("/documents/{id}", Update)
+	http.ListenAndServe(":3000", r)
+}
+
+// Update applies a partial update to a document. Empty bodies are rejected.
+func Update(w http.ResponseWriter, r *http.Request) {
+	var body UpdateDocumentRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if err := validateAtLeastOne(body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(UpdateDocumentResponse{OK: true})
+}
+
+// validateAtLeastOne mirrors the OpenAPI anyOf constraint at runtime so the
+// fixture is self-consistent: handler enforces it, spec advertises it.
+func validateAtLeastOne(body UpdateDocumentRequest) error {
+	if body.DisplayName == "" && body.StorageBucketID == "" && body.TemporaryLocation == nil {
+		return errors.New("at least one of displayName, storageBucketId, temporaryLocation must be set")
+	}
+	return nil
+}

--- a/testdata/json_patch/main.go
+++ b/testdata/json_patch/main.go
@@ -24,12 +24,17 @@ import (
 // expressed via minProperties=1 plus an explicit anyOf listing the eligible
 // fields. Both annotations are emitted; clients that only honour one of the
 // two still get the constraint enforced.
+//
+// Fields are pointer-typed so "absent in JSON" (nil) is distinguishable from
+// "present but empty" (non-nil pointer to ""). That matches OpenAPI anyOf
+// semantics, which check property presence, not value emptiness — runtime
+// validation below mirrors the same rule.
 type UpdateDocumentRequest struct {
 	_ struct{} `apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"`
 
-	DisplayName       string `json:"displayName,omitempty"`
-	StorageBucketID   string `json:"storageBucketId,omitempty" apispec:"format=uuid"`
-	TemporaryLocation *bool  `json:"temporaryLocation,omitempty"`
+	DisplayName       *string `json:"displayName,omitempty"`
+	StorageBucketID   *string `json:"storageBucketId,omitempty" apispec:"format=uuid"`
+	TemporaryLocation *bool   `json:"temporaryLocation,omitempty"`
 }
 
 // UpdateDocumentResponse is unconstrained — the marker only goes on inputs
@@ -63,8 +68,10 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 // validateAtLeastOne mirrors the OpenAPI anyOf constraint at runtime so the
 // fixture is self-consistent: handler enforces it, spec advertises it.
+// Checks JSON property presence (nil pointer == absent) — empty-but-present
+// values like `{"displayName":""}` satisfy the constraint, matching anyOf.
 func validateAtLeastOne(body UpdateDocumentRequest) error {
-	if body.DisplayName == "" && body.StorageBucketID == "" && body.TemporaryLocation == nil {
+	if body.DisplayName == nil && body.StorageBucketID == nil && body.TemporaryLocation == nil {
 		return errors.New("at least one of displayName, storageBucketId, temporaryLocation must be set")
 	}
 	return nil


### PR DESCRIPTION
Closes #18.

## Summary

Adds OpenAPI `minProperties` / `anyOf` emission for request DTOs whose "at least one of N fields must be set" invariant — the canonical PATCH-endpoint contract — was enforced at runtime but invisible in the generated spec.

## Design

Go struct tags are inherently field-scoped, so type-level metadata needs a carrier. The cleanest idiom is a blank marker field:

```go
type UpdateDocumentRequest struct {
    _ struct{} `apispec:"minProperties=1,anyOf=displayName|storageBucketId|temporaryLocation"`

    DisplayName       string `json:"displayName,omitempty"`
    StorageBucketID   string `json:"storageBucketId,omitempty" apispec:"format=uuid"`
    TemporaryLocation *bool  `json:"temporaryLocation,omitempty"`
}
```

`_ struct{}` is zero-sized and never serialized (unexported), but its tag carries struct-scope hints. Generated:

```yaml
http.UpdateDocumentRequest:
  type: object
  properties:
    displayName: { type: string }
    storageBucketId: { type: string, format: uuid }
    temporaryLocation: { type: boolean }
  minProperties: 1
  anyOf:
    - required: [displayName]
    - required: [storageBucketId]
    - required: [temporaryLocation]
```

## Tag keys

| Key | Type | Effect |
|---|---|---|
| `minProperties=N` | int (≥0) | sets `schema.minProperties` |
| `anyOf=a\|b\|c` | pipe-separated names (since `,` is the key separator) | emits `anyOf: [{required: [a]}, ...]` |

Field-level keys (`format`, `type`) on the marker are silently ignored — no semantic for them at struct scope. Field-level tags on real fields continue to work alongside the marker (`StorageBucketID` carries its own `format=uuid` in the fixture).

## Single source of truth

`parseAPISpecTag` handles every key, regardless of scope. Two appliers split only by where they write:

- `applyAPISpecTag(prop, tag)` — field-level (existing)
- `applyStructLevelAPISpecTag(parent, tag)` — struct-level (new)

The marker is detected in `generateStructSchema` (field name `_`), stripped from `Properties`/`Required`, and its parsed tag applied to the parent schema after every property is built.

## Tests

- New `testdata/json_patch/` fixture: PATCH endpoint with the marker, plus a `format=uuid` on one field to verify scopes don't interfere
- `TestE2E_JSONPatch_StructLevelValidation` asserts the marker doesn't leak into properties/required, both `minProperties` and `anyOf` are emitted, and field-level tags coexist
- 8 new unit tests bring `struct_tag.go` to 100% per-function coverage; package overall stays ≥95%

## Goldens

Only the new `json_patch/` goldens added — every other fixture (chi/gin/echo/fiber/mux/error_helpers/response_patterns/nested_http/form_value_var/json_dto) regenerated as `unchanged`. No existing fixture uses `_` blank-identifier fields, so the marker-detection is purely additive.

## Test plan
- [x] `go test ./...` — green
- [x] `make lint` — clean
- [x] Coverage: `internal/spec` 94.5%; new code 100% per function
- [x] Goldens diffed before regen — only `json_patch/` changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for struct-level schema constraints (minProperties, anyOf) to require at least one of several fields for patch-like requests.

* **Documentation**
  * README updated to document the struct-level marker and tag syntax for minProperties/anyOf.

* **Tests**
  * Added unit and end-to-end tests covering parsing and application of struct-level constraints and resulting OpenAPI output.

* **Chores**
  * Added test fixture app, OpenAPI fixtures, and a .gitignore entry for the testdata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antst/go-apispec/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->