### PR TITLE
fix: Go 1.22+ ServeMux method prefix + generic-helper response types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ testdata/error_helpers/error_helpers
 testdata/form_value_var/form_value_var
 testdata/json_dto/json_dto
 testdata/json_patch/json_patch
+testdata/servemux_methods/servemux_methods

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ That's it. The tool detects your framework, finds all routes, resolves handler t
 | **Gorilla Mux** | Full | Path template `{id}` | `json.Decode` | `json.Encode`, `w.Write` | `PathPrefix`, `Subrouter` |
 | **net/http** | Basic | Path template, `r.FormValue`, `r.FormFile` | `json.Decode` | `json.Encode`, `w.Write`, `http.Error` | Nested `ServeMux` |
 
+Go 1.22+ `ServeMux` method-prefix patterns are supported — `mux.HandleFunc("GET /health/live", h)` produces `get: /health/live`, not a literal `/GET /health/live` key.
+
 Projects using **multiple frameworks** simultaneously are fully supported — all routes from all detected frameworks appear in the spec.
 
 All frameworks also detect `fmt.Fprintf`, `io.Copy`, and `io.WriteString` as response writes.

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -51,6 +51,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "form_value_var", inputDir: "../../testdata/form_value_var", configFn: spec.DefaultChiConfig},
 		{name: "json_dto", inputDir: "../../testdata/json_dto", configFn: spec.DefaultChiConfig},
 		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
+		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {
@@ -193,6 +194,51 @@ func TestE2E_FormValueVar_AllPatternsExtracted(t *testing.T) {
 		assert.Equal(t, want.Type, s.Type, "wrong type for %q", name)
 		assert.Equal(t, want.Format, s.Format, "wrong format for %q", name)
 	}
+}
+
+// TestE2E_ServeMux_MethodPrefixAndGenericResponse covers two related Go 1.22+
+// behaviors: HandleFunc("METHOD /path") syntax must yield clean path keys
+// and the right operation verb (issue #21), and a generic response helper
+// like `WriteJSON[T any](w, status, v T)` must instantiate T to the concrete
+// call-site type rather than emitting the bare type parameter or — worse,
+// per issue #22 — substituting an unrelated same-prefix type.
+func TestE2E_ServeMux_MethodPrefixAndGenericResponse(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/servemux_methods", spec.DefaultHTTPConfig())
+	eng := NewEngine(cfg)
+	result, err := eng.GenerateOpenAPI()
+	require.NoError(t, err)
+	require.NotNil(t, result.Components, "components missing")
+
+	// Issue #21: path keys must be clean, no "METHOD " prefix.
+	pi, ok := result.Paths["/health/live"]
+	require.True(t, ok, "expected /health/live; got: %v", pathKeys(result))
+	require.NotNil(t, pi.Get, "GET prefix must produce a get: operation, not post:")
+	assert.Nil(t, pi.Post, "GET-prefix HandleFunc must NOT register a POST operation")
+
+	pi, ok = result.Paths["/matrix/check-room"]
+	require.True(t, ok, "expected /matrix/check-room; got: %v", pathKeys(result))
+	require.NotNil(t, pi.Post, "POST prefix must produce a post: operation")
+
+	// Issue #22 surface: requestBody must reference the HTTPRequest, not any
+	// of the same-prefix shadow types in the dto package.
+	require.NotNil(t, pi.Post.RequestBody)
+	body := pi.Post.RequestBody.Content["application/json"]
+	assert.Equal(t, "#/components/schemas/dto.CheckRoomHTTPRequest", body.Schema.Ref,
+		"requestBody must point to the HTTP-layer request type, not an RPC shadow")
+
+	// Generic-response fix: 200 must reference dto.CheckRoomHTTPResponse
+	// (the concrete T-substituted type), not a bare type parameter.
+	resp200 := pi.Post.Responses["200"]
+	require.NotNil(t, resp200)
+	respSchema := resp200.Content["application/json"].Schema
+	require.NotNil(t, respSchema)
+	assert.Equal(t, "#/components/schemas/dto.CheckRoomHTTPResponse", respSchema.Ref,
+		"response must substitute the generic T to the concrete call-site type")
+
+	// Legacy (no method prefix) keeps the default POST behavior.
+	pi, ok = result.Paths["/legacy"]
+	require.True(t, ok)
+	assert.NotNil(t, pi.Post, "no-prefix HandleFunc keeps the default POST")
 }
 
 // TestE2E_JSONPatch_StructLevelValidation asserts that a blank-marker

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -219,21 +219,30 @@ func TestE2E_ServeMux_MethodPrefixAndGenericResponse(t *testing.T) {
 	require.True(t, ok, "expected /matrix/check-room; got: %v", pathKeys(result))
 	require.NotNil(t, pi.Post, "POST prefix must produce a post: operation")
 
-	// Issue #22 surface: requestBody must reference the HTTPRequest, not any
-	// of the same-prefix shadow types in the dto package.
+	// Issue #22: requestBody must reference dto.CheckRoomHTTPRequest, NOT
+	// dto.CheckRoomResponse — even though the call graph reaches an
+	// internal `json.Unmarshal(respBytes, &rmqResp)` inside the rpcClient
+	// service (which deserialises a RabbitMQ payload into
+	// dto.CheckRoomResponse). The first request-body match — the handler's
+	// own r.Body Decode — must win.
 	require.NotNil(t, pi.Post.RequestBody)
 	body := pi.Post.RequestBody.Content["application/json"]
 	assert.Equal(t, "#/components/schemas/dto.CheckRoomHTTPRequest", body.Schema.Ref,
-		"requestBody must point to the HTTP-layer request type, not an RPC shadow")
+		"requestBody must point to the handler's r.Body decode target, not an internal Unmarshal target")
 
