### PR TITLE
fix: variable-scoped TrimPrefix matching in security detection

### DIFF
--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -257,6 +257,15 @@ func TestE2E_SecurityBearer_AllSchemesAndSuppression(t *testing.T) {
 	expectScheme(t, "/protected/basic", "basicAuth")
 	expectScheme(t, "/protected/apikey", "apiKeyAuth")
 
+	// Regression: /matrix/user reads Authorization (no TrimPrefix on the
+	// header value) AND processes a Matrix user-ID via
+	// strings.TrimPrefix(userID, "@"). The unrelated "@" TrimPrefix must
+	// NOT poison auth detection — the resulting scheme stays apiKeyAuth,
+	// not the v0.4.12-era nonsense "@Auth".
+	expectScheme(t, "/matrix/user", "apiKeyAuth")
+	require.NotContains(t, result.Components.SecuritySchemes, "@Auth",
+		"unrelated TrimPrefix on '@' must not produce a bogus scheme")
+
 	// Open endpoint: no security stanza, no Authorization parameter.
 	open, ok := result.Paths["/open/ping"]
 	require.True(t, ok, "expected /open/ping in paths; got %v", pathKeys(result))

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -1381,7 +1381,14 @@ func DefaultHTTPConfig() *APISpecConfig {
 					DefaultType:   "string",
 					DefaultFormat: "binary",
 				},
-				{BasePattern: BasePattern{CallRegex: "^Get$"}, ParamIn: "header",
+				{BasePattern: BasePattern{CallRegex: "^Get$",
+
+					RecvTypeRegex: `\.Header$|^net/http\.Header$`}, ParamIn: "header",
+					ParamArgIndex: 0,
+				},
+				{BasePattern: BasePattern{CallRegex: "^Get$",
+
+					RecvType: "net/url.Values"}, ParamIn: "query",
 					ParamArgIndex: 0,
 				},
 				{BasePattern: BasePattern{CallRegex: "^Cookie$"}, ParamIn: "cookie",

--- a/internal/spec/security_detection.go
+++ b/internal/spec/security_detection.go
@@ -69,6 +69,14 @@ func walkCallersForAuthPrefix(handlerID string, meta *metadata.Metadata) (string
 	queue := []queued{{handlerID, 0}}
 
 	hasHeaderRead := false
+	// authVars holds the names of local variables assigned from
+	// r.Header.Get("Authorization"). A TrimPrefix call only counts as an
+	// auth-scheme signal when its first argument is one of these variables
+	// (or an inline Header.Get("Authorization") call expression). Without
+	// this scoping, unrelated TrimPrefix calls elsewhere in the call graph
+	// — e.g. strings.TrimPrefix(matrixUserID, "@") — were being picked up
+	// as the auth prefix, producing nonsense schemes like "@Auth".
+	authVars := map[string]bool{}
 	var prefix string
 
 	for len(queue) > 0 {
@@ -83,9 +91,14 @@ func walkCallersForAuthPrefix(handlerID string, meta *metadata.Metadata) (string
 			switch {
 			case isAuthHeaderRead(callee, recv, edge, meta):
 				hasHeaderRead = true
+				if v := edge.CalleeRecvVarName; v != "" {
+					authVars[v] = true
+				}
 			case isTrimPrefixCall(callee, pkg):
-				if p := trimPrefixValue(edge, meta); p != "" && prefix == "" {
-					prefix = p
+				if prefix == "" && trimPrefixOnAuthVar(edge, authVars, meta) {
+					if p := trimPrefixValue(edge, meta); p != "" {
+						prefix = p
+					}
 				}
 			}
 
@@ -109,6 +122,73 @@ func walkCallersForAuthPrefix(handlerID string, meta *metadata.Metadata) (string
 	}
 
 	return prefix, hasHeaderRead
+}
+
+// trimPrefixOnAuthVar reports whether the TrimPrefix call's first argument
+// traces back to an Authorization-header read. Two shapes count:
+//
+//   - First arg is an ident whose name is in authVars (the common
+//     `header := r.Header.Get("Authorization"); strings.TrimPrefix(header, "Bearer ")`
+//     idiom — Header.Get's result is bound to a local variable that's
+//     then trimmed).
+//   - First arg is itself a call to Header.Get("Authorization") — the
+//     inline `strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")`
+//     idiom that skips the intermediate variable.
+//
+// Any other shape (different ident, literal, expression that doesn't
+// reduce to a Header.Get) is treated as unrelated and ignored — this is
+// what stops e.g. `strings.TrimPrefix(matrixUserID, "@")` from poisoning
+// auth detection.
+func trimPrefixOnAuthVar(edge *metadata.CallGraphEdge, authVars map[string]bool, meta *metadata.Metadata) bool {
+	if len(edge.Args) == 0 {
+		return false
+	}
+	first := edge.Args[0]
+	if first == nil {
+		return false
+	}
+	switch first.GetKind() {
+	case metadata.KindIdent:
+		return authVars[first.GetName()]
+	case metadata.KindCall:
+		return isInlineAuthHeaderCall(first, meta)
+	}
+	return false
+}
+
+// isInlineAuthHeaderCall recognises the call expression
+// `r.Header.Get("Authorization")` (or any equivalent receiver shape) when
+// it appears directly as another call's argument. Used so the inline-trim
+// idiom `strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")`
+// resolves without the result being bound to a local variable first.
+func isInlineAuthHeaderCall(arg *metadata.CallArgument, meta *metadata.Metadata) bool {
+	if arg == nil || arg.Fun == nil {
+		return false
+	}
+	if arg.Fun.GetKind() != metadata.KindSelector || arg.Fun.Sel == nil {
+		return false
+	}
+	if stringFromPool(meta, arg.Fun.Sel.Name) != "Get" {
+		return false
+	}
+	// The receiver shape can land in either arg.Fun.X.Type (canonical) or
+	// arg.Fun.Type depending on how the chained expression was parsed;
+	// match against both so we don't miss equivalent shapes.
+	recv := stringFromPool(meta, 0)
+	if arg.Fun.X != nil {
+		recv = stringFromPool(meta, arg.Fun.X.Type)
+	}
+	if !strings.Contains(recv, "Header") {
+		recv = stringFromPool(meta, arg.Fun.Type)
+		if !strings.Contains(recv, "Header") {
+			return false
+		}
+	}
+	if len(arg.Args) == 0 {
+		return false
+	}
+	name := strings.Trim(stringFromPool(meta, arg.Args[0].Value), `"`)
+	return strings.EqualFold(name, authHeaderName)
 }
 
 // edgesFromCaller returns the edges originating from the named function

--- a/internal/spec/security_detection.go
+++ b/internal/spec/security_detection.go
@@ -69,46 +69,56 @@ func walkCallersForAuthPrefix(handlerID string, meta *metadata.Metadata) (string
 	queue := []queued{{handlerID, 0}}
 
 	hasHeaderRead := false
-	// authVars holds the names of local variables assigned from
-	// r.Header.Get("Authorization"). A TrimPrefix call only counts as an
-	// auth-scheme signal when its first argument is one of these variables
-	// (or an inline Header.Get("Authorization") call expression). Without
-	// this scoping, unrelated TrimPrefix calls elsewhere in the call graph
-	// — e.g. strings.TrimPrefix(matrixUserID, "@") — were being picked up
-	// as the auth prefix, producing nonsense schemes like "@Auth".
-	authVars := map[string]bool{}
 	var prefix string
 
 	for len(queue) > 0 {
 		cur := queue[0]
 		queue = queue[1:]
 
-		for _, edge := range edgesFromCaller(meta, cur.id) {
+		edges := edgesFromCaller(meta, cur.id)
+
+		// Two-pass scan, scoped to THIS function. authVars are local-scope
+		// identifiers — a `header` variable in one function has nothing to
+		// do with a `header` variable in another — so the set is rebuilt
+		// per caller. Pass 1 registers Authorization-header reads (so we
+		// know which variables hold the result before any TrimPrefix can
+		// reference them, irrespective of slice order). Pass 2 then
+		// validates TrimPrefix matches against that local set.
+		authVars := map[string]bool{}
+		for _, edge := range edges {
 			callee := stringFromPool(meta, edge.Callee.Name)
-			pkg := stringFromPool(meta, edge.Callee.Pkg)
 			recv := stringFromPool(meta, edge.Callee.RecvType)
-
-			switch {
-			case isAuthHeaderRead(callee, recv, edge, meta):
-				hasHeaderRead = true
-				if v := edge.CalleeRecvVarName; v != "" {
-					authVars[v] = true
-				}
-			case isTrimPrefixCall(callee, pkg):
-				if prefix == "" && trimPrefixOnAuthVar(edge, authVars, meta) {
-					if p := trimPrefixValue(edge, meta); p != "" {
-						prefix = p
-					}
-				}
-			}
-
-			if cur.depth+1 >= maxDepth {
+			if !isAuthHeaderRead(callee, recv, edge, meta) {
 				continue
 			}
-			// Descend into the callee — but only when it's a user-defined
-			// function we can re-look-up in meta.Callers. Builtins and
-			// stdlib calls (json, strings, http stdlib helpers) don't have
-			// further edges relevant to auth detection.
+			hasHeaderRead = true
+			if v := edge.CalleeRecvVarName; v != "" {
+				authVars[v] = true
+			}
+		}
+		if prefix == "" {
+			for _, edge := range edges {
+				callee := stringFromPool(meta, edge.Callee.Name)
+				pkg := stringFromPool(meta, edge.Callee.Pkg)
+				if !isTrimPrefixCall(callee, pkg) {
+					continue
+				}
+				if !trimPrefixOnAuthVar(edge, authVars, meta) {
+					continue
+				}
+				if p := trimPrefixValue(edge, meta); p != "" {
+					prefix = p
+					break
+				}
+			}
+		}
+
+		// Enqueue user-defined callees (builtins and stdlib helpers don't
+		// expose edges that matter for auth detection).
+		if cur.depth+1 >= maxDepth {
+			continue
+		}
+		for _, edge := range edges {
 			calleeID := edge.Callee.BaseID()
 			if visited[calleeID] {
 				continue

--- a/internal/spec/security_detection_test.go
+++ b/internal/spec/security_detection_test.go
@@ -203,6 +203,207 @@ func TestDetectSecuritySchemeFromHandler_NoAuth(t *testing.T) {
 	assert.Nil(t, detectSecuritySchemeFromHandler(&RouteInfo{Function: "pkg.Handler", Metadata: meta}))
 }
 
+func TestDetectSecuritySchemeFromHandler_UnrelatedTrimPrefix_DoesNotPoison(t *testing.T) {
+	// Handler reads r.Header.Get("Authorization") without trimming any
+	// prefix from the result, AND also calls strings.TrimPrefix(userID, "@")
+	// on an unrelated variable — exactly the alkem-io/matrix-adapter-go
+	// shape that produced bogus "@Auth" schemes in v0.4.12. The fix scopes
+	// TrimPrefix matching to calls whose first argument traces back to the
+	// Authorization-header read, so the "@" prefix is ignored and the
+	// handler resolves to plain apiKeyAuth.
+	meta := newTestMeta()
+
+	// Header.Get("Authorization") — result NOT trimmed by anything related.
+	get := makeEdge(meta, "Handler", "pkg", "Get", "net/http",
+		[]*metadata.CallArgument{makeLiteralArg(meta, `"Authorization"`)})
+	get.Callee.RecvType = meta.StringPool.Get("Header")
+	get.CalleeRecvVarName = "token"
+	// Unrelated TrimPrefix on a totally different variable (Matrix user ID).
+	matrixTrim := makeEdge(meta, "Handler", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{
+			makeIdentArg(meta, "userID", "string"),
+			makeLiteralArg(meta, `"@"`),
+		})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		get.Caller.BaseID(): {&get, &matrixTrim},
+	}
+
+	got := detectSecuritySchemeFromHandler(&RouteInfo{
+		Function: get.Caller.BaseID(),
+		Metadata: meta,
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "apiKeyAuth", got.Name,
+		"unrelated TrimPrefix on '@' must not change the scheme away from apiKey")
+}
+
+func TestTrimPrefixOnAuthVar_VariableMatch(t *testing.T) {
+	meta := newTestMeta()
+	authVars := map[string]bool{"header": true}
+	edge := makeEdge(meta, "h", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{
+			makeIdentArg(meta, "header", "string"),
+			makeLiteralArg(meta, `"Bearer "`),
+		})
+	assert.True(t, trimPrefixOnAuthVar(&edge, authVars, meta))
+
+	// Different ident → not the auth variable, refuse.
+	other := makeEdge(meta, "h", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{
+			makeIdentArg(meta, "userID", "string"),
+			makeLiteralArg(meta, `"@"`),
+		})
+	assert.False(t, trimPrefixOnAuthVar(&other, authVars, meta))
+}
+
+func TestTrimPrefixOnAuthVar_EmptyArgsOrNil(t *testing.T) {
+	meta := newTestMeta()
+	edge := makeEdge(meta, "h", "pkg", "TrimPrefix", "strings", nil)
+	assert.False(t, trimPrefixOnAuthVar(&edge, map[string]bool{}, meta))
+
+	withNil := makeEdge(meta, "h", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{nil, makeLiteralArg(meta, `"Bearer "`)})
+	assert.False(t, trimPrefixOnAuthVar(&withNil, map[string]bool{}, meta))
+}
+
+func TestTrimPrefixOnAuthVar_NonIdentNonCallFirstArg(t *testing.T) {
+	// First arg is a literal — not an ident, not a call. Must not match.
+	meta := newTestMeta()
+	edge := makeEdge(meta, "h", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{
+			makeLiteralArg(meta, `"some literal"`),
+			makeLiteralArg(meta, `"Bearer "`),
+		})
+	assert.False(t, trimPrefixOnAuthVar(&edge, map[string]bool{"header": true}, meta))
+}
+
+// buildHeaderGetCallArg constructs a CallArgument shaped like
+// `r.Header.Get("Authorization")` for the inline-call helper tests. The
+// arg.Fun is a selector whose Sel name is "Get" and whose receiver
+// resolves to a type containing "Header"; arg.Args[0] is the
+// literal header name. Mirrors what ExprToCallArgument builds for the
+// real `strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")`
+// idiom.
+func buildHeaderGetCallArg(meta *metadata.Metadata, headerName string) *metadata.CallArgument {
+	receiver := makeCallArg(meta)
+	receiver.SetKind(metadata.KindIdent)
+	receiver.SetType("net/http.Header")
+
+	sel := makeCallArg(meta)
+	sel.SetKind(metadata.KindSelector)
+	sel.X = receiver
+	sel.Sel = makeCallArg(meta)
+	sel.Sel.SetKind(metadata.KindIdent)
+	sel.Sel.SetName("Get")
+
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindCall)
+	arg.Fun = sel
+	arg.Args = []*metadata.CallArgument{makeLiteralArg(meta, `"`+headerName+`"`)}
+	return arg
+}
+
+func TestIsInlineAuthHeaderCall_HappyPath(t *testing.T) {
+	// strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ") — the
+	// first arg of TrimPrefix is a KindCall to Header.Get with literal
+	// "Authorization". This must match without the result ever being
+	// bound to a local variable first.
+	meta := newTestMeta()
+	arg := buildHeaderGetCallArg(meta, authHeaderName)
+	assert.True(t, isInlineAuthHeaderCall(arg, meta))
+}
+
+func TestIsInlineAuthHeaderCall_FallbackReceiverPath(t *testing.T) {
+	// Some builders fill arg.Fun.Type instead of arg.Fun.X.Type. Both
+	// should resolve. Clear X.Type, set Fun.Type — same conclusion.
+	meta := newTestMeta()
+	arg := buildHeaderGetCallArg(meta, authHeaderName)
+	arg.Fun.X.SetType("")
+	arg.Fun.SetType("net/http.Header")
+	assert.True(t, isInlineAuthHeaderCall(arg, meta))
+}
+
+func TestIsInlineAuthHeaderCall_DifferentHeader(t *testing.T) {
+	// Header.Get for a header other than Authorization — must not match.
+	meta := newTestMeta()
+	arg := buildHeaderGetCallArg(meta, "X-Trace-ID")
+	assert.False(t, isInlineAuthHeaderCall(arg, meta))
+}
+
+func TestIsInlineAuthHeaderCall_DifferentMethod(t *testing.T) {
+	// Some other method on Header (e.g. Set) — must not match.
+	meta := newTestMeta()
+	arg := buildHeaderGetCallArg(meta, authHeaderName)
+	arg.Fun.Sel.SetName("Set")
+	assert.False(t, isInlineAuthHeaderCall(arg, meta))
+}
+
+func TestIsInlineAuthHeaderCall_WrongReceiverType(t *testing.T) {
+	// Selector exists but receiver type doesn't contain "Header" — e.g.
+	// some other type's Get method. Must not match.
+	meta := newTestMeta()
+	arg := buildHeaderGetCallArg(meta, authHeaderName)
+	arg.Fun.X.SetType("url.Values")
+	// Also clear the fallback path so neither resolves.
+	arg.Fun.SetType("url.Values")
+	assert.False(t, isInlineAuthHeaderCall(arg, meta))
+}
+
+func TestIsInlineAuthHeaderCall_NotASelector(t *testing.T) {
+	// arg.Fun is an ident (not a selector) — e.g. a bare package-level
+	// call. The recognised shape requires the X.Sel form.
+	meta := newTestMeta()
+	arg := makeCallArg(meta)
+	arg.SetKind(metadata.KindCall)
+	arg.Fun = makeIdentArg(meta, "Get", "")
+	assert.False(t, isInlineAuthHeaderCall(arg, meta))
+
+	// Selector with nil Sel — bail safely.
+	arg2 := makeCallArg(meta)
+	arg2.SetKind(metadata.KindCall)
+	arg2.Fun = makeCallArg(meta)
+	arg2.Fun.SetKind(metadata.KindSelector)
+	assert.False(t, isInlineAuthHeaderCall(arg2, meta))
+
+	// Selector with nil X.
+	arg3 := makeCallArg(meta)
+	arg3.SetKind(metadata.KindCall)
+	arg3.Fun = makeCallArg(meta)
+	arg3.Fun.SetKind(metadata.KindSelector)
+	arg3.Fun.Sel = makeCallArg(meta)
+	arg3.Fun.Sel.SetName("Get")
+	assert.False(t, isInlineAuthHeaderCall(arg3, meta))
+}
+
+func TestIsInlineAuthHeaderCall_NoArgs(t *testing.T) {
+	// Selector + receiver look right but the inner call has no args.
+	meta := newTestMeta()
+	arg := buildHeaderGetCallArg(meta, authHeaderName)
+	arg.Args = nil
+	assert.False(t, isInlineAuthHeaderCall(arg, meta))
+}
+
+func TestTrimPrefixOnAuthVar_InlineCallFirstArg(t *testing.T) {
+	// strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ") — the
+	// inline-call path: the auth-var set is empty but the first arg IS
+	// an Authorization-header read inline, so this still matches.
+	meta := newTestMeta()
+	innerCall := buildHeaderGetCallArg(meta, authHeaderName)
+	edge := makeEdge(meta, "h", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{innerCall, makeLiteralArg(meta, `"Bearer "`)})
+	assert.True(t, trimPrefixOnAuthVar(&edge, map[string]bool{}, meta))
+}
+
+func TestIsInlineAuthHeaderCall_NilGuards(t *testing.T) {
+	meta := newTestMeta()
+	assert.False(t, isInlineAuthHeaderCall(nil, meta))
+
+	// Arg with no Fun.
+	bare := makeCallArg(meta)
+	bare.SetKind(metadata.KindCall)
+	assert.False(t, isInlineAuthHeaderCall(bare, meta))
+}
+
 func TestDetectSecuritySchemeFromHandler_HelperTransitive(t *testing.T) {
 	// Handler() calls ValidateBearer(). ValidateBearer() does the actual
 	// Header.Get + TrimPrefix. The BFS must follow into the helper and
@@ -213,11 +414,12 @@ func TestDetectSecuritySchemeFromHandler_HelperTransitive(t *testing.T) {
 
 	// Handler → ValidateBearer (helper call)
 	helperCall := makeEdge(meta, "Handler", "pkg", "ValidateBearer", "pkg", nil)
-	// ValidateBearer → Header.Get("Authorization")
+	// ValidateBearer → header := r.Header.Get("Authorization")
 	headerGet := makeEdge(meta, "ValidateBearer", "pkg", "Get", "net/http",
 		[]*metadata.CallArgument{makeLiteralArg(meta, `"Authorization"`)})
 	headerGet.Callee.RecvType = meta.StringPool.Get("Header")
-	// ValidateBearer → strings.TrimPrefix(_, "Bearer ")
+	headerGet.CalleeRecvVarName = "header"
+	// ValidateBearer → strings.TrimPrefix(header, "Bearer ")
 	trim := makeEdge(meta, "ValidateBearer", "pkg", "TrimPrefix", "strings",
 		[]*metadata.CallArgument{
 			makeIdentArg(meta, "header", "string"),
@@ -398,20 +600,23 @@ func TestDropAuthorizationHeaderParam(t *testing.T) {
 
 // buildAuthHandlerMeta is a shared fixture for the detector tests — it
 // stamps a tiny call graph mimicking a handler that reads the Auth header
-// and runs TrimPrefix with the given scheme prefix.
+// into a local variable `header` and runs TrimPrefix on that variable
+// with the given scheme prefix. The CalleeRecvVarName on the Header.Get
+// edge is what lets the scoped TrimPrefix matcher pair the two.
 func buildAuthHandlerMeta(t *testing.T, prefix string) *metadata.Metadata {
 	t.Helper()
 	meta := newTestMeta()
 	get := makeEdge(meta, "Handler", "pkg", "Get", "net/http",
 		[]*metadata.CallArgument{makeLiteralArg(meta, `"Authorization"`)})
 	get.Callee.RecvType = meta.StringPool.Get("Header")
+	get.CalleeRecvVarName = "header"
 	trim := makeEdge(meta, "Handler", "pkg", "TrimPrefix", "strings",
 		[]*metadata.CallArgument{
 			makeIdentArg(meta, "header", "string"),
 			makeLiteralArg(meta, `"`+prefix+`"`),
 		})
 	meta.Callers = map[string][]*metadata.CallGraphEdge{
-		"pkg.Handler": {&get, &trim},
+		get.Caller.BaseID(): {&get, &trim},
 	}
 	return meta
 }

--- a/internal/spec/security_detection_test.go
+++ b/internal/spec/security_detection_test.go
@@ -203,6 +203,78 @@ func TestDetectSecuritySchemeFromHandler_NoAuth(t *testing.T) {
 	assert.Nil(t, detectSecuritySchemeFromHandler(&RouteInfo{Function: "pkg.Handler", Metadata: meta}))
 }
 
+func TestDetectSecuritySchemeFromHandler_CrossFunctionVarLeak(t *testing.T) {
+	// Defensive: authVars are local to a function. Handler A does
+	// `header := r.Header.Get("Authorization")` (no TrimPrefix). Helper B
+	// has `strings.TrimPrefix(header, "Bearer ")` on ITS OWN local variable
+	// named `header` (unrelated — could be any string named "header"). The
+	// two `header` idents are scope-distinct, so the helper's TrimPrefix
+	// must NOT count as the handler's auth-scheme signal. The handler must
+	// resolve to apiKeyAuth (raw read, no prefix).
+	meta := newTestMeta()
+
+	get := makeEdge(meta, "Handler", "pkg", "Get", "net/http",
+		[]*metadata.CallArgument{makeLiteralArg(meta, `"Authorization"`)})
+	get.Callee.RecvType = meta.StringPool.Get("Header")
+	get.CalleeRecvVarName = "header"
+	helperCall := makeEdge(meta, "Handler", "pkg", "UnrelatedHelper", "pkg", nil)
+
+	// In UnrelatedHelper there's a local `header` (e.g. parameter name)
+	// passed to TrimPrefix with "Bearer ". Without per-function scoping
+	// this would leak into Handler's detection.
+	helperTrim := makeEdge(meta, "UnrelatedHelper", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{
+			makeIdentArg(meta, "header", "string"),
+			makeLiteralArg(meta, `"Bearer "`),
+		})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		get.Caller.BaseID():        {&get, &helperCall},
+		helperTrim.Caller.BaseID(): {&helperTrim},
+	}
+
+	got := detectSecuritySchemeFromHandler(&RouteInfo{
+		Function: get.Caller.BaseID(),
+		Metadata: meta,
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "apiKeyAuth", got.Name,
+		"a same-named ident in a different function must not poison auth detection")
+}
+
+func TestDetectSecuritySchemeFromHandler_TrimBeforeGetInSlice(t *testing.T) {
+	// Defensive: meta.Callers stores edges in call-graph build order, not
+	// necessarily source order. If TrimPrefix appears EARLIER in the slice
+	// than the corresponding Header.Get, a single-pass scan would skip the
+	// match because authVars wasn't populated yet. The two-pass scan
+	// resolves it regardless of slice ordering.
+	meta := newTestMeta()
+
+	get := makeEdge(meta, "Handler", "pkg", "Get", "net/http",
+		[]*metadata.CallArgument{makeLiteralArg(meta, `"Authorization"`)})
+	get.Callee.RecvType = meta.StringPool.Get("Header")
+	get.CalleeRecvVarName = "header"
+	trim := makeEdge(meta, "Handler", "pkg", "TrimPrefix", "strings",
+		[]*metadata.CallArgument{
+			makeIdentArg(meta, "header", "string"),
+			makeLiteralArg(meta, `"Bearer "`),
+		})
+
+	// TrimPrefix listed BEFORE Get — order-shuffled to expose any
+	// single-pass dependency.
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		get.Caller.BaseID(): {&trim, &get},
+	}
+
+	got := detectSecuritySchemeFromHandler(&RouteInfo{
+		Function: get.Caller.BaseID(),
+		Metadata: meta,
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "bearerAuth", got.Name,
+		"two-pass scan must resolve regardless of edge order in the slice")
+}
+
 func TestDetectSecuritySchemeFromHandler_UnrelatedTrimPrefix_DoesNotPoison(t *testing.T) {
 	// Handler reads r.Header.Get("Authorization") without trimming any
 	// prefix from the result, AND also calls strings.TrimPrefix(userID, "@")

--- a/testdata/security_bearer/expected_openapi.json
+++ b/testdata/security_bearer/expected_openapi.json
@@ -21,7 +21,7 @@
         "parameters": [
           {
             "name": "user",
-            "in": "header",
+            "in": "query",
             "schema": {
               "type": "string"
             }

--- a/testdata/security_bearer/expected_openapi.json
+++ b/testdata/security_bearer/expected_openapi.json
@@ -13,6 +13,49 @@
     }
   },
   "paths": {
+    "/matrix/user": {
+      "post": {
+        "summary": "matrixUserHandler reads Authorization (no scheme prefix → apiKey) AND\nprocesses a Matrix user ID via stripMatrixIDPrefix.",
+        "description": "matrixUserHandler reads Authorization (no scheme prefix → apiKey) AND\nprocesses a Matrix user ID via stripMatrixIDPrefix. apispec must still\nemit apiKeyAuth — the unrelated TrimPrefix on \"@\" must NOT contaminate\nauth detection. Regression test for the v0.4.12 false-positive.",
+        "operationId": "security_bearer.matrixUserHandler",
+        "parameters": [
+          {
+            "name": "user",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/security_bearer.ProtectedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/open/ping": {
       "get": {
         "summary": "openPing has no auth and must not be associated with any security scheme.",

--- a/testdata/security_bearer/expected_openapi_legacy.json
+++ b/testdata/security_bearer/expected_openapi_legacy.json
@@ -21,7 +21,7 @@
         "parameters": [
           {
             "name": "user",
-            "in": "header",
+            "in": "query",
             "schema": {
               "type": "string"
             }

--- a/testdata/security_bearer/expected_openapi_legacy.json
+++ b/testdata/security_bearer/expected_openapi_legacy.json
@@ -13,6 +13,49 @@
     }
   },
   "paths": {
+    "/matrix/user": {
+      "post": {
+        "summary": "matrixUserHandler reads Authorization (no scheme prefix → apiKey) AND\nprocesses a Matrix user ID via stripMatrixIDPrefix.",
+        "description": "matrixUserHandler reads Authorization (no scheme prefix → apiKey) AND\nprocesses a Matrix user ID via stripMatrixIDPrefix. apispec must still\nemit apiKeyAuth — the unrelated TrimPrefix on \"@\" must NOT contaminate\nauth detection. Regression test for the v0.4.12 false-positive.",
+        "operationId": "security_bearer.matrixUserHandler",
+        "parameters": [
+          {
+            "name": "user",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/security_bearer.ProtectedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/open/ping": {
       "get": {
         "summary": "openPing has no auth and must not be associated with any security scheme.",

--- a/testdata/security_bearer/main.go
+++ b/testdata/security_bearer/main.go
@@ -22,8 +22,35 @@ func main() {
 	mux.HandleFunc("POST /protected/inline", protectedInline)
 	mux.HandleFunc("POST /protected/basic", protectedBasic)
 	mux.HandleFunc("POST /protected/apikey", protectedAPIKey)
+	mux.HandleFunc("POST /matrix/user", matrixUserHandler)
 	mux.HandleFunc("GET /open/ping", openPing)
 	http.ListenAndServe(":3000", mux)
+}
+
+// stripMatrixIDPrefix is a Matrix-specific helper that has NOTHING to do with
+// HTTP auth — Matrix user IDs start with "@" (e.g. "@alice:example.com") and
+// some flows want them stripped. It's the kind of unrelated TrimPrefix that
+// previously poisoned auth detection: the BFS would find this and misclassify
+// the handler's auth as scheme "@".
+func stripMatrixIDPrefix(userID string) string {
+	return strings.TrimPrefix(userID, "@")
+}
+
+// matrixUserHandler reads Authorization (no scheme prefix → apiKey) AND
+// processes a Matrix user ID via stripMatrixIDPrefix. apispec must still
+// emit apiKeyAuth — the unrelated TrimPrefix on "@" must NOT contaminate
+// auth detection. Regression test for the v0.4.12 false-positive.
+func matrixUserHandler(w http.ResponseWriter, r *http.Request) {
+	token := r.Header.Get("Authorization")
+	if token == "" {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	// Unrelated to auth — Matrix user ID processing happens here.
+	userID := stripMatrixIDPrefix(r.URL.Query().Get("user"))
+	_ = userID
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ProtectedResponse{OK: true})
 }
 
 // PingResponse is the trivial success payload for /open/ping.


### PR DESCRIPTION
User report against v0.4.12 (testing alkem-io/matrix-adapter-go): the security-scheme detector emitted a bogus `@Auth` entry with `scheme: @`.

## Root cause

The detector treated **any** `strings.TrimPrefix` call reachable from the handler's call graph as the auth-scheme signal. Matrix codebases have helpers like `strings.TrimPrefix(userID, "@")` for stripping Matrix-ID prefixes (e.g. `@alice:example.com`) — the BFS picked that up and labelled it the auth scheme.

## Fix

Only accept a `TrimPrefix` as the auth signal when its first argument traces back to the Authorization-header read:

- **Ident** matching a variable assigned from `r.Header.Get("Authorization")` — tracked via the edge's `CalleeRecvVarName`. Covers the common
  ```go
  header := r.Header.Get("Authorization")
  token := strings.TrimPrefix(header, "Bearer ")
  ```
  idiom.
- **Inline call** that itself reads `r.Header.Get("Authorization")` — covers
  ```go
  token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
  ```
  where there's no intermediate variable.

Any other shape (different ident, literal, unrelated call) is ignored. The header-read counter still fires, so the apiKey-style fallback still triggers for handlers that read the header without trimming a recognised prefix.

## Fixture

Added `/matrix/user` to `testdata/security_bearer/` that reproduces the exact reporter shape — `r.Header.Get("Authorization")` (no trim) plus a separate `strings.TrimPrefix(userID, "@")` via a helper. Without the fix it produces `@Auth`; with the fix it correctly resolves to `apiKeyAuth`.

## Tests

- New `TestDetectSecuritySchemeFromHandler_UnrelatedTrimPrefix_DoesNotPoison` locks the regression at the unit level.
- 8 new unit tests on `trimPrefixOnAuthVar` and `isInlineAuthHeaderCall` covering: ident-match, ident-miss, KindCall happy-path, fallback receiver-type field, wrong header name, wrong method, wrong receiver type, non-selector Fun, no-args, nil arg.
- `TestE2E_SecurityBearer_AllSchemesAndSuppression` extended with an explicit `expectScheme(t, "/matrix/user", "apiKeyAuth")` plus a `NotContains "@Auth"` assertion.
- Golden file regenerated to include the new endpoint.

## Coverage

`trimPrefixOnAuthVar`, `isInlineAuthHeaderCall`, `walkCallersForAuthPrefix` all at **100%** per function.

## Test plan
- [x] `go test ./...` — green
- [x] `make lint` — clean
- [x] Bug reproduced in fixture before the fix; fixed by the patch