### PR TITLE
fix: schema-aware response picker prevents mis-attribution across status codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ testdata/json_dto/json_dto
 testdata/json_patch/json_patch
 testdata/servemux_methods/servemux_methods
 testdata/security_bearer/security_bearer
+testdata/error_switch_minimal/error_switch_minimal
+testdata/error_switch_file_service/error_switch_file_service

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -54,6 +54,8 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 		{name: "security_bearer", inputDir: "../../testdata/security_bearer", configFn: spec.DefaultHTTPConfig},
 		{name: "writejson_helper", inputDir: "../../testdata/writejson_helper", configFn: spec.DefaultHTTPConfig},
+		{name: "error_switch_minimal", inputDir: "../../testdata/error_switch_minimal", configFn: spec.DefaultChiConfig},
+		{name: "error_switch_file_service", inputDir: "../../testdata/error_switch_file_service", configFn: spec.DefaultChiConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -63,6 +63,29 @@ const (
 	defaultSep = "."
 )
 
+// findVacantStatusForBody picks the lowest status code in route.Response
+// that hasn't yet been claimed by a body-bearing pattern. An entry is
+// "vacant" only when BOTH BodyType and Schema are empty — entries with a
+// schema set by expandHelperFunctionResponses (Schema != nil, BodyType == "")
+// must NOT be picked, otherwise Render-method schemas mis-attribute to
+// lower-numbered helper statuses (issue #30 — RejectedContentResponse
+// leaking to 400 in alkem-io/file-service). Bodyless status codes
+// (1xx/204/304) are also excluded per RFC 7231.
+//
+// Returns the status code and true on a successful pick; returns 0/false
+// when no vacant slot exists.
+func findVacantStatusForBody(route *RouteInfo) (int, bool) {
+	for _, key := range slices.Sorted(maps.Keys(route.Response)) {
+		resp := route.Response[key]
+		if resp.BodyType == "" && resp.Schema == nil &&
+			resp.StatusCode >= 100 && resp.StatusCode < 600 &&
+			!isBodylessStatusCode(resp.StatusCode) {
+			return resp.StatusCode, true
+		}
+	}
+	return 0, false
+}
+
 // isBodylessStatusCode returns true for HTTP status codes that must not
 // include a message body per RFC 7231: 1xx informational, 204 No Content,
 // and 304 Not Modified.
@@ -1587,12 +1610,8 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 		// If status code is not from argument, find the lowest valid status code
 		// with no body type assigned yet. Skip bodyless codes (1xx, 204, 304).
 		if !r.pattern.StatusFromArg {
-			for _, key := range slices.Sorted(maps.Keys(route.Response)) {
-				resp := route.Response[key]
-				if resp.BodyType == "" && resp.StatusCode >= 100 && resp.StatusCode < 600 && !isBodylessStatusCode(resp.StatusCode) {
-					respInfo.StatusCode = resp.StatusCode
-					break
-				}
+			if status, ok := findVacantStatusForBody(route); ok {
+				respInfo.StatusCode = status
 			}
 		}
 

--- a/internal/spec/extractor_vacant_status_test.go
+++ b/internal/spec/extractor_vacant_status_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFindVacantStatusForBody covers FR-002 from spec 005 (the schema-aware
+// picker fix for issue #30). The picker must require BOTH BodyType=="" AND
+// Schema==nil; entries populated by expandHelperFunctionResponses carry a
+// Schema but leave BodyType empty, and treating those as "vacant" mis-
+// attributes Render-method schemas to lower-numbered helper statuses.
+//
+// Reverting the `&& resp.Schema == nil` clause in findVacantStatusForBody
+// MUST make TestFindVacantStatusForBody_PrefersSchemaNil fail — this is
+// SC-006's "load-bearing" check on the picker fix.
+func TestFindVacantStatusForBody_PrefersSchemaNil(t *testing.T) {
+	// 400 has a schema (from expand-pass); 422 is truly vacant. The picker
+	// must skip 400 and pick 422 even though 400 sorts lower.
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"400": {StatusCode: 400, BodyType: "", Schema: &Schema{Type: "object"}},
+			"422": {StatusCode: 422, BodyType: "", Schema: nil},
+		},
+	}
+	status, ok := findVacantStatusForBody(route)
+	assert.True(t, ok, "expected a vacant pick")
+	assert.Equal(t, 422, status, "picker must skip the schema-set entry at 400 and pick the schema-nil entry at 422")
+}
+
+func TestFindVacantStatusForBody_NoPickWhenAllPopulated(t *testing.T) {
+	// All entries carry a schema; the picker must report no vacant slot
+	// rather than attaching a body schema to an already-populated status.
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"200": {StatusCode: 200, BodyType: "", Schema: &Schema{Type: "object"}},
+			"400": {StatusCode: 400, BodyType: "", Schema: &Schema{Type: "object"}},
+			"422": {StatusCode: 422, BodyType: "", Schema: &Schema{Type: "string"}},
+		},
+	}
+	_, ok := findVacantStatusForBody(route)
+	assert.False(t, ok, "all entries are populated; the picker must not pick any")
+}
+
+func TestFindVacantStatusForBody_PicksLowestVacant(t *testing.T) {
+	// Two truly-vacant entries; the picker returns the lower sort-key entry
+	// (the historical "lowest empty BodyType" semantics, preserved post-fix).
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"422": {StatusCode: 422, BodyType: "", Schema: nil},
+			"500": {StatusCode: 500, BodyType: "", Schema: nil},
+		},
+	}
+	status, ok := findVacantStatusForBody(route)
+	assert.True(t, ok)
+	assert.Equal(t, 422, status, "lowest sort-key vacant entry wins")
+}
+
+func TestFindVacantStatusForBody_SkipsBodylessAnd2xxLike304(t *testing.T) {
+	// 204 No Content and 304 Not Modified must never receive a body schema.
+	// The picker must skip them even if otherwise "vacant".
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"204": {StatusCode: 204, BodyType: "", Schema: nil},
+			"304": {StatusCode: 304, BodyType: "", Schema: nil},
+			"422": {StatusCode: 422, BodyType: "", Schema: nil},
+		},
+	}
+	status, ok := findVacantStatusForBody(route)
+	assert.True(t, ok)
+	assert.Equal(t, 422, status, "must skip bodyless 204/304 and pick the next vacant body-bearing status")
+}
+
+func TestFindVacantStatusForBody_SkipsOutOfRange(t *testing.T) {
+	// Statuses outside the valid HTTP range (100..599) must never be picked.
+	// The sentinel "no real status" value used elsewhere in extractor.go is
+	// a negative number (leastStatusCode - 1); these must NOT be claimed.
+	route := &RouteInfo{
+		Response: map[string]*ResponseInfo{
+			"-1":  {StatusCode: -1, BodyType: "", Schema: nil},
+			"600": {StatusCode: 600, BodyType: "", Schema: nil},
+		},
+	}
+	_, ok := findVacantStatusForBody(route)
+	assert.False(t, ok, "out-of-range statuses must not be picked")
+}
+
+func TestFindVacantStatusForBody_EmptyRoute(t *testing.T) {
+	route := &RouteInfo{Response: map[string]*ResponseInfo{}}
+	_, ok := findVacantStatusForBody(route)
+	assert.False(t, ok, "empty route.Response cannot yield a pick")
+}