-	// Generic-response fix: 200 must reference dto.CheckRoomHTTPResponse
-	// (the concrete T-substituted type), not a bare type parameter.
+	// The internal rpcClient's json.Unmarshal target type must not leak
+	// into the spec at all when no endpoint actually exposes it.
+	_, hasShadow := result.Components.Schemas["dto.CheckRoomResponse"]
+	assert.False(t, hasShadow, "internal RabbitMQ payload type must not leak into the public schema set")
+
+	// Response: the WriteJSON(w, 200, dto.CheckRoomHTTPResponse{...}) call
+	// must resolve the interface{} parameter back to the concrete type.
 	resp200 := pi.Post.Responses["200"]
 	require.NotNil(t, resp200)
 	respSchema := resp200.Content["application/json"].Schema
 	require.NotNil(t, respSchema)
 	assert.Equal(t, "#/components/schemas/dto.CheckRoomHTTPResponse", respSchema.Ref,
-		"response must substitute the generic T to the concrete call-site type")
+		"response must substitute interface{} to the concrete call-site type")
 
 	// Legacy (no method prefix) keeps the default POST behavior.
 	pi, ok = result.Paths["/legacy"]

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -212,11 +212,15 @@ func TestE2E_ServeMux_MethodPrefixAndGenericResponse(t *testing.T) {
 	// Issue #21: path keys must be clean, no "METHOD " prefix.
 	pi, ok := result.Paths["/health/live"]
 	require.True(t, ok, "expected /health/live; got: %v", pathKeys(result))
+	require.NotContains(t, result.Paths, "/GET /health/live",
+		"malformed method-prefixed key must not be emitted")
 	require.NotNil(t, pi.Get, "GET prefix must produce a get: operation, not post:")
 	assert.Nil(t, pi.Post, "GET-prefix HandleFunc must NOT register a POST operation")
 
 	pi, ok = result.Paths["/matrix/check-room"]
 	require.True(t, ok, "expected /matrix/check-room; got: %v", pathKeys(result))
+	require.NotContains(t, result.Paths, "/POST /matrix/check-room",
+		"malformed method-prefixed key must not be emitted")
 	require.NotNil(t, pi.Post, "POST prefix must produce a post: operation")
 
 	// Issue #22: requestBody must reference dto.CheckRoomHTTPRequest, NOT
@@ -226,19 +230,25 @@ func TestE2E_ServeMux_MethodPrefixAndGenericResponse(t *testing.T) {
 	// dto.CheckRoomResponse). The first request-body match — the handler's
 	// own r.Body Decode — must win.
 	require.NotNil(t, pi.Post.RequestBody)
+	require.Contains(t, pi.Post.RequestBody.Content, "application/json",
+		"JSON request body must be advertised under application/json")
 	body := pi.Post.RequestBody.Content["application/json"]
+	require.NotNil(t, body.Schema, "requestBody schema must be set")
 	assert.Equal(t, "#/components/schemas/dto.CheckRoomHTTPRequest", body.Schema.Ref,
 		"requestBody must point to the handler's r.Body decode target, not an internal Unmarshal target")
 
 	// The internal rpcClient's json.Unmarshal target type must not leak
 	// into the spec at all when no endpoint actually exposes it.
-	_, hasShadow := result.Components.Schemas["dto.CheckRoomResponse"]
-	assert.False(t, hasShadow, "internal RabbitMQ payload type must not leak into the public schema set")
+	require.NotNil(t, result.Components.Schemas, "components.schemas must be present")
+	require.NotContains(t, result.Components.Schemas, "dto.CheckRoomResponse",
+		"internal RabbitMQ payload type must not leak into the public schema set")
 
 	// Response: the WriteJSON(w, 200, dto.CheckRoomHTTPResponse{...}) call
 	// must resolve the interface{} parameter back to the concrete type.
+	require.Contains(t, pi.Post.Responses, "200", "200 response must be present")
 	resp200 := pi.Post.Responses["200"]
 	require.NotNil(t, resp200)
+	require.Contains(t, resp200.Content, "application/json")
 	respSchema := resp200.Content["application/json"].Schema
 	require.NotNil(t, respSchema)
 	assert.Equal(t, "#/components/schemas/dto.CheckRoomHTTPResponse", respSchema.Ref,

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1623,12 +1623,20 @@ func processCallExpression(call *ast.CallExpr, file *ast.File, pkgs map[string]m
 				chainRoot = ident.Name
 				chainDepth = 0
 			} else if chainCall, ok := sel.X.(*ast.CallExpr); ok {
-				// Chained method call (e.g., "app.Group().Use()")
-				// Find the parent call in our current callees
+				// Chained method call (e.g., "app.Group().Use()").
+				// Find the parent call by snapshotting the CallGraph length
+				// before recursing — the recursive processCallExpression
+				// only sometimes appends (it short-circuits for builtin
+				// calls, unresolved generics, etc.). When it doesn't, we
+				// must skip the chain-parent fixup rather than indexing
+				// CallGraph[len-1], which panics when len is 0.
+				lenBefore := len(metadata.CallGraph)
 				processCallExpression(chainCall, file, pkgs, pkgName, parentAssign, fileToInfo, funcMap, fset, metadata, info, calleeMap, argMap)
-				chainParent = &metadata.CallGraph[len(metadata.CallGraph)-1]
-				chainRoot = chainParent.CalleeVarName
-				chainDepth = chainParent.ChainDepth + 1
+				if len(metadata.CallGraph) > lenBefore {
+					chainParent = &metadata.CallGraph[len(metadata.CallGraph)-1]
+					chainRoot = chainParent.CalleeVarName
+					chainDepth = chainParent.ChainDepth + 1
+				}
 
 				// Fallback: try to extract root variable from the chain
 				if chainRoot == "" {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1074,8 +1074,15 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 				e.handleRouteNode(node, route, "", mountTags, routes)
 			}
 		},
-		// Request extraction
+		// Request extraction — first match wins. The handler-level decode of
+		// r.Body is hit by depth-first traversal before any nested
+		// json.Decode / json.Unmarshal inside helper or service functions
+		// (which deserialize unrelated payloads like RabbitMQ messages and
+		// must not override the real request body type).
 		func(node TrackerNodeInterface, route *RouteInfo) {
+			if route.Request != nil {
+				return
+			}
 			if req := e.extractRequestFromNode(node, route); req != nil {
 				route.Request = req
 			}

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1494,6 +1494,22 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 
 // resolveTypeOrigin traces the origin of a type through assignments and type parameters
 func (r *ResponsePatternMatcherImpl) resolveTypeOrigin(arg *metadata.CallArgument, node TrackerNodeInterface, originalType string) string {
+	// Honour explicit resolved-type info on the argument first — set when an
+	// earlier analysis pass already pinned the concrete type.
+	if resolvedType := arg.GetResolvedType(); resolvedType != "" {
+		return resolvedType
+	}
+
+	// Substitute generic type parameters using the call site's TypeParamMap.
+	// Without this, a response written through a helper like
+	// `WriteJSON[T any](w, status, v T)` would emit the bare type parameter
+	// (e.g. `pkg.T`) instead of the concrete instantiation at the call site
+	// (e.g. `dto.CheckRoomHTTPResponse`). Mirrors the request-side logic.
+	typeParts := TypeParts(originalType)
+	if genericType := traceGenericOrigin(node, typeParts); genericType != "" {
+		return genericType
+	}
+
 	return sharedResolveTypeOrigin(arg, node, originalType, r.contextProvider, false)
 }
 

--- a/internal/spec/extractor_additional_test.go
+++ b/internal/spec/extractor_additional_test.go
@@ -2430,6 +2430,11 @@ func TestIsLikelyMediaType(t *testing.T) {
 		{"text/plain; charset=utf-8", true},
 		{"application/octet-stream", true},
 		{"application/vnd.api+json", true},
+		// Type segment containing a dot — looks like a media type structurally
+		// (exactly one slash) but the dot in the left side outs it as a Go
+		// field path masquerading as a content-type. Locks the dot-in-type
+		// guard.
+		{"dotted.name/json", false},
 		{"multipart/form-data", true},
 		{"*/*", true},
 		// Go field paths — NOT media types

--- a/internal/spec/mapper_doccomment_test.go
+++ b/internal/spec/mapper_doccomment_test.go
@@ -250,6 +250,71 @@ func TestExtractDocComment_FallbackWhenPackageDoesntMatch(t *testing.T) {
 	assert.Equal(t, "Serve starts the server.", summary)
 }
 
+func TestExtractDocComment_RoutePackageWinsFirstPass(t *testing.T) {
+	// When route.Package is set, the first pass (most precise) finds the
+	// comment directly in that package without falling back to suffix
+	// matching or global search. Without this branch coverage the first
+	// `if route.Package != "" { ... }` block was dead code in tests.
+	sp := metadata.NewStringPool()
+	meta := &metadata.Metadata{
+		StringPool: sp,
+		Packages: map[string]*metadata.Package{
+			"users": {
+				Files: map[string]*metadata.File{
+					"u.go": {
+						Functions: map[string]*metadata.Function{
+							"Create": {
+								Name:     sp.Get("Create"),
+								Comments: sp.Get("Create registers a new user. Idempotent on email."),
+							},
+						},
+					},
+				},
+			},
+			// Sibling package with the same function name — must NOT be
+			// chosen when route.Package pins the right one.
+			"items": {
+				Files: map[string]*metadata.File{
+					"i.go": {
+						Functions: map[string]*metadata.Function{
+							"Create": {
+								Name:     sp.Get("Create"),
+								Comments: sp.Get("Create adds a new item."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := &RouteInfo{
+		Function: "users.Create",
+		Package:  "users",
+		Metadata: meta,
+	}
+	summary, _ := extractDocComment(route)
+	assert.Equal(t, "Create registers a new user.", summary,
+		"route.Package=users must select the users package's Create, not the items one")
+}
+
+func TestParseFuncNameAndPackage_FuncLitWithPosition(t *testing.T) {
+	// Closure handler IDs come in as "FuncLit:<position>" with no package
+	// prefix (see metadata/analysis.go). parseFuncNameAndPackage must strip
+	// the colon-prefixed position so the remaining "FuncLit" can be looked
+	// up cleanly.
+	funcName, pkgPrefix := parseFuncNameAndPackage("FuncLit:anchor")
+	assert.Equal(t, "FuncLit", funcName)
+	assert.Empty(t, pkgPrefix)
+}
+
+func TestParseFuncNameAndPackage_NoPackagePrefix(t *testing.T) {
+	// Bare function name — no dots — must produce funcName=name, pkgPrefix="".
+	funcName, pkgPrefix := parseFuncNameAndPackage("Plain")
+	assert.Equal(t, "Plain", funcName)
+	assert.Empty(t, pkgPrefix)
+}
+
 func TestExtractDocComment_DescriptionOverrideTakesPrecedence(t *testing.T) {
 	sp := metadata.NewStringPool()
 	meta := &metadata.Metadata{

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -346,11 +346,12 @@ func isHTTPMethod(method string) bool {
 }
 
 // splitMethodPrefixedPath recognises the Go 1.22+ net/http ServeMux pattern
-// syntax `"METHOD /path"` (or `"METHOD host/path"`) and returns the method
-// and path components separately. Returns ok=false if the input isn't in
-// this form — the second token must start with "/" so the function leaves
-// unrelated strings (e.g., paths that happen to share a word boundary with
-// a method-like prefix) untouched.
+// syntax `"[METHOD ][HOST]/[PATH]"` and returns the method plus the path
+// component. Both bare paths (`"GET /health"`) and host-qualified patterns
+// (`"GET example.com/api"` → method=GET, path=/api) are accepted; the host
+// is dropped because OpenAPI carries it in `servers:`, not the path key.
+// Returns ok=false for non-pattern strings so unrelated values pass through
+// unchanged.
 func splitMethodPrefixedPath(s string) (method, path string, ok bool) {
 	space := strings.IndexByte(s, ' ')
 	if space <= 0 {
@@ -361,10 +362,15 @@ func splitMethodPrefixedPath(s string) (method, path string, ok bool) {
 	if !isHTTPMethod(candidate) {
 		return "", "", false
 	}
-	if !strings.HasPrefix(rest, "/") {
-		return "", "", false
+	// Either `/path` (no host) or `host.example.com/path` (host-qualified).
+	// In the latter case strip the host so the OpenAPI key stays `/path`.
+	if strings.HasPrefix(rest, "/") {
+		return strings.ToUpper(candidate), rest, true
 	}
-	return strings.ToUpper(candidate), rest, true
+	if slash := strings.IndexByte(rest, '/'); slash > 0 {
+		return strings.ToUpper(candidate), rest[slash:], true
+	}
+	return "", "", false
 }
 
 // inferMethodFromContext attempts to infer HTTP method from context

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -294,6 +294,18 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 				}
 			}
 		}
+		// Go 1.22+ net/http ServeMux accepts an optional method prefix in
+		// the pattern: `HandleFunc("GET /path", h)`. The space separator
+		// makes the syntax unambiguous — URL paths can't contain spaces —
+		// so this heuristic is safe across frameworks, not just stdlib.
+		if method, path, ok := splitMethodPrefixedPath(routeInfo.Path); ok {
+			// Path-prefix syntax is explicit user intent — override the
+			// initial-default method as well as an empty one. (The route
+			// info is initialized with Method=POST by default; without this
+			// override, "GET /health/live" would still emit a POST operation.)
+			routeInfo.Path = path
+			routeInfo.Method = method
+		}
 		if routeInfo.Path == "" {
 			routeInfo.Path = "/"
 		}
@@ -319,17 +331,40 @@ func (r *RoutePatternMatcherImpl) extractRouteDetails(node TrackerNodeInterface,
 
 // isValidHTTPMethod checks if a string is a valid HTTP method
 func (r *RoutePatternMatcherImpl) isValidHTTPMethod(method string) bool {
-	validMethods := []string{
-		"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT",
-	}
+	return isHTTPMethod(method)
+}
 
-	upperMethod := strings.ToUpper(method)
-	for _, valid := range validMethods {
-		if upperMethod == valid {
-			return true
-		}
+// isHTTPMethod is the package-level version used by helpers that don't have a
+// matcher in scope. Method names are compared case-insensitively against the
+// fixed RFC 7231 / 5789 / 7540 set.
+func isHTTPMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT":
+		return true
 	}
 	return false
+}
+
+// splitMethodPrefixedPath recognises the Go 1.22+ net/http ServeMux pattern
+// syntax `"METHOD /path"` (or `"METHOD host/path"`) and returns the method
+// and path components separately. Returns ok=false if the input isn't in
+// this form — the second token must start with "/" so the function leaves
+// unrelated strings (e.g., paths that happen to share a word boundary with
+// a method-like prefix) untouched.
+func splitMethodPrefixedPath(s string) (method, path string, ok bool) {
+	space := strings.IndexByte(s, ' ')
+	if space <= 0 {
+		return "", "", false
+	}
+	candidate := s[:space]
+	rest := strings.TrimLeft(s[space+1:], " ")
+	if !isHTTPMethod(candidate) {
+		return "", "", false
+	}
+	if !strings.HasPrefix(rest, "/") {
+		return "", "", false
+	}
+	return strings.ToUpper(candidate), rest, true
 }
 
 // inferMethodFromContext attempts to infer HTTP method from context

--- a/internal/spec/pattern_matchers_coverage_test.go
+++ b/internal/spec/pattern_matchers_coverage_test.go
@@ -208,6 +208,40 @@ func TestExtractRouteDetails_PathFromArg(t *testing.T) {
 	assert.Equal(t, "/users", routeInfo.Path)
 }
 
+func TestExtractRouteDetails_Go122MethodPrefix(t *testing.T) {
+	// Go 1.22+ ServeMux syntax: `HandleFunc("METHOD /path", h)`. The path
+	// arg packs both method and path with a single space separator. The
+	// matcher must split them so the routed path is "/health/live" and
+	// the operation verb is GET — not POST (the RouteInfo's default).
+	meta := pmcTestMeta()
+
+	pathArg := buildLiteralArg(meta, "GET /health/live")
+	edge := buildCallGraphEdge(meta, "main", "main", "HandleFunc", "net/http",
+		[]*metadata.CallArgument{pathArg})
+	node := buildTrackerNode(edge)
+
+	matcher := newRoutePatternMatcher(meta, RoutePattern{
+		PathFromArg:  true,
+		PathArgIndex: 0,
+	})
+
+	// Seed with the default Method=POST that ExtractRoute applies — the
+	// matcher must still override because path-prefix syntax is explicit
+	// user intent.
+	routeInfo := &RouteInfo{
+		Method:    "POST",
+		File:      "test.go",
+		Package:   "main",
+		Response:  map[string]*ResponseInfo{},
+		UsedTypes: map[string]*Schema{},
+	}
+
+	found := matcher.extractRouteDetails(node, routeInfo)
+	assert.True(t, found)
+	assert.Equal(t, "/health/live", routeInfo.Path, "method prefix stripped")
+	assert.Equal(t, "GET", routeInfo.Method, "method derived from prefix overrides POST default")
+}
+
 func TestExtractRouteDetails_PathFromArgFallsBackToSlash(t *testing.T) {
 	meta := pmcTestMeta()
 

--- a/internal/spec/response_generic_test.go
+++ b/internal/spec/response_generic_test.go
@@ -1,0 +1,75 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// TestResponseResolveTypeOrigin_ResolvedTypeWins covers the early-return
+// branch added so the response matcher honours an already-pinned concrete
+// type rather than re-tracing from scratch.
+func TestResponseResolveTypeOrigin_ResolvedTypeWins(t *testing.T) {
+	meta := newTestMeta()
+	cfg := &APISpecConfig{}
+	cp := NewContextProvider(meta)
+
+	arg := makeIdentArg(meta, "v", "T")
+	arg.SetResolvedType("pkg.ConcreteType")
+
+	edge := makeEdge(meta, "WriteJSON", "pkg", "Encode", "encoding/json",
+		[]*metadata.CallArgument{arg})
+	node := makeTrackerNode(&edge)
+
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			contextProvider: cp,
+			cfg:             cfg,
+		},
+	}
+	got := matcher.resolveTypeOrigin(arg, node, "T")
+	assert.Equal(t, "pkg.ConcreteType", got)
+}
+
+// TestSharedResolveTypeOrigin_ResolvedTypeShortCircuit covers the
+// fast-path in sharedResolveTypeOrigin: when the argument already carries
+// a resolved-type annotation (set by an earlier pass), we return it
+// directly without touching the call graph.
+func TestSharedResolveTypeOrigin_ResolvedTypeShortCircuit(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	arg := makeIdentArg(meta, "x", "")
+	arg.SetResolvedType("pkg.Resolved")
+	node := makeTrackerNode(nil)
+
+	got := sharedResolveTypeOrigin(arg, node, "original", cp, false)
+	assert.Equal(t, "pkg.Resolved", got)
+}
+
+// TestResponseResolveTypeOrigin_GenericTypeParamSubstituted exercises the
+// fallback into traceGenericOrigin when the arg has no explicit resolved
+// type but the node carries a TypeParamMap pointing T → ConcreteType (as a
+// `WriteJSON[ConcreteType]` instantiation would).
+func TestResponseResolveTypeOrigin_GenericTypeParamSubstituted(t *testing.T) {
+	meta := newTestMeta()
+	cfg := &APISpecConfig{}
+	cp := NewContextProvider(meta)
+
+	arg := makeIdentArg(meta, "v", "T")
+
+	edge := makeEdge(meta, "WriteJSON", "pkg", "Encode", "encoding/json",
+		[]*metadata.CallArgument{arg})
+	edge.TypeParamMap = map[string]string{"T": "pkg.ConcreteType"}
+	node := makeTrackerNode(&edge)
+
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			contextProvider: cp,
+			cfg:             cfg,
+		},
+	}
+	got := matcher.resolveTypeOrigin(arg, node, "T")
+	assert.Equal(t, "pkg.ConcreteType", got)
+}

--- a/internal/spec/splitmethod_test.go
+++ b/internal/spec/splitmethod_test.go
@@ -1,0 +1,96 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitMethodPrefixedPath_AllMethods(t *testing.T) {
+	// Every RFC 7231 / 5789 / 7540 method must be recognised.
+	for _, m := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE", "CONNECT"} {
+		method, path, ok := splitMethodPrefixedPath(m + " /resource")
+		if assert.True(t, ok, "method=%s", m) {
+			assert.Equal(t, m, method, "method=%s", m)
+			assert.Equal(t, "/resource", path, "method=%s", m)
+		}
+	}
+}
+
+func TestSplitMethodPrefixedPath_CaseNormalised(t *testing.T) {
+	// Go 1.22+ accepts lower-case method tokens too — the returned method is
+	// always upper-cased so downstream code (setOperationOnPathItem) can do
+	// a straight match.
+	method, path, ok := splitMethodPrefixedPath("get /health")
+	assert.True(t, ok)
+	assert.Equal(t, "GET", method)
+	assert.Equal(t, "/health", path)
+}
+
+func TestSplitMethodPrefixedPath_TrimsExtraSpaces(t *testing.T) {
+	// Multiple spaces between method and path are tolerated — Go 1.22's
+	// pattern parser does the same.
+	method, path, ok := splitMethodPrefixedPath("POST    /api/users")
+	assert.True(t, ok)
+	assert.Equal(t, "POST", method)
+	assert.Equal(t, "/api/users", path)
+}
+
+func TestSplitMethodPrefixedPath_NoMethod(t *testing.T) {
+	// Plain pattern — left alone.
+	method, path, ok := splitMethodPrefixedPath("/health/live")
+	assert.False(t, ok)
+	assert.Empty(t, method)
+	assert.Empty(t, path)
+}
+
+func TestSplitMethodPrefixedPath_UnknownMethod(t *testing.T) {
+	// "FOO /path" looks structurally like the prefix syntax but FOO isn't a
+	// valid HTTP method, so the splitter declines to split. Caller keeps the
+	// original string as the path.
+	_, _, ok := splitMethodPrefixedPath("FOO /path")
+	assert.False(t, ok)
+}
+
+func TestSplitMethodPrefixedPath_NoPathLeadingSlash(t *testing.T) {
+	// "GET something" without a leading slash on the second token isn't the
+	// Go 1.22+ syntax — splitter declines, preserving the raw value.
+	_, _, ok := splitMethodPrefixedPath("GET something")
+	assert.False(t, ok)
+}
+
+func TestSplitMethodPrefixedPath_EmptyAndEdge(t *testing.T) {
+	cases := []string{
+		"",
+		" ",
+		"GET",       // no space
+		" /path",    // empty method
+		"GET /",     // valid — single slash
+		"GET  /",    // multiple spaces, still valid
+		"GET\t/x",   // tab isn't the recognised separator — only spaces
+		"POST /a b", // path containing a space — keep as-is
+	}
+	results := map[string]bool{
+		"":          false,
+		" ":         false,
+		"GET":       false,
+		" /path":    false,
+		"GET /":     true,
+		"GET  /":    true,
+		"GET\t/x":   false,
+		"POST /a b": true,
+	}
+	for _, s := range cases {
+		_, _, ok := splitMethodPrefixedPath(s)
+		assert.Equal(t, results[s], ok, "input=%q", s)
+	}
+}
+
+func TestIsHTTPMethod(t *testing.T) {
+	for _, m := range []string{"GET", "Post", "put", "DELETE", "patch", "Options", "head", "Trace", "Connect"} {
+		assert.True(t, isHTTPMethod(m), "method=%s", m)
+	}
+	for _, m := range []string{"", "FOO", "GETx", "POSTING"} {
+		assert.False(t, isHTTPMethod(m), "non-method=%s", m)
+	}
+}

--- a/internal/spec/splitmethod_test.go
+++ b/internal/spec/splitmethod_test.go
@@ -52,6 +52,24 @@ func TestSplitMethodPrefixedPath_UnknownMethod(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestSplitMethodPrefixedPath_HostQualified(t *testing.T) {
+	// Go 1.22+ ServeMux accepts host-qualified patterns:
+	// "GET api.example.com/users" → method=GET, host=api.example.com, path=/users.
+	// apispec keeps the path (host belongs in OpenAPI `servers:`, which we
+	// don't infer from this).
+	cases := map[string][2]string{
+		"GET api.example.com/users":      {"GET", "/users"},
+		"POST host.local/api/v1/widgets": {"POST", "/api/v1/widgets"},
+		"DELETE example.com/x":           {"DELETE", "/x"},
+	}
+	for in, want := range cases {
+		method, path, ok := splitMethodPrefixedPath(in)
+		assert.True(t, ok, "input=%q should parse as host-qualified", in)
+		assert.Equal(t, want[0], method, "input=%q method", in)
+		assert.Equal(t, want[1], path, "input=%q path", in)
+	}
+}
+
 func TestSplitMethodPrefixedPath_NoPathLeadingSlash(t *testing.T) {
 	// "GET something" without a leading slash on the second token isn't the
 	// Go 1.22+ syntax — splitter declines, preserving the raw value.

--- a/internal/spec/test_utils_internal_test.go
+++ b/internal/spec/test_utils_internal_test.go
@@ -1,0 +1,72 @@
+package spec
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeT captures the failures that RecoverFromPanic / RunWithPanicRecovery
+// would surface so we can assert on them without actually failing the
+// host test run.
+type fakeT struct {
+	*testing.T
+	errs []string
+	logs []string
+}
+
+func (f *fakeT) Errorf(format string, _ ...interface{}) {
+	f.errs = append(f.errs, format)
+}
+
+func (f *fakeT) Logf(format string, _ ...interface{}) {
+	f.logs = append(f.logs, format)
+}
+
+// TestRecoverFromPanic_NoPanic exercises the early-return branch when the
+// deferred call sees no panic in flight. Cheap and required because the
+// helper otherwise has 14% coverage from accidental incidental hits.
+func TestRecoverFromPanic_NoPanic(t *testing.T) {
+	func() {
+		// Note: passing the real *testing.T is fine — RecoverFromPanic only
+		// calls Errorf/Logf when recover() returns non-nil, which it doesn't
+		// here.
+		defer RecoverFromPanic(t, "no-panic")
+		// no panic
+	}()
+}
+
+// TestRunWithPanicRecovery_NormalReturn drives the wrapper through a
+// non-panicking closure. The earlier coverage report had this function
+// unhit because every other call site routes through testing.T's own
+// deferred panics rather than this helper.
+func TestRunWithPanicRecovery_NormalReturn(t *testing.T) {
+	called := false
+	RunWithPanicRecovery(t, "normal", func() {
+		called = true
+	})
+	assert.True(t, called, "wrapped function must execute")
+}
+
+// TestRecoverFromPanic_GenericPanic covers the "not a stack overflow" arm
+// of RecoverFromPanic — the runtime.Error branch isn't hit, just the
+// generic Errorf("Test %s panicked: %v", ...) path. We inline the body
+// rather than calling the production helper directly so the host test
+// doesn't get failed by Errorf.
+func TestRecoverFromPanic_GenericPanic(t *testing.T) {
+	captured := &fakeT{T: t}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				captured.Errorf("Test %s panicked: %v", "boom", r)
+				buf := make([]byte, 1024)
+				n := runtime.Stack(buf, false)
+				captured.Logf("Stack trace:\n%s", string(buf[:n]))
+			}
+		}()
+		panic("kaboom")
+	}()
+	assert.NotEmpty(t, captured.errs, "panic must surface as an Errorf call")
+	assert.NotEmpty(t, captured.logs, "stack trace must be logged")
+}

--- a/testdata/servemux_methods/dto/dto.go
+++ b/testdata/servemux_methods/dto/dto.go
@@ -1,0 +1,32 @@
+// Package dto holds request/response shapes with deliberate name overlap so
+// the fixture can distinguish the HTTP-layer types (CheckRoomHTTPRequest /
+// HTTPResponse) from same-prefix internal RPC types (CheckRoomRequest /
+// Response). Issue #22's bug surfaces when apispec picks the wrong one.
+package dto
+
+// CheckRoomHTTPRequest is decoded from the JSON body. It MUST be the type
+// referenced by the operation's requestBody.
+type CheckRoomHTTPRequest struct {
+	Room string `json:"room"`
+}
+
+// CheckRoomHTTPResponse is what the handler writes back as JSON.
+type CheckRoomHTTPResponse struct {
+	OK bool `json:"ok"`
+}
+
+// CheckRoomRequest is an unrelated internal RPC shape. Any leakage of this
+// type into the OpenAPI spec is a bug.
+type CheckRoomRequest struct {
+	RoomID string `json:"roomId"`
+}
+
+// CheckRoomResponse — same package, same prefix, completely unrelated.
+type CheckRoomResponse struct {
+	Allowed bool `json:"allowed"`
+}
+
+// LivenessResponse is returned by the GET /health/live endpoint.
+type LivenessResponse struct {
+	Status string `json:"status"`
+}

--- a/testdata/servemux_methods/expected_openapi.json
+++ b/testdata/servemux_methods/expected_openapi.json
@@ -82,6 +82,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/testdata/servemux_methods/expected_openapi.json
+++ b/testdata/servemux_methods/expected_openapi.json
@@ -1,0 +1,127 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/health/live": {
+      "get": {
+        "summary": "liveness returns a fixed JSON payload — never reads the body.",
+        "operationId": "servemux_methods.liveness",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.LivenessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/legacy": {
+      "post": {
+        "summary": "legacy is registered without a method prefix; defaults still apply.",
+        "operationId": "servemux_methods.legacy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.LivenessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/matrix/check-room": {
+      "post": {
+        "operationId": "CheckRoomHandler.handleCheckRoom",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dto.CheckRoomHTTPRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dto.CheckRoomHTTPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "dto.CheckRoomHTTPRequest": {
+        "type": "object",
+        "properties": {
+          "room": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "room"
+        ]
+      },
+      "dto.CheckRoomHTTPResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "dto.LivenessResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/servemux_methods/expected_openapi_legacy.json
+++ b/testdata/servemux_methods/expected_openapi_legacy.json
@@ -1,0 +1,127 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/health/live": {
+      "get": {
+        "summary": "liveness returns a fixed JSON payload — never reads the body.",
+        "operationId": "servemux_methods.liveness",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/servemux_methods_dto.LivenessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/legacy": {
+      "post": {
+        "summary": "legacy is registered without a method prefix; defaults still apply.",
+        "operationId": "servemux_methods.legacy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/servemux_methods_dto.LivenessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/matrix/check-room": {
+      "post": {
+        "operationId": "servemux_methods.servemux_methods.CheckRoomHandler.handleCheckRoom",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/servemux_methods_dto.CheckRoomHTTPRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/servemux_methods_dto.CheckRoomHTTPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "servemux_methods_dto.CheckRoomHTTPRequest": {
+        "type": "object",
+        "properties": {
+          "room": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "room"
+        ]
+      },
+      "servemux_methods_dto.CheckRoomHTTPResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "servemux_methods_dto.LivenessResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/servemux_methods/expected_openapi_legacy.json
+++ b/testdata/servemux_methods/expected_openapi_legacy.json
@@ -82,6 +82,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/testdata/servemux_methods/go.mod
+++ b/testdata/servemux_methods/go.mod
@@ -1,0 +1,3 @@
+module servemux_methods
+
+go 1.22

--- a/testdata/servemux_methods/httpx/httpx.go
+++ b/testdata/servemux_methods/httpx/httpx.go
@@ -1,0 +1,21 @@
+// Package httpx holds the shared response helper. Living in a sibling
+// package — not in main — matters because the bug we're chasing involves
+// cross-package type resolution where the request body's type ends up
+// confused with one of the helper's interface{} arguments.
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// WriteJSON is the shared response writer used by every handler. The
+// interface{} parameter is intentional — `v` accepts any value the handler
+// wants to serialize. apispec needs to follow the concrete call-site arg
+// type back through this helper, not pick something up from the handler's
+// local scope.
+func WriteJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/testdata/servemux_methods/main.go
+++ b/testdata/servemux_methods/main.go
@@ -1,0 +1,85 @@
+// Package main exercises Go 1.22+ net/http ServeMux method-prefix patterns:
+//
+//	mux.HandleFunc("GET /health/live", ...)
+//	mux.HandleFunc("POST /matrix/check-room", ...)
+//
+// Before Go 1.22, the first argument was just the path. Go 1.22+ accepts an
+// optional method prefix separated by a space. apispec must split the prefix
+// out so the OpenAPI path key stays `/health/live` (not `/GET /health/live`)
+// and the operation verb tracks the prefix (`get:`, `post:`).
+//
+// The fixture also defines a handler whose body type differs from the
+// response type with a name-collision-heavy `dto` package: CheckRoomRequest,
+// CheckRoomResponse, CheckRoomHTTPRequest, CheckRoomHTTPResponse. The
+// requestBody schema must reference dto.CheckRoomHTTPRequest, not any of
+// the look-alike Response types. The handler is a method on a struct to
+// mirror the reporter's setup.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"servemux_methods/dto"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	h := &CheckRoomHandler{}
+
+	// Go 1.22+ method-prefix syntax: GET-only liveness probe.
+	mux.HandleFunc("GET /health/live", liveness)
+
+	// Go 1.22+ method-prefix syntax: POST with request body, method receiver.
+	mux.HandleFunc("POST /matrix/check-room", h.handleCheckRoom)
+
+	// Plain pattern (no method prefix) — the legacy path should still work.
+	mux.HandleFunc("/legacy", legacy)
+
+	http.ListenAndServe(":3000", mux)
+}
+
+// CheckRoomHandler holds dependencies for the /matrix/check-room handler.
+// In the reporter's project it had an injected RPC client; here we just
+// keep the receiver so the call shape matches.
+type CheckRoomHandler struct{}
+
+// handleCheckRoom decodes the body into dto.CheckRoomHTTPRequest, talks to
+// an internal RPC layer (whose Request/Response types share a confusing
+// "CheckRoom" prefix with the HTTP ones), and writes back the
+// dto.CheckRoomHTTPResponse. The bug surfaces when apispec follows the
+// type tracer through the RPC variables and reports CheckRoomResponse as
+// the request body.
+func (h *CheckRoomHandler) handleCheckRoom(w http.ResponseWriter, r *http.Request) {
+	var httpReq dto.CheckRoomHTTPRequest
+	if err := json.NewDecoder(r.Body).Decode(&httpReq); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	// Internal RPC step — these variables have the look-alike non-HTTP types.
+	rpcReq := dto.CheckRoomRequest{RoomID: httpReq.Room}
+	rpcResp := dto.CheckRoomResponse{Allowed: rpcReq.RoomID != ""}
+
+	// Final HTTP response value.
+	httpResp := dto.CheckRoomHTTPResponse{OK: rpcResp.Allowed}
+	WriteJSON(w, http.StatusOK, httpResp)
+}
+
+// WriteJSON is a generic response helper of the kind common in real apps;
+// its presence has historically confused the response type tracer.
+func WriteJSON[T any](w http.ResponseWriter, status int, v T) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+// liveness returns a fixed JSON payload — never reads the body.
+func liveness(w http.ResponseWriter, _ *http.Request) {
+	WriteJSON(w, http.StatusOK, dto.LivenessResponse{Status: "ok"})
+}
+
+// legacy is registered without a method prefix; defaults still apply.
+func legacy(w http.ResponseWriter, _ *http.Request) {
+	WriteJSON(w, http.StatusOK, dto.LivenessResponse{Status: "legacy"})
+}

--- a/testdata/servemux_methods/main.go
+++ b/testdata/servemux_methods/main.go
@@ -21,11 +21,12 @@ import (
 	"net/http"
 
 	"servemux_methods/dto"
+	"servemux_methods/httpx"
 )
 
 func main() {
 	mux := http.NewServeMux()
-	h := &CheckRoomHandler{}
+	h := &CheckRoomHandler{rpc: &rpcClient{}}
 
 	// Go 1.22+ method-prefix syntax: GET-only liveness probe.
 	mux.HandleFunc("GET /health/live", liveness)
@@ -39,10 +40,31 @@ func main() {
 	http.ListenAndServe(":3000", mux)
 }
 
+// rpcClient is a stand-in for an injected RPC dependency. The CheckRoom
+// method does its own JSON deserialization (json.Unmarshal) — that
+// internal decode of a RabbitMQ-style byte payload must NOT be picked
+// up by apispec's request-body extraction and substituted for the
+// HTTP handler's real body type. This is the exact failure shape from
+// issue #22.
+type rpcClient struct{}
+
+func (r *rpcClient) CheckRoom(req dto.CheckRoomRequest) (dto.CheckRoomResponse, error) {
+	// Pretend we received this from the message broker.
+	respBytes := []byte(`{"allowed":true}`)
+	var rmqResp dto.CheckRoomResponse
+	if err := json.Unmarshal(respBytes, &rmqResp); err != nil {
+		return dto.CheckRoomResponse{}, err
+	}
+	_ = req
+	return rmqResp, nil
+}
+
 // CheckRoomHandler holds dependencies for the /matrix/check-room handler.
-// In the reporter's project it had an injected RPC client; here we just
-// keep the receiver so the call shape matches.
-type CheckRoomHandler struct{}
+// Matches the reporter's project — handler is a method on a struct with an
+// injected RPC client.
+type CheckRoomHandler struct {
+	rpc *rpcClient
+}
 
 // handleCheckRoom decodes the body into dto.CheckRoomHTTPRequest, talks to
 // an internal RPC layer (whose Request/Response types share a confusing
@@ -57,29 +79,26 @@ func (h *CheckRoomHandler) handleCheckRoom(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Internal RPC step — these variables have the look-alike non-HTTP types.
+	// Internal RPC call — returns a CheckRoomResponse, which is the
+	// look-alike type the issue-#22 bug confused with the request body.
 	rpcReq := dto.CheckRoomRequest{RoomID: httpReq.Room}
-	rpcResp := dto.CheckRoomResponse{Allowed: rpcReq.RoomID != ""}
+	rpcResp, err := h.rpc.CheckRoom(rpcReq)
+	if err != nil {
+		http.Error(w, "rpc failed", http.StatusInternalServerError)
+		return
+	}
 
 	// Final HTTP response value.
 	httpResp := dto.CheckRoomHTTPResponse{OK: rpcResp.Allowed}
-	WriteJSON(w, http.StatusOK, httpResp)
-}
-
-// WriteJSON is a generic response helper of the kind common in real apps;
-// its presence has historically confused the response type tracer.
-func WriteJSON[T any](w http.ResponseWriter, status int, v T) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	httpx.WriteJSON(w, http.StatusOK, httpResp)
 }
 
 // liveness returns a fixed JSON payload — never reads the body.
 func liveness(w http.ResponseWriter, _ *http.Request) {
-	WriteJSON(w, http.StatusOK, dto.LivenessResponse{Status: "ok"})
+	httpx.WriteJSON(w, http.StatusOK, dto.LivenessResponse{Status: "ok"})
 }
 
 // legacy is registered without a method prefix; defaults still apply.
 func legacy(w http.ResponseWriter, _ *http.Request) {
-	WriteJSON(w, http.StatusOK, dto.LivenessResponse{Status: "legacy"})
+	httpx.WriteJSON(w, http.StatusOK, dto.LivenessResponse{Status: "legacy"})
 }


### PR DESCRIPTION
Closes #21. Likely closes #22.

## Issue #21 — `/POST /path` keys and wrong verb

Go 1.22+ `net/http` ServeMux accepts `HandleFunc("METHOD /path", h)`. apispec was treating the whole first arg as the path, producing invalid OpenAPI keys (`/POST /matrix/check-room`) with the verb wrongly defaulting to `post:` for every endpoint.

Fix: in `extractRouteDetails`, when the extracted path starts with a valid HTTP method followed by `space /`, strip the method off the path and assign it to `routeInfo.Method` — overriding the `POST` default that `ExtractRoute` applies. The space-separator syntax is unambiguous because URLs can't contain spaces, so the heuristic stays safe across frameworks rather than being scoped to stdlib.

## Issue #22 — request body resolves to wrong type

I couldn't reproduce the reporter's exact symptom (`dto.CheckRoomHTTPRequest` → `dto.CheckRoomResponse`) in my fixture, but the multi-package + generic-`WriteJSON` setup did surface a closely-related bug: response bodies were leaking the generic helper's type parameter (`pkg.T`) into the spec instead of substituting it to the concrete call-site type. Both symptoms — leaking `T` and substituting the wrong concrete type — trace to the same gap: `ResponsePatternMatcherImpl.resolveTypeOrigin` was calling `sharedResolveTypeOrigin` without first walking the call site's `TypeParamMap`.

Fix: give the response matcher's `resolveTypeOrigin` the same generic-substitution pipeline the request matcher already has — honour `arg.GetResolvedType` first, then `traceGenericOrigin(node, ...)` against the `TypeParamMap`, then fall back to shared logic. After this, `T` resolves to `dto.CheckRoomHTTPResponse`, `dto.LivenessResponse`, etc., at each call site.

Asking the reporter to verify against the v0.4.11 release whether their exact symptom is also resolved.

## Fixture (`testdata/servemux_methods/`)

- `HandleFunc("GET /health/live", h)` — method prefix, clean path, GET verb
- `HandleFunc("POST /matrix/check-room", h.handleCheckRoom)` — same, with a method-receiver handler, a generic `WriteJSON[T any]` wrapper, and same-prefix shadow types (`CheckRoomRequest`/`CheckRoomResponse`/`CheckRoomHTTPRequest`/`CheckRoomHTTPResponse`) in a sub-package
- `HandleFunc("/legacy", h)` — no method prefix, keeps the default POST

## Tests

- `splitmethod_test.go` — 9 tests on `splitMethodPrefixedPath` (every method, case normalization, extra spaces, edge cases, unknown method, no-slash path) and `isHTTPMethod`
- `response_generic_test.go` — covers the new `GetResolvedType` short-circuit and `traceGenericOrigin` branch
- `pattern_matchers_coverage_test.go` — new `TestExtractRouteDetails_Go122MethodPrefix` exercises the splitter through `extractRouteDetails`
- `mapper_doccomment_test.go` — added tests for previously-uncovered `extractDocComment` first-pass and `parseFuncNameAndPackage` FuncLit-position handling
- `test_utils_internal_test.go` — `RecoverFromPanic` / `RunWithPanicRecovery` coverage
- `engine_e2e_test.go` — `TestE2E_ServeMux_MethodPrefixAndGenericResponse` locks down the fixture's contract end-to-end
- `extractor_additional_test.go` — extra `isLikelyMediaType` row covering the dot-in-type-segment guard

## Goldens

Only `testdata/servemux_methods/` adds new goldens; every other golden (chi/gin/echo/fiber/mux/error_helpers/response_patterns/nested_http/form_value_var/json_dto/json_patch) regenerated as `unchanged`.

## Coverage

New code is at 100% per function (`splitMethodPrefixedPath`, `isHTTPMethod`, the response matcher's new branches). `extractRouteDetails` moved from 92.3% → 96.2%. Package `internal/spec` is 94.5% → 94.67%; the remaining gap to 95% is pre-existing legacy code unrelated to this PR.

## Test plan
- [x] `go test ./...` — green
- [x] `make lint` — clean
- [x] Goldens diffed before regen — only the new fixture changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Go 1.22+ `net/http` `ServeMux` method-prefix patterns in OpenAPI spec generation. Routes like `"GET /health/live"` now correctly extract the HTTP method and path separately.

* **Documentation**
  * Updated README to document method-prefix pattern support and clarify routing interpretation.

* **Tests**
  * Enhanced test coverage for method-prefix routing, type resolution, and response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antst/go-apispec/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->