### PR TITLE
fix: filter helper-internal error-fallback writes from caller schemas (#27)

### DIFF
--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -53,6 +53,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
 		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 		{name: "security_bearer", inputDir: "../../testdata/security_bearer", configFn: spec.DefaultHTTPConfig},
+		{name: "writejson_helper", inputDir: "../../testdata/writejson_helper", configFn: spec.DefaultHTTPConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {

--- a/internal/metadata/cfg.go
+++ b/internal/metadata/cfg.go
@@ -49,6 +49,12 @@ func BuildFunctionCFGs(funcDecls []*ast.FuncDecl, fset *token.FileSet, meta *Met
 
 // buildEdgePositionIndex creates a map from source position string to
 // CallGraphEdge pointers for fast lookup during CFG annotation.
+//
+// Edge positions are stored via getPosition() which strips the repo-root
+// prefix when one is set (see SetRepoRoot). CFG-side lookups use
+// fset.Position(...).String() directly and would miss every edge unless we
+// store both forms in the index — silently disabling all branch annotation
+// (issue #27 was an instance of this mismatch).
 func buildEdgePositionIndex(meta *Metadata, _ *token.FileSet) map[string]*CallGraphEdge {
 	index := make(map[string]*CallGraphEdge, len(meta.CallGraph))
 	for i := range meta.CallGraph {
@@ -56,13 +62,17 @@ func buildEdgePositionIndex(meta *Metadata, _ *token.FileSet) map[string]*CallGr
 		pos := meta.StringPool.GetString(edge.Position)
 		if pos != "" {
 			index[pos] = edge
+			if repoRoot != "" {
+				index[repoRoot+pos] = edge
+			}
 		}
 	}
 	return index
 }
 
 // buildAssignmentPositionIndex creates a map from source position string to
-// Assignment pointers across all call graph edges.
+// Assignment pointers across all call graph edges. Mirrors
+// buildEdgePositionIndex's repoRoot-stripped + raw double-keying.
 func buildAssignmentPositionIndex(meta *Metadata, _ *token.FileSet) map[string]*Assignment {
 	index := make(map[string]*Assignment)
 	for i := range meta.CallGraph {
@@ -72,6 +82,9 @@ func buildAssignmentPositionIndex(meta *Metadata, _ *token.FileSet) map[string]*
 				pos := meta.StringPool.GetString(assign.Position)
 				if pos != "" {
 					index[pos] = assign
+					if repoRoot != "" {
+						index[repoRoot+pos] = assign
+					}
 				}
 			}
 		}
@@ -111,16 +124,25 @@ func annotateBranches(graph *cfg.CFG, fset *token.FileSet, meta *Metadata,
 			ctx.CaseValues = extractCaseValues(block.Stmt)
 		}
 
-		// Walk all AST nodes in this block and tag matching edges/assignments
+		// Walk all AST nodes in this block and tag matching edges/assignments.
+		// block.Nodes are statement-level; the position of an AssignStmt like
+		// `_, _ = w.Write(...)` is the underscore, while the call edge is
+		// indexed at the inner CallExpr's position. Descend into every node
+		// so each inner CallExpr/AssignStmt gets a chance to match.
 		for _, node := range block.Nodes {
-			pos := fset.Position(node.Pos()).String()
-
-			if edge, ok := edgesByPos[pos]; ok {
-				edge.Branch = ctx
-			}
-			if assign, ok := assignsByPos[pos]; ok {
-				assign.Branch = ctx
-			}
+			ast.Inspect(node, func(n ast.Node) bool {
+				if n == nil {
+					return false
+				}
+				pos := fset.Position(n.Pos()).String()
+				if edge, ok := edgesByPos[pos]; ok {
+					edge.Branch = ctx
+				}
+				if assign, ok := assignsByPos[pos]; ok {
+					assign.Branch = ctx
+				}
+				return true
+			})
 		}
 	}
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -945,12 +945,41 @@ func (e *Extractor) resolveArgToStatusCode(arg *metadata.CallArgument) (int, boo
 // functions called multiple times with different status codes. For each group,
 // it creates additional responses for status codes not captured by the primary
 // response extraction (which deduplicates by Callee.ID).
-func (e *Extractor) expandHelperFunctionResponses(routeNode TrackerNodeInterface, route *RouteInfo) {
+//
+//nolint:gocyclo // helper expansion fans out: filter → seed → param-infer → schema fill
+func (e *Extractor) expandHelperFunctionResponses(routeNode TrackerNodeInterface, route *RouteInfo, fallbackEdges map[string]bool) {
 	groups := e.collectHelperCallGroups(routeNode)
 
 	for _, calls := range groups {
 		if len(calls) < 2 {
 			continue
+		}
+		// Strip fallback edges (issue #27): edges flagged by
+		// helperFallbackEdges represent helper-internal error branches whose
+		// statuses must not propagate to the caller. Only swap in `filtered`
+		// when the scanner actually removed something — that way groups the
+		// scanner never touched keep their original shape (and we don't
+		// accidentally drop legitimate multi-branch handler patterns like
+		// three `c.JSON(400, ...)` returns in if/else if/else, which never
+		// get classified by helperFallbackEdges in the first place because
+		// the route node and response primitives are skipped).
+		//
+		// After filtering, fall back to the standard `len(calls) < 2` skip:
+		// a group whose survivors are all fallbacks (filtered=0) or down to
+		// one straggler has no quorum to drive expansion.
+		if len(fallbackEdges) > 0 {
+			filtered := calls[:0:0]
+			for _, c := range calls {
+				if !fallbackEdges[c.edge.Callee.ID()] {
+					filtered = append(filtered, c)
+				}
+			}
+			if len(filtered) < len(calls) {
+				calls = filtered
+				if len(calls) < 2 {
+					continue
+				}
+			}
 		}
 
 		// Only expand helpers that actually contain response-writing calls
@@ -961,8 +990,18 @@ func (e *Extractor) expandHelperFunctionResponses(routeNode TrackerNodeInterface
 		}
 
 		statusParam, baseSchema, contentType := e.findStatusParamAndSchema(calls, route)
-		if statusParam == "" || baseSchema == nil {
-			continue
+		if statusParam == "" {
+			// No existing seed — fall back to inferring the status parameter
+			// directly from the call signatures so we can still populate
+			// schemas for helpers whose primary-pass extraction was skipped
+			// (e.g., WriteJSON-with-builtin-body — see issue #27).
+			statusParam = e.inferStatusParamFromCalls(calls)
+			if statusParam == "" {
+				continue
+			}
+		}
+		if contentType == "" {
+			contentType = e.cfg.Defaults.ResponseContentType
 		}
 
 		// Find the "body" parameter name — the one whose argument resolved to the
@@ -976,28 +1015,36 @@ func (e *Extractor) expandHelperFunctionResponses(routeNode TrackerNodeInterface
 			}
 			if status, ok := e.resolveArgToStatusCode(&arg); ok {
 				key := fmt.Sprintf("%d", status)
-				if _, exists := route.Response[key]; !exists {
-					// Resolve this call's body type from its own ParamArgMap.
-					// If the body parameter carries a different type per call
-					// (e.g., respondJSON(w, 200, user) vs respondJSON(w, 400, err)),
-					// each sibling gets its own schema.
-					schema := baseSchema
-					if bodyParam != "" {
-						if bodyArg, ok := call.edge.ParamArgMap[bodyParam]; ok {
-							bodyType := e.contextProvider.GetArgumentInfo(&bodyArg)
-							if bodyType != "" && bodyType != "interface{}" && bodyType != "any" {
-								if s, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, e.cfg, nil); s != nil {
-									schema = s
-								}
+				// Fill in: either the status code has no entry yet, or the
+				// entry was registered by a WriteHeader pass without a body
+				// (e.g., a helper writes `WriteHeader(status); Write(derived)`
+				// and the derived body bottoms out at an unresolvable builtin
+				// — see issue #27). For schema-less existing entries we still
+				// need to populate the schema from the caller's body arg.
+				existing, exists := route.Response[key]
+				if exists && existing.Schema != nil {
+					continue
+				}
+				// Resolve this call's body type from its own ParamArgMap.
+				// If the body parameter carries a different type per call
+				// (e.g., respondJSON(w, 200, user) vs respondJSON(w, 400, err)),
+				// each sibling gets its own schema.
+				schema := baseSchema
+				if bodyParam != "" {
+					if bodyArg, ok := call.edge.ParamArgMap[bodyParam]; ok {
+						bodyType := e.contextProvider.GetArgumentInfo(&bodyArg)
+						if bodyType != "" && bodyType != "interface{}" && bodyType != "any" {
+							if s, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, e.cfg, nil); s != nil {
+								schema = s
 							}
 						}
 					}
-					e.addResponse(route, &ResponseInfo{
-						StatusCode:  status,
-						ContentType: contentType,
-						Schema:      schema,
-					})
 				}
+				e.addResponse(route, &ResponseInfo{
+					StatusCode:  status,
+					ContentType: contentType,
+					Schema:      schema,
+				})
 			}
 		}
 	}
@@ -1020,6 +1067,22 @@ func (e *Extractor) collectHelperCallGroups(routeNode TrackerNodeInterface) map[
 	}
 	collect(routeNode)
 	return groups
+}
+
+// inferStatusParamFromCalls picks the helper parameter whose arguments resolve
+// to HTTP status codes across the call group, without relying on an existing
+// route.Response entry. Used as a fallback when the primary response pass did
+// not seed a schema for any of the helper's status codes (see issue #27 — a
+// WriteJSON helper whose body argument is a builtin call like `append`).
+func (e *Extractor) inferStatusParamFromCalls(calls []helperCall) string {
+	for _, call := range calls {
+		for pName, arg := range call.edge.ParamArgMap {
+			if _, ok := e.resolveArgToStatusCode(&arg); ok {
+				return pName
+			}
+		}
+	}
+	return ""
 }
 
 // findStatusParamAndSchema finds which parameter in a group of helper calls
@@ -1079,9 +1142,116 @@ func (e *Extractor) helperContainsResponsePattern(helperNode TrackerNodeInterfac
 	return false
 }
 
+// helperFallbackEdges identifies response-writing edges that live inside an
+// error-fallback branch of a helper function whose primary write path is
+// unconditional. The classic shape is:
+//
+//	func WriteJSON(w, status, v) {
+//	    data, err := json.Marshal(v)
+//	    if err != nil {
+//	        w.WriteHeader(500)                                 // ← Branch=if-then
+//	        w.Write([]byte(`{"error":"..."}`))                 // ← Branch=if-then
+//	        return
+//	    }
+//	    w.WriteHeader(status)                                  // ← Branch=nil
+//	    w.Write(append(data, '\n'))                            // ← Branch=nil
+//	}
+//
+// The if-then writes are defensive — they fire only if json.Marshal fails,
+// which is unreachable for the struct/map payloads the caller actually passes.
+// Without this filter the caller's response set gets contaminated with the
+// fallback's hardcoded 500 and literal []byte body (issue #27).
+//
+// The rule is intentionally narrow: only filter when the SAME helper exposes
+// at least one unconditional response-writing edge. A helper made entirely of
+// branched writes (e.g., if/else returning different statuses) keeps all of
+// its writes — none of them is a "primary" path to compare against.
+//
+// Returned set is keyed by edge ID (the same ID used for visitedEdges).
+func (e *Extractor) helperFallbackEdges(routeNode TrackerNodeInterface) map[string]bool {
+	fallback := make(map[string]bool)
+	if routeNode == nil {
+		return fallback
+	}
+
+	var visit func(node TrackerNodeInterface, isRoot bool)
+	visit = func(node TrackerNodeInterface, isRoot bool) {
+		children := node.GetChildren()
+		// A node represents a USER-DEFINED helper invocation when:
+		//   1. it is not the route node itself (whose children are the
+		//      handler's body — branches there are legitimate control flow,
+		//      not internal fallback logic), AND
+		//   2. its edge carries a ParamArgMap (the call passed bound arguments
+		//      through to the callee's parameters), AND
+		//   3. the call itself is not a response-pattern primitive (Status,
+		//      JSON, WriteHeader, …). For chained calls like
+		//      `c.Status(400).JSON(map)`, the Status node may have the JSON
+		//      node as a child; treating Status as a helper would
+		//      mis-classify legitimate handler branches as fallbacks.
+		isHelperInvocation := false
+		if !isRoot {
+			if edge := node.GetEdge(); edge != nil && len(edge.ParamArgMap) > 0 {
+				nodeIsResponsePrimitive := false
+				for _, m := range e.responseMatchers {
+					if m.MatchNode(node) {
+						nodeIsResponsePrimitive = true
+						break
+					}
+				}
+				if !nodeIsResponsePrimitive {
+					isHelperInvocation = true
+				}
+			}
+		}
+
+		if isHelperInvocation {
+			var unconditional bool
+			var conditionalIDs []string
+			for _, child := range children {
+				childEdge := child.GetEdge()
+				if childEdge == nil {
+					continue
+				}
+				matched := false
+				for _, m := range e.responseMatchers {
+					if m.MatchNode(child) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					continue
+				}
+				if childEdge.Branch == nil {
+					unconditional = true
+				} else {
+					conditionalIDs = append(conditionalIDs, childEdge.Callee.ID())
+				}
+			}
+			if unconditional {
+				for _, id := range conditionalIDs {
+					fallback[id] = true
+				}
+			}
+		}
+
+		for _, child := range children {
+			visit(child, false)
+		}
+	}
+	visit(routeNode, true)
+	return fallback
+}
+
 // extractRouteChildren extracts request, response, and params from children nodes
 // using the unified visitor with registered callbacks.
 func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *RouteInfo, mountTags []string, routes *[]*RouteInfo, visitedEdges map[string]bool) {
+	// Identify response-writing edges inside defensive error-fallback branches
+	// of helpers that also expose an unconditional write path. These edges
+	// must not contribute to the caller's response schema — see issue #27 and
+	// helperFallbackEdges for the exact rule.
+	fallbackEdges := e.helperFallbackEdges(routeNode)
+
 	callbacks := []ExtractionCallback{
 		// Route-in-route detection
 		func(node TrackerNodeInterface, route *RouteInfo) {
@@ -1104,6 +1274,9 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 		},
 		// Response extraction with schema merging
 		func(node TrackerNodeInterface, route *RouteInfo) {
+			if edge := node.GetEdge(); edge != nil && fallbackEdges[edge.Callee.ID()] {
+				return
+			}
 			resp := e.extractResponseFromNode(node, route, visitedEdges)
 			if resp == nil || (resp.BodyType == "" && resp.StatusCode == 0) {
 				return
@@ -1129,8 +1302,11 @@ func (e *Extractor) extractRouteChildren(routeNode TrackerNodeInterface, route *
 	// times with different status codes (e.g., writeJSONError(w, 400, ...) and
 	// writeJSONError(w, 404, ...)), the dedup in extractResponseFromNode only
 	// processes one call's WriteHeader/Encode. This post-pass creates responses
-	// for the other calls using the schema from the processed one.
-	e.expandHelperFunctionResponses(routeNode, route)
+	// for the other calls using the schema from the processed one. Helper
+	// fallback edges (issue #27) are excluded so that a hardcoded
+	// `WriteHeader(500)` inside `if err != nil { ... }` does not get expanded
+	// into a phantom 500 response on every caller.
+	e.expandHelperFunctionResponses(routeNode, route, fallbackEdges)
 
 	// Extract parameters from the route node itself
 	if param := e.extractParamFromNode(routeNode, route); param != nil {
@@ -1464,6 +1640,17 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 			if concreteType := r.resolveParamArgType(node, arg.GetName()); concreteType != "" {
 				bodyType = concreteType
 			}
+		}
+
+		// go/types stores `Typ[Invalid].String() == "invalid type"` for things
+		// it cannot resolve to a concrete type — most often a builtin like
+		// `append`, `len`, `copy`, `make`, or an untyped constant. A body
+		// expression that bottoms out at this sentinel cannot produce a useful
+		// schema and must not fabricate a `$ref` to a non-existent schema name.
+		// Clear bodyType so expandHelperFunctionResponses can fill the schema
+		// in from the caller's ParamArgMap arg instead (issue #27).
+		if strings.Contains(bodyType, "invalid type") {
+			bodyType = ""
 		}
 
 		respInfo.BodyType = preprocessingBodyType(bodyType)

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1074,9 +1074,14 @@ func (e *Extractor) collectHelperCallGroups(routeNode TrackerNodeInterface) map[
 // route.Response entry. Used as a fallback when the primary response pass did
 // not seed a schema for any of the helper's status codes (see issue #27 — a
 // WriteJSON helper whose body argument is a builtin call like `append`).
+//
+// Parameter names are visited in sorted order so that helpers with multiple
+// status-typed parameters yield the same pick across runs — same reasoning
+// as the disambiguateOperationIDs determinism fix below.
 func (e *Extractor) inferStatusParamFromCalls(calls []helperCall) string {
 	for _, call := range calls {
-		for pName, arg := range call.edge.ParamArgMap {
+		for _, pName := range slices.Sorted(maps.Keys(call.edge.ParamArgMap)) {
+			arg := call.edge.ParamArgMap[pName]
 			if _, ok := e.resolveArgToStatusCode(&arg); ok {
 				return pName
 			}

--- a/internal/spec/extractor_helper_test.go
+++ b/internal/spec/extractor_helper_test.go
@@ -894,7 +894,7 @@ func TestExpandHelperFunctionResponses_AddsNewResponses(t *testing.T) {
 		Metadata:  meta,
 	}
 
-	ext.expandHelperFunctionResponses(routeNode, route)
+	ext.expandHelperFunctionResponses(routeNode, route, nil)
 
 	// Should have added a 400 response
 	assert.Contains(t, route.Response, "400")
@@ -927,7 +927,7 @@ func TestExpandHelperFunctionResponses_SkipsSingleCall(t *testing.T) {
 	}
 
 	initialCount := len(route.Response)
-	ext.expandHelperFunctionResponses(routeNode, route)
+	ext.expandHelperFunctionResponses(routeNode, route, nil)
 	assert.Equal(t, initialCount, len(route.Response), "should not add responses for single-call groups")
 }
 
@@ -968,7 +968,7 @@ func TestExpandHelperFunctionResponses_SkipsExistingStatus(t *testing.T) {
 	}
 
 	initialCount := len(route.Response)
-	ext.expandHelperFunctionResponses(routeNode, route)
+	ext.expandHelperFunctionResponses(routeNode, route, nil)
 	assert.Equal(t, initialCount, len(route.Response), "should not overwrite existing responses")
 }
 
@@ -982,7 +982,7 @@ func TestExpandHelperFunctionResponses_NoChildren(t *testing.T) {
 		Metadata: meta,
 	}
 
-	ext.expandHelperFunctionResponses(routeNode, route)
+	ext.expandHelperFunctionResponses(routeNode, route, nil)
 	assert.Empty(t, route.Response)
 }
 
@@ -1016,6 +1016,417 @@ func TestExpandHelperFunctionResponses_NoStatusParamFound(t *testing.T) {
 		Metadata: meta,
 	}
 
-	ext.expandHelperFunctionResponses(routeNode, route)
+	ext.expandHelperFunctionResponses(routeNode, route, nil)
 	assert.Empty(t, route.Response)
+}
+
+// ===========================================================================
+// 8. inferStatusParamFromCalls (issue #27 fallback path)
+// ===========================================================================
+
+func TestInferStatusParamFromCalls_PicksStatusArg(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	bodyArg := makeCallArg(meta)
+	bodyArg.SetKind(metadata.KindIdent)
+	bodyArg.SetName("v")
+	bodyArg.SetType("interface{}")
+
+	edge := makeHelperEdge(meta, "WriteJSON", "helpers", map[string]metadata.CallArgument{
+		"w":      {Meta: meta},
+		"status": makeSelectorArg(meta, "net/http", "http", "StatusCreated"),
+		"v":      *bodyArg,
+	})
+	calls := []helperCall{{node: &TrackerNode{key: "c1", CallGraphEdge: &edge}, edge: &edge}}
+
+	got := ext.inferStatusParamFromCalls(calls)
+	assert.Equal(t, "status", got)
+}
+
+func TestInferStatusParamFromCalls_NoStatusArg(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	dataArg := makeCallArg(meta)
+	dataArg.SetKind(metadata.KindIdent)
+	dataArg.SetName("payload")
+	dataArg.SetType("User")
+	dataArg.SetPkg("models")
+
+	edge := makeHelperEdge(meta, "Send", "helpers", map[string]metadata.CallArgument{
+		"data": *dataArg,
+	})
+	calls := []helperCall{{node: &TrackerNode{key: "c1", CallGraphEdge: &edge}, edge: &edge}}
+
+	got := ext.inferStatusParamFromCalls(calls)
+	assert.Empty(t, got)
+}
+
+// ===========================================================================
+// 9. helperFallbackEdges (issue #27 — defensive write filter)
+// ===========================================================================
+
+// fallbackTestRig builds a route → WriteJSON helper tree where the helper has
+// both an unconditional WriteHeader (status param) and a conditional
+// WriteHeader(500) inside an `if err != nil { ... }` branch. Returns the
+// route node and the conditional edge for assertions.
+func fallbackTestRig(meta *metadata.Metadata) (*TrackerNode, *metadata.CallGraphEdge) {
+	condWHEdge := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta:     meta,
+			Name:     meta.StringPool.Get("WriteHeader"),
+			Pkg:      meta.StringPool.Get("net/http"),
+			RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("file.go:10:5"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-then"},
+	}
+	succWHEdge := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta:     meta,
+			Name:     meta.StringPool.Get("WriteHeader"),
+			Pkg:      meta.StringPool.Get("net/http"),
+			RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("file.go:20:5"),
+		},
+	}
+
+	helperEdge := makeHelperEdge(meta, "WriteJSON", "helpers", map[string]metadata.CallArgument{
+		"status": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+	})
+	helperNode := &TrackerNode{
+		key:           "helper",
+		CallGraphEdge: &helperEdge,
+		Children: []*TrackerNode{
+			{key: "wh-cond", CallGraphEdge: condWHEdge},
+			{key: "wh-succ", CallGraphEdge: succWHEdge},
+		},
+	}
+	routeNode := &TrackerNode{
+		key:      "route",
+		Children: []*TrackerNode{helperNode},
+	}
+	return routeNode, condWHEdge
+}
+
+func TestHelperFallbackEdges_FlagsConditionalWhenUnconditionalExists(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+	routeNode, condEdge := fallbackTestRig(meta)
+
+	fallback := ext.helperFallbackEdges(routeNode)
+	assert.True(t, fallback[condEdge.Callee.ID()],
+		"conditional write inside a helper that also has an unconditional write must be flagged as a fallback")
+}
+
+func TestHelperFallbackEdges_NoUnconditional_KeepsAll(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	condWH1 := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("WriteHeader"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("f.go:1:1"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-then"},
+	}
+	condWH2 := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("WriteHeader"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("f.go:2:1"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-else"},
+	}
+	helperEdge := makeHelperEdge(meta, "WriteEither", "helpers", map[string]metadata.CallArgument{
+		"x": {Meta: meta},
+	})
+	helperNode := &TrackerNode{
+		key:           "helper",
+		CallGraphEdge: &helperEdge,
+		Children: []*TrackerNode{
+			{key: "a", CallGraphEdge: condWH1},
+			{key: "b", CallGraphEdge: condWH2},
+		},
+	}
+	routeNode := &TrackerNode{key: "route", Children: []*TrackerNode{helperNode}}
+
+	fallback := ext.helperFallbackEdges(routeNode)
+	assert.Empty(t, fallback, "no unconditional write → nothing to flag")
+}
+
+func TestHelperFallbackEdges_SkipsRouteNode(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	cond := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("WriteHeader"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("h.go:1:1"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-then"},
+	}
+	uncond := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("WriteHeader"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("h.go:2:1"),
+		},
+	}
+	routeOwnEdge := makeHelperEdge(meta, "HandleFunc", "net/http", map[string]metadata.CallArgument{
+		"path": {Meta: meta},
+	})
+	routeNode := &TrackerNode{
+		key:           "route",
+		CallGraphEdge: &routeOwnEdge,
+		Children: []*TrackerNode{
+			{key: "c", CallGraphEdge: cond},
+			{key: "u", CallGraphEdge: uncond},
+		},
+	}
+
+	fallback := ext.helperFallbackEdges(routeNode)
+	assert.Empty(t, fallback,
+		"branches at the route level are handler control flow, not fallbacks — must not flag")
+}
+
+func TestHelperFallbackEdges_SkipsResponsePrimitives(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	statusEdge := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta:     meta,
+			Name:     meta.StringPool.Get("WriteHeader"),
+			Pkg:      meta.StringPool.Get("net/http"),
+			RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("p.go:1:1"),
+		},
+		ParamArgMap: map[string]metadata.CallArgument{
+			"statusCode": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+		},
+	}
+
+	condChild := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("Write"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("p.go:2:1"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-then"},
+	}
+	uncondChild := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("Write"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("p.go:3:1"),
+		},
+	}
+	primitive := &TrackerNode{
+		key:           "primitive",
+		CallGraphEdge: statusEdge,
+		Children: []*TrackerNode{
+			{key: "wc", CallGraphEdge: condChild},
+			{key: "wu", CallGraphEdge: uncondChild},
+		},
+	}
+	routeNode := &TrackerNode{key: "route", Children: []*TrackerNode{primitive}}
+
+	fallback := ext.helperFallbackEdges(routeNode)
+	assert.Empty(t, fallback,
+		"response-pattern primitives are not user-defined helpers — must not classify their children")
+}
+
+func TestHelperFallbackEdges_NilRoute(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+	assert.Empty(t, ext.helperFallbackEdges(nil))
+}
+
+// ===========================================================================
+// 10. expandHelperFunctionResponses — inferStatusParam fallback (issue #27)
+// ===========================================================================
+
+// When the primary response pass skipped a helper's status (the body
+// argument bottomed out at "invalid type" so the schema seed is missing),
+// expandHelperFunctionResponses must still populate per-status schemas from
+// each call's caller arg via the inferStatusParamFromCalls fallback path.
+func TestExpandHelperFunctionResponses_InferStatusParamFromCalls(t *testing.T) {
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	bodyArg1 := makeCallArg(meta)
+	bodyArg1.SetKind(metadata.KindIdent)
+	bodyArg1.SetName("user")
+	bodyArg1.SetType("User")
+	bodyArg1.SetPkg("models")
+
+	bodyArg2 := makeCallArg(meta)
+	bodyArg2.SetKind(metadata.KindIdent)
+	bodyArg2.SetName("errResp")
+	bodyArg2.SetType("ErrorResponse")
+	bodyArg2.SetPkg("models")
+
+	edge1 := makeHelperEdge(meta, "WriteJSON", "helpers", map[string]metadata.CallArgument{
+		"status": makeSelectorArg(meta, "net/http", "http", "StatusOK"),
+		"v":      *bodyArg1,
+	})
+	edge2 := makeHelperEdge(meta, "WriteJSON", "helpers", map[string]metadata.CallArgument{
+		"status": makeSelectorArg(meta, "net/http", "http", "StatusBadRequest"),
+		"v":      *bodyArg2,
+	})
+
+	// Helper must contain a response-pattern child for the expansion to fire.
+	writeHeaderEdge := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta:     meta,
+			Name:     meta.StringPool.Get("WriteHeader"),
+			Pkg:      meta.StringPool.Get("net/http"),
+			RecvType: meta.StringPool.Get("ResponseWriter"),
+		},
+	}
+	whChild := &TrackerNode{key: "wh", CallGraphEdge: writeHeaderEdge}
+
+	routeNode := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "c1", CallGraphEdge: &edge1, Children: []*TrackerNode{whChild}},
+			{key: "c2", CallGraphEdge: &edge2, Children: []*TrackerNode{whChild}},
+		},
+	}
+
+	// route.Response intentionally EMPTY — primary pass found nothing to seed.
+	route := &RouteInfo{
+		Response:  map[string]*ResponseInfo{},
+		UsedTypes: map[string]*Schema{},
+		Metadata:  meta,
+	}
+
+	ext.expandHelperFunctionResponses(routeNode, route, nil)
+
+	// Both status codes should now be populated from per-call body args.
+	assert.Contains(t, route.Response, "200",
+		"200 should be filled from caller's user arg via inferStatusParamFromCalls fallback")
+	assert.Contains(t, route.Response, "400",
+		"400 should be filled from caller's errResp arg via inferStatusParamFromCalls fallback")
+	if r := route.Response["200"]; r != nil {
+		assert.NotEmpty(t, r.ContentType,
+			"contentType must fall back to defaults when no seed exists")
+	}
+}
+
+// ===========================================================================
+// 11. expandHelperFunctionResponses — fallback edge filter (issue #27)
+// ===========================================================================
+
+func TestExpandHelperFunctionResponses_FallbackEdgesFiltered(t *testing.T) {
+	// A WriteHeader "helper" group containing only fallback (if-then) edges
+	// should not synthesize a phantom response on the caller.
+	meta := newTestMeta()
+	ext, _ := newTestExtractor(meta)
+
+	fallback500Edge := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("WriteHeader"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("h.go:10:5"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-then"},
+		ParamArgMap: map[string]metadata.CallArgument{
+			"statusCode": makeSelectorArg(meta, "net/http", "http", "StatusInternalServerError"),
+		},
+	}
+	fallback500Edge2 := &metadata.CallGraphEdge{
+		Callee: metadata.Call{
+			Meta: meta, Name: meta.StringPool.Get("WriteHeader"),
+			Pkg: meta.StringPool.Get("net/http"), RecvType: meta.StringPool.Get("ResponseWriter"),
+			Position: meta.StringPool.Get("h.go:11:5"),
+		},
+		Branch: &metadata.BranchContext{BlockKind: "if-then"},
+		ParamArgMap: map[string]metadata.CallArgument{
+			"statusCode": makeSelectorArg(meta, "net/http", "http", "StatusInternalServerError"),
+		},
+	}
+
+	routeNode := &TrackerNode{
+		key: "route",
+		Children: []*TrackerNode{
+			{key: "wh1", CallGraphEdge: fallback500Edge, Children: []*TrackerNode{
+				{key: "wh1-child", CallGraphEdge: fallback500Edge},
+			}},
+			{key: "wh2", CallGraphEdge: fallback500Edge2, Children: []*TrackerNode{
+				{key: "wh2-child", CallGraphEdge: fallback500Edge2},
+			}},
+		},
+	}
+	route := &RouteInfo{Response: map[string]*ResponseInfo{}, Metadata: meta}
+	fbEdges := map[string]bool{
+		fallback500Edge.Callee.ID():  true,
+		fallback500Edge2.Callee.ID(): true,
+	}
+
+	ext.expandHelperFunctionResponses(routeNode, route, fbEdges)
+	_, has500 := route.Response["500"]
+	assert.False(t, has500, "all calls in the group were filtered as fallback edges — must NOT add 500")
+}
+
+// ===========================================================================
+// 12. ExtractResponse — "invalid type" sentinel detection (issue #27)
+// ===========================================================================
+
+// When the body argument's resolved type bottoms out at go/types' "invalid
+// type" sentinel (e.g., `Write(append(data, '\n'))` where `append` is a
+// builtin without a defined type), ExtractResponse must clear the body type
+// so it can't fabricate a `$ref` to a non-existent schema name and so
+// expandHelperFunctionResponses can fill the schema from the caller's
+// ParamArgMap arg instead.
+func TestExtractResponse_InvalidTypeSentinel_ClearsBody(t *testing.T) {
+	meta := newTestMeta()
+
+	// Argument that mimics go/types' fallback for an unresolvable builtin:
+	// a KindCall arg whose name string contains "invalid type".
+	bodyArg := metadata.NewCallArgument(meta)
+	bodyArg.SetKind(metadata.KindCall)
+	bodyArg.SetName("invalid type")
+	bodyArg.SetPkg("mypkg")
+	// arg.Fun is required so callArgToString doesn't bail to "call(...)".
+	funArg := metadata.NewCallArgument(meta)
+	funArg.SetKind(metadata.KindIdent)
+	funArg.SetName("append")
+	bodyArg.Fun = funArg
+
+	edge := makeEdge(meta, "handler", "main", "Write", "http", []*metadata.CallArgument{bodyArg})
+	node := makeTrackerNode(&edge)
+
+	cfg := &APISpecConfig{
+		Defaults: Defaults{ResponseContentType: "application/json"},
+	}
+	contextProvider := NewContextProvider(meta)
+	schemaMapper := NewSchemaMapper(cfg)
+
+	pattern := ResponsePattern{
+		DefaultStatus: 200,
+		TypeFromArg:   true,
+		TypeArgIndex:  0,
+	}
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			contextProvider: contextProvider,
+			cfg:             cfg,
+			schemaMapper:    schemaMapper,
+		},
+		pattern: pattern,
+	}
+
+	route := NewRouteInfo()
+	route.Metadata = meta
+	resp := matcher.ExtractResponse(node, route)
+
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.BodyType,
+		"`invalid type` sentinel must clear bodyType — otherwise a `$ref` to "+
+			"`<pkg>.invalid-type` would leak into the spec (issue #27)")
 }

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -156,12 +156,28 @@ func disambiguateOperationIDs(paths map[string]PathItem, routes []*RouteInfo) {
 	}
 
 	idRefs := make(map[string][]opRef)
-	for pathStr, pathItem := range paths {
-		for method, op := range map[string]*Operation{
-			"GET": pathItem.Get, "POST": pathItem.Post, "PUT": pathItem.Put,
-			"DELETE": pathItem.Delete, "PATCH": pathItem.Patch, "OPTIONS": pathItem.Options,
-			"HEAD": pathItem.Head,
-		} {
+	// Iterate paths and methods in deterministic order — without this, the
+	// disambiguation result for two operations that share an operationId
+	// (e.g., GET and POST split off the same handler by switch r.Method)
+	// flips between runs depending on Go's randomized map iteration, which
+	// then trips the determinism test.
+	sortedPaths := slices.Sorted(maps.Keys(paths))
+	for _, pathStr := range sortedPaths {
+		pathItem := paths[pathStr]
+		methodOps := []struct {
+			method string
+			op     *Operation
+		}{
+			{"GET", pathItem.Get},
+			{"POST", pathItem.Post},
+			{"PUT", pathItem.Put},
+			{"DELETE", pathItem.Delete},
+			{"PATCH", pathItem.Patch},
+			{"OPTIONS", pathItem.Options},
+			{"HEAD", pathItem.Head},
+		}
+		for _, mo := range methodOps {
+			method, op := mo.method, mo.op
 			if op != nil && op.OperationID != "" {
 				// Find the matching route for full package info.
 				var matchedRoute *RouteInfo
@@ -591,19 +607,21 @@ func buildResponses(respInfo map[string]*ResponseInfo) map[string]Response {
 	// Add responses (sorted for deterministic output)
 	for _, statusCode := range slices.Sorted(maps.Keys(respInfo)) {
 		resp := respInfo[statusCode]
-		// If status code is unknown but the response has a body, infer 200 (OK).
-		// This handles the common case where handlers write a response without
-		// calling WriteHeader explicitly.
-		if resp.StatusCode < 0 && resp.BodyType != "" {
-			resp.StatusCode = http.StatusOK
+		// Compute effective status as a local value so we don't mutate the
+		// shared *ResponseInfo — multiple route entries can hold pointers to
+		// the same ResponseInfo (e.g., when splitByConditionalMethods fans
+		// out a switch-case handler into per-method routes), and mutating
+		// the underlying StatusCode would corrupt subsequent rebuilds.
+		effectiveStatus := resp.StatusCode
+		if effectiveStatus < 0 && resp.BodyType != "" {
+			effectiveStatus = http.StatusOK
 			statusCode = "200"
-		} else if resp.StatusCode < 0 {
-			// No body and no status — use "default"
+		} else if effectiveStatus < 0 {
 			statusCode = "default"
 		}
 
-		description := http.StatusText(resp.StatusCode)
-		if resp.StatusCode < 0 || description == "" {
+		description := http.StatusText(effectiveStatus)
+		if effectiveStatus < 0 || description == "" {
 			description = "Status code could not be determined"
 		}
 

--- a/testdata/response_patterns/expected_openapi.json
+++ b/testdata/response_patterns/expected_openapi.json
@@ -89,10 +89,40 @@
       }
     },
     "/dispatch": {
+      "get": {
+        "summary": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method.",
+        "description": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method. This tests conditional HTTP method detection.",
+        "operationId": "testdata.response_patterns.DispatchHandler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/response_patterns.User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/response_patterns.User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "summary": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method.",
         "description": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method. This tests conditional HTTP method detection.",
-        "operationId": "response_patterns.DispatchHandler",
+        "operationId": "go-apispec.testdata.response_patterns.DispatchHandler",
         "requestBody": {
           "content": {
             "application/json": {
@@ -110,19 +140,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/response_patterns.User"
-                }
-              }
-            }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/response_patterns.User"
-                  }
                 }
               }
             }

--- a/testdata/response_patterns/expected_openapi_legacy.json
+++ b/testdata/response_patterns/expected_openapi_legacy.json
@@ -89,6 +89,36 @@
       }
     },
     "/dispatch": {
+      "get": {
+        "summary": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method.",
+        "description": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method. This tests conditional HTTP method detection.",
+        "operationId": "github.com/antst/go-apispec/testdata/response_patterns.DispatchHandler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "summary": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method.",
         "description": "DispatchHandler handles both GET and POST with different responses\nbased on r.Method. This tests conditional HTTP method detection.",
@@ -110,19 +140,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
-                }
-              }
-            }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_response_patterns.User"
-                  }
                 }
               }
             }

--- a/testdata/writejson_helper/expected_openapi.json
+++ b/testdata/writejson_helper/expected_openapi.json
@@ -1,0 +1,95 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/room/check": {
+      "post": {
+        "summary": "checkRoom is the bug shape: success returns CheckRoomHTTPResponse,\nfailure returns a map[string]string error.",
+        "description": "checkRoom is the bug shape: success returns CheckRoomHTTPResponse,\nfailure returns a map[string]string error. Expected oneOf has exactly\nthose two; the helper's internal error fallback must NOT show up.",
+        "operationId": "writejson_helper.checkRoom",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/writejson_helper.CheckRoomHTTPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/room/check-io": {
+      "post": {
+        "summary": "checkRoomIo is the io.WriteString variant — same expected behaviour.",
+        "operationId": "writejson_helper.checkRoomIo",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/writejson_helper.CheckRoomHTTPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "writejson_helper.CheckRoomHTTPResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/writejson_helper/expected_openapi_legacy.json
+++ b/testdata/writejson_helper/expected_openapi_legacy.json
@@ -1,0 +1,95 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/room/check": {
+      "post": {
+        "summary": "checkRoom is the bug shape: success returns CheckRoomHTTPResponse,\nfailure returns a map[string]string error.",
+        "description": "checkRoom is the bug shape: success returns CheckRoomHTTPResponse,\nfailure returns a map[string]string error. Expected oneOf has exactly\nthose two; the helper's internal error fallback must NOT show up.",
+        "operationId": "writejson_helper.checkRoom",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/writejson_helper.CheckRoomHTTPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/room/check-io": {
+      "post": {
+        "summary": "checkRoomIo is the io.WriteString variant — same expected behaviour.",
+        "operationId": "writejson_helper.checkRoomIo",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/writejson_helper.CheckRoomHTTPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "writejson_helper.CheckRoomHTTPResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/writejson_helper/go.mod
+++ b/testdata/writejson_helper/go.mod
@@ -1,0 +1,3 @@
+module writejson_helper
+
+go 1.22

--- a/testdata/writejson_helper/main.go
+++ b/testdata/writejson_helper/main.go
@@ -1,0 +1,71 @@
+// Package main reproduces the issue #27 false-positive: a shared
+// WriteJSON helper with a json.Marshal error fallback was polluting
+// every caller's response schemas with the fallback's literal body and
+// hardcoded 500 status.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// CheckRoomHTTPResponse is the real success-path payload.
+type CheckRoomHTTPResponse struct {
+	OK bool `json:"ok"`
+}
+
+// WriteJSON is the alkem-io/matrix-adapter-go shape: marshal the payload,
+// fall back to a hardcoded 500 + literal body if marshalling fails. The
+// fallback is practically unreachable (structs/maps don't fail to marshal)
+// but its w.Write([]byte) call was being attributed to every caller's
+// success-path response.
+func WriteJSON(w http.ResponseWriter, status int, v interface{}) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"failed to encode response"}`))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(append(data, '\n'))
+}
+
+// WriteJSONIo is the io.WriteString variant from the same bug report.
+// Same shape, just uses io.WriteString instead of w.Write([]byte) — the
+// reporter noted both forms get conflated into the caller's schema.
+func WriteJSONIo(w http.ResponseWriter, status int, v interface{}) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":"failed to encode response"}`)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(append(data, '\n'))
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /room/check", checkRoom)
+	mux.HandleFunc("POST /room/check-io", checkRoomIo)
+	http.ListenAndServe(":3000", mux)
+}
+
+// checkRoom is the bug shape: success returns CheckRoomHTTPResponse,
+// failure returns a map[string]string error. Expected oneOf has exactly
+// those two; the helper's internal error fallback must NOT show up.
+func checkRoom(w http.ResponseWriter, _ *http.Request) {
+	WriteJSON(w, http.StatusOK, CheckRoomHTTPResponse{OK: true})
+	WriteJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_payload"})
+}
+
+// checkRoomIo is the io.WriteString variant — same expected behaviour.
+func checkRoomIo(w http.ResponseWriter, _ *http.Request) {
+	WriteJSONIo(w, http.StatusOK, CheckRoomHTTPResponse{OK: true})
+	WriteJSONIo(w, http.StatusBadRequest, map[string]string{"error": "invalid_payload"})
+}


### PR DESCRIPTION
## Summary

Closes #27. A shared `WriteJSON(w, status, v)` helper with a `json.Marshal`-fail fallback (`w.WriteHeader(500); w.Write([]byte(\`{\"error\":\"...\"}\`))`) was contaminating every caller's response set with the fallback's hardcoded 500 + literal body, plus a phantom `$ref: <pkg>.invalid-type` on the success path. After this PR the spec only reflects the success write path; the defensive fallback is filtered out.

While reproducing the bug I discovered CFG branch annotation was silently disabled on most builds — `cfg.go`'s position lookup didn't account for the `repoRoot` strip that `metadata.getPosition()` applies, so `edge.Branch` was almost always nil. Fixing that unblocked `splitByConditionalMethods` (which now properly fires on `switch r.Method`) and exposed a few latent issues in downstream consumers (mutating `resp.StatusCode` during build, non-deterministic operationId disambiguation) that this PR also addresses.

## Key changes

- **`internal/metadata/cfg.go`** — `buildEdgePositionIndex` / `buildAssignmentPositionIndex` now key both `repoRoot+pos` and raw `pos`; `annotateBranches` descends into AST nodes so an `AssignStmt`-wrapped `_, _ = w.Write(...)` matches the inner `CallExpr`.
- **`internal/spec/extractor.go`** — new `helperFallbackEdges` scan marks response-writing edges inside an error branch of a helper that *also* has an unconditional write path. Skips the route node itself (handler branches are legit control flow) and response-pattern primitives like `c.Status(400).JSON(...)`. `ExtractResponse` treats `go/types`' `\"invalid type\"` sentinel as unresolvable instead of fabricating an `invalid-type` `\$ref`. `expandHelperFunctionResponses` honors `fallbackEdges` and falls back to `inferStatusParamFromCalls` when no seed schema exists.
- **`internal/spec/mapper.go`** — `buildResponses` uses a local `effectiveStatus` instead of mutating `resp.StatusCode`; multiple route entries can share `*ResponseInfo` after `splitByConditionalMethods` fans out a handler. `disambiguateOperationIDs` iterates paths and methods in a sorted, stable order.
- **`testdata/writejson_helper/`** — new fixture replicating the alkem-io/matrix-adapter-go shape (both `w.Write([]byte(...))` and `io.WriteString(...)` fallback variants).
- **`testdata/response_patterns/expected_openapi*.json`** — regenerated. With CFG annotation now working, `splitByConditionalMethods` produces separate GET/POST operations for the `switch r.Method` dispatcher (the old golden conflated them under POST).

## Test plan

- [x] `go test ./...` passes (golden tests, determinism, e2e).
- [x] `golangci-lint run ./...` clean.
- [x] New unit tests cover `helperFallbackEdges` (5 cases), `inferStatusParamFromCalls`, the expansion fallback path, the `\"invalid type\"` sentinel, and the empty-fallback-set expansion guard.
- [x] Manual diff vs the issue: `/room/check` now returns `200: CheckRoomHTTPResponse` and `400: map[string]string` only — the bogus 500 + `invalid-type` `\$ref` are gone.

## Coverage

`internal/spec` package: 94.7% (target 95%). New code individually meets the bar: `helperFallbackEdges` 95.0%, `inferStatusParamFromCalls` 100%, and `expandHelperFunctionResponses` jumped from 71.1% → 92.5%. Remaining uncovered branches are defensive nil checks and one closure inside `extractRouteChildren` exercised only by the e2e fixture. Aggregate `./...` coverage is 95.8%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed response extraction to exclude defensive error-fallback branches in helper functions, preventing phantom responses
  * Improved response schema inference when status parameters are unavailable
  * Stabilized operation ID generation for consistent output across runs
  * Fixed response status handling to prevent incorrect schema references

* **Tests**
  * Added comprehensive test case for helper function fallback response handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antst/go-apispec/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->