--- a/testdata/error_switch_file_service/expected_openapi.json
+++ b/testdata/error_switch_file_service/expected_openapi.json
@@ -1,0 +1,181 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/{id}/content": {
+      "put": {
+        "operationId": "DocumentHandler.ReplaceContent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.ReplaceContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.RejectedContentResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "error_switch_file_service.MimeMismatchDetail": {
+        "type": "object",
+        "properties": {
+          "detectedMime": {
+            "type": "string"
+          },
+          "knownMime": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "knownMime",
+          "detectedMime"
+        ]
+      },
+      "error_switch_file_service.RejectedContentResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "detail": {
+            "$ref": "#/components/schemas/error_switch_file_service.MimeMismatchDetail"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "error"
+        ]
+      },
+      "error_switch_file_service.ReplaceContentResponse": {
+        "type": "object",
+        "properties": {
+          "externalID": {
+            "type": "string"
+          },
+          "imageHeight": {
+            "type": "integer"
+          },
+          "imageWidth": {
+            "type": "integer"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "externalID",
+          "mimeType",
+          "size"
+        ]
+      },
+      "error_switch_file_service.errorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "code"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/error_switch_file_service/expected_openapi_legacy.json
+++ b/testdata/error_switch_file_service/expected_openapi_legacy.json
@@ -1,0 +1,181 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/{id}/content": {
+      "put": {
+        "operationId": "github.com/antst/go-apispec/testdata/error_switch_file_service.DocumentHandler.ReplaceContent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.ReplaceContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.RejectedContentResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.errorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "github.com_antst_go-apispec_testdata_error_switch_file_service.MimeMismatchDetail": {
+        "type": "object",
+        "properties": {
+          "detectedMime": {
+            "type": "string"
+          },
+          "knownMime": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "knownMime",
+          "detectedMime"
+        ]
+      },
+      "github.com_antst_go-apispec_testdata_error_switch_file_service.RejectedContentResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "detail": {
+            "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_file_service.MimeMismatchDetail"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "error"
+        ]
+      },
+      "github.com_antst_go-apispec_testdata_error_switch_file_service.ReplaceContentResponse": {
+        "type": "object",
+        "properties": {
+          "externalID": {
+            "type": "string"
+          },
+          "imageHeight": {
+            "type": "integer"
+          },
+          "imageWidth": {
+            "type": "integer"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "externalID",
+          "mimeType",
+          "size"
+        ]
+      },
+      "github.com_antst_go-apispec_testdata_error_switch_file_service.errorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "code"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/error_switch_file_service/go.mod
+++ b/testdata/error_switch_file_service/go.mod
@@ -1,0 +1,5 @@
+module github.com/antst/go-apispec/testdata/error_switch_file_service
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/error_switch_file_service/go.sum
+++ b/testdata/error_switch_file_service/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/error_switch_file_service/main.go
+++ b/testdata/error_switch_file_service/main.go
@@ -1,0 +1,149 @@
+// Package main mirrors the alkem-io/file-service DocumentHandler.ReplaceContent
+// handler shape locally. This is the bug-reproduction guarantee fixture for
+// antst/go-apispec#30: a 7-status switch where the same status (422) is
+// written both by a parameter-status helper and by a struct-method Render
+// that hardcodes its status.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type errorResponse struct {
+	Error string `json:"error"`
+	Code  int    `json:"code"`
+}
+
+type ReplaceContentResponse struct {
+	ExternalID  string `json:"externalID"`
+	MimeType    string `json:"mimeType"`
+	Size        int    `json:"size"`
+	ImageWidth  *int   `json:"imageWidth,omitempty"`
+	ImageHeight *int   `json:"imageHeight,omitempty"`
+}
+
+func (r ReplaceContentResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(r)
+}
+
+// MimeMismatchDetail is the nested-pointer field on RejectedContentResponse
+// — present in the original file-service code, replicated here so the
+// generated schema matches the report.
+type MimeMismatchDetail struct {
+	KnownMime    string `json:"knownMime"`
+	DetectedMime string `json:"detectedMime"`
+}
+
+type RejectedContentResponse struct {
+	Code   string              `json:"code"`
+	Error  string              `json:"error"`
+	Detail *MimeMismatchDetail `json:"detail,omitempty"`
+}
+
+func (r RejectedContentResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_ = json.NewEncoder(w).Encode(r)
+}
+
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: msg, Code: code})
+}
+
+// MimeMismatchError is the typed error caught via errors.As — mirrors the
+// service-layer type from the original handler.
+type MimeMismatchError struct {
+	Known    string
+	Detected string
+}
+
+func (e *MimeMismatchError) Error() string { return "mime mismatch" }
+
+// MaxBytesError stubs http.MaxBytesError so errors.As works the same way
+// as in the original code.
+type MaxBytesError struct{}
+
+func (e *MaxBytesError) Error() string { return "request too large" }
+
+var (
+	ErrDocumentNotFound = errors.New("document not found")
+	ErrEmptyContent     = errors.New("empty content")
+	ErrImageProcessing  = errors.New("image processing failed")
+	ErrConflict         = errors.New("conflict")
+)
+
+// DocumentHandler matches the file-service receiver shape.
+type DocumentHandler struct{}
+
+// ReplaceContent: PUT /documents/{id}/content — the full file-service shape.
+func (h *DocumentHandler) ReplaceContent(w http.ResponseWriter, r *http.Request) {
+	docID, err := parseDocID(r)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "invalid document ID")
+		return
+	}
+	_ = docID
+
+	content, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxErr *MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+
+	result, serr := h.storeAndLink(r.Context(), "doc-id", content)
+	if serr != nil {
+		var mismatch *MimeMismatchError
+		switch {
+		case errors.Is(serr, ErrDocumentNotFound):
+			writeJSONError(w, http.StatusNotFound, "document not found")
+		case errors.Is(serr, ErrEmptyContent):
+			RejectedContentResponse{Code: "EMPTY_CONTENT", Error: serr.Error()}.Render(w)
+		case errors.As(serr, &mismatch):
+			RejectedContentResponse{
+				Code:  "MIME_MISMATCH",
+				Error: mismatch.Error(),
+				Detail: &MimeMismatchDetail{
+					KnownMime:    mismatch.Known,
+					DetectedMime: mismatch.Detected,
+				},
+			}.Render(w)
+		case errors.Is(serr, ErrImageProcessing):
+			writeJSONError(w, http.StatusUnprocessableEntity, serr.Error())
+		case errors.Is(serr, ErrConflict):
+			writeJSONError(w, http.StatusConflict, "conflict with existing document")
+		default:
+			writeJSONError(w, http.StatusInternalServerError, "internal error")
+		}
+		return
+	}
+
+	result.Render(w)
+}
+
+func (h *DocumentHandler) storeAndLink(_ context.Context, _ string, _ []byte) (ReplaceContentResponse, error) {
+	return ReplaceContentResponse{}, nil
+}
+
+func parseDocID(_ *http.Request) (string, error) { return "", nil }
+
+func main() {
+	r := chi.NewRouter()
+	h := &DocumentHandler{}
+	r.Put("/documents/{id}/content", h.ReplaceContent)
+	_ = http.ListenAndServe(":3000", r)
+}

--- a/testdata/error_switch_minimal/expected_openapi.json
+++ b/testdata/error_switch_minimal/expected_openapi.json
@@ -1,0 +1,123 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/{id}/content": {
+      "put": {
+        "operationId": "Handler.ReplaceContent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_minimal.ReplaceContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_minimal.errorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_minimal.RejectedContentResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_switch_minimal.errorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "error_switch_minimal.RejectedContentResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "error"
+        ]
+      },
+      "error_switch_minimal.ReplaceContentResponse": {
+        "type": "object",
+        "properties": {
+          "externalID": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "externalID",
+          "size"
+        ]
+      },
+      "error_switch_minimal.errorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "code"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/error_switch_minimal/expected_openapi_legacy.json
+++ b/testdata/error_switch_minimal/expected_openapi_legacy.json
@@ -1,0 +1,123 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/{id}/content": {
+      "put": {
+        "operationId": "github.com/antst/go-apispec/testdata/error_switch_minimal.Handler.ReplaceContent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_minimal.ReplaceContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_minimal.errorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_minimal.RejectedContentResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github.com_antst_go-apispec_testdata_error_switch_minimal.errorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "github.com_antst_go-apispec_testdata_error_switch_minimal.RejectedContentResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "error"
+        ]
+      },
+      "github.com_antst_go-apispec_testdata_error_switch_minimal.ReplaceContentResponse": {
+        "type": "object",
+        "properties": {
+          "externalID": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "externalID",
+          "size"
+        ]
+      },
+      "github.com_antst_go-apispec_testdata_error_switch_minimal.errorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "code"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/error_switch_minimal/go.mod
+++ b/testdata/error_switch_minimal/go.mod
@@ -1,0 +1,5 @@
+module github.com/antst/go-apispec/testdata/error_switch_minimal
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/error_switch_minimal/go.sum
+++ b/testdata/error_switch_minimal/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/error_switch_minimal/main.go
+++ b/testdata/error_switch_minimal/main.go
@@ -1,0 +1,92 @@
+// Package main is the minimal regression fixture for antst/go-apispec#30 —
+// a chi handler whose error switch writes different response schemas under
+// different status codes. Before the Layer-1 fix, the schema bound to 422 by
+// RejectedContentResponse.Render leaks to 400.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type errorResponse struct {
+	Error string `json:"error"`
+	Code  int    `json:"code"`
+}
+
+type ReplaceContentResponse struct {
+	ExternalID string `json:"externalID"`
+	Size       int    `json:"size"`
+}
+
+func (r ReplaceContentResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(r)
+}
+
+type RejectedContentResponse struct {
+	Code  string `json:"code"`
+	Error string `json:"error"`
+}
+
+func (r RejectedContentResponse) Render(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_ = json.NewEncoder(w).Encode(r)
+}
+
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: msg, Code: code})
+}
+
+var (
+	ErrEmptyContent    = errors.New("empty content")
+	ErrImageProcessing = errors.New("image processing failed")
+)
+
+// Handler is a method receiver — required for the route-in-route arg-node
+// bug to fire (the handler-ref arg-node carries the function body subtree,
+// where the second-pass Encode re-fires).
+type Handler struct{}
+
+// ReplaceContent is the buggy shape: 422 has both a helper-write AND a
+// struct-method-write. Pre-fix, RejectedContentResponse leaks to 400.
+func (h *Handler) ReplaceContent(w http.ResponseWriter, r *http.Request) {
+	content, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	_ = content
+
+	serr := process()
+	if serr != nil {
+		switch {
+		case errors.Is(serr, ErrEmptyContent):
+			RejectedContentResponse{Code: "EMPTY_CONTENT", Error: serr.Error()}.Render(w)
+		case errors.Is(serr, ErrImageProcessing):
+			writeJSONError(w, http.StatusUnprocessableEntity, serr.Error())
+		default:
+			writeJSONError(w, http.StatusInternalServerError, "unknown error")
+		}
+		return
+	}
+
+	ReplaceContentResponse{ExternalID: "ext-1", Size: 0}.Render(w)
+}
+
+func process() error { return nil }
+
+func main() {
+	r := chi.NewRouter()
+	h := &Handler{}
+	r.Put("/documents/{id}/content", h.ReplaceContent)
+	_ = http.ListenAndServe(":3000", r)
+}


### PR DESCRIPTION
## Summary

- Tighten the response status picker in `ResponsePatternMatcherImpl.ExtractResponse` to require BOTH `BodyType == ""` AND `Schema == nil` (extracted into `findVacantStatusForBody` for direct testing). Entries populated by `expandHelperFunctionResponses` carry a schema but leave `BodyType` empty — pre-fix they were falsely treated as "vacant", letting `Render`-method schemas mis-attribute to lower-numbered helper statuses.
- Add two regression fixtures: `testdata/error_switch_minimal/` (4-status correctness regression) and `testdata/error_switch_file_service/` (7-status bug-reproduction mirror of `alkem-io/file-service` `DocumentHandler.ReplaceContent`).
- Add 6 unit tests covering schema-nil preference, no-pick-when-all-populated, lowest-vacant tie-break, bodyless 204/304 skip, out-of-range skip, and empty route.

Fixes #30.

## Symptom (pre-fix, `alkem-io/file-service`)

```yaml
"400":
  content: { application/json: { schema: { oneOf: [errorResponse, RejectedContentResponse] } } }
"422":
  content: { application/json: { schema: { $ref: ReplaceContentResponse } } }
```

## Output (post-fix, same handler)

```yaml
"400": { schema: { $ref: errorResponse } }
"422": { schema: { $ref: RejectedContentResponse } }
```

## Implementation notes

The original triage identified two layers (structural route-in-route duplicate-pass + fragile picker). During implementation, the route-in-route arg-node skip was found to break the `echo` fixture — the recursive pass is load-bearing for `c.JSON(StatusBadRequest, ...)` calls inside `if err != nil` branches that the outer pass's `helperFallbackEdges` blocks. Layer-2 (the schema-aware picker) alone fixes the bug without disturbing that mechanism. See `specs/005-fix-error-switch-attribution/spec.md` Clarifications session 2026-06-12.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] 14 existing testdata fixtures: golden files byte-identical (FR-003)
- [x] `internal/spec` coverage 95.4%, total 96.1%
- [x] SC-006 load-bearing: reverting `&& resp.Schema == nil` makes `TestFindVacantStatusForBody_PrefersSchemaNil` fail
- [x] SC-001 spot-check against local `alkem-io/file-service` `019-preserve-mime-on-edit` confirms the bug shape from the issue is gone
- [x] `gofmt -l .` clean, `go vet ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response status code assignment to prevent incorrect schema reuse during API specification generation.

* **Tests**
  * Added new test fixtures demonstrating error-handling patterns.
  * Expanded framework test coverage with additional regression scenarios.
  * Added unit tests for status code selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->