### PR TITLE
fix: make schema inference follow the call graph into helpers (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'
         run: go tool cover -func=coverage.out | tail -1
 
+      - name: Coverage gate (>=95% per package)
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'
+        run: bash scripts/check-coverage.sh coverage.out
+
   golden:
     name: Golden file regression
     runs-on: ubuntu-latest

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -453,6 +453,7 @@ func TestE2E_JSONDtoHelpers_InterproceduralInference(t *testing.T) {
 	// decodeStrictJSON(dst any) helper rather than collapsing to free-form.
 	require.NotNil(t, pi.Post.RequestBody)
 	assert.True(t, pi.Post.RequestBody.Required)
+	require.Contains(t, pi.Post.RequestBody.Content, "application/json")
 	reqSchema := pi.Post.RequestBody.Content["application/json"].Schema
 	require.NotNil(t, reqSchema)
 	assert.Equal(t, "#/components/schemas/json_dto.CopyDocumentRequest", reqSchema.Ref,
@@ -471,11 +472,17 @@ func TestE2E_JSONDtoHelpers_InterproceduralInference(t *testing.T) {
 	// response body, 400 stays a text/plain string (issue #36).
 	resp200, ok := pi.Post.Responses["200"]
 	require.True(t, ok, "200 response must be present")
-	assert.Equal(t, "#/components/schemas/json_dto.CopyDocumentResponse",
-		resp200.Content["application/json"].Schema.Ref)
+	require.Contains(t, resp200.Content, "application/json")
+	resp200Schema := resp200.Content["application/json"].Schema
+	require.NotNil(t, resp200Schema)
+	assert.Equal(t, "#/components/schemas/json_dto.CopyDocumentResponse", resp200Schema.Ref)
+
 	resp400, ok := pi.Post.Responses["400"]
 	require.True(t, ok, "400 response must be present")
-	assert.Equal(t, "string", resp400.Content["text/plain; charset=utf-8"].Schema.Type,
+	require.Contains(t, resp400.Content, "text/plain; charset=utf-8")
+	resp400Schema := resp400.Content["text/plain; charset=utf-8"].Schema
+	require.NotNil(t, resp400Schema)
+	assert.Equal(t, "string", resp400Schema.Type,
 		"400 must remain a plain-text string, not steal the success body schema")
 }
 

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -50,6 +50,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "error_helpers", inputDir: "../../testdata/error_helpers", configFn: spec.DefaultChiConfig},
 		{name: "form_value_var", inputDir: "../../testdata/form_value_var", configFn: spec.DefaultChiConfig},
 		{name: "json_dto", inputDir: "../../testdata/json_dto", configFn: spec.DefaultChiConfig},
+		{name: "json_dto_helpers", inputDir: "../../testdata/json_dto_helpers", configFn: spec.DefaultChiConfig},
 		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
 		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 		{name: "security_bearer", inputDir: "../../testdata/security_bearer", configFn: spec.DefaultHTTPConfig},
@@ -430,6 +431,52 @@ func TestE2E_JSONDto_FormatAndRequiredInference(t *testing.T) {
 			assert.Equal(t, w.Format, ps.Format, "%s.%s format", typeName, prop)
 		}
 	}
+}
+
+// TestE2E_JSONDtoHelpers_InterproceduralInference asserts that the same
+// request/response contract as json_dto survives the lint-driven helper
+// extractions in issue #36: the decode boilerplate moved into a helper with an
+// `any` parameter, and uuid.Parse moved into field-passed and struct-passed
+// helpers. Request binding, per-field format: uuid, and the 200/400 split must
+// all match the inline fixture rather than degrading.
+func TestE2E_JSONDtoHelpers_InterproceduralInference(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/json_dto_helpers", spec.DefaultChiConfig())
+	eng := NewEngine(cfg)
+	result, err := eng.GenerateOpenAPI()
+	require.NoError(t, err)
+
+	pi, ok := result.Paths["/documents/copy"]
+	require.True(t, ok)
+	require.NotNil(t, pi.Post)
+
+	// Repro 2: request body still binds to the concrete type through the
+	// decodeStrictJSON(dst any) helper rather than collapsing to free-form.
+	require.NotNil(t, pi.Post.RequestBody)
+	assert.True(t, pi.Post.RequestBody.Required)
+	reqSchema := pi.Post.RequestBody.Content["application/json"].Schema
+	require.NotNil(t, reqSchema)
+	assert.Equal(t, "#/components/schemas/json_dto.CopyDocumentRequest", reqSchema.Ref,
+		"request body must $ref the concrete schema, not inline a free-form object")
+
+	// Repro 1: format: uuid propagates from helpers back onto the fields.
+	reqType := result.Components.Schemas["json_dto.CopyDocumentRequest"]
+	require.NotNil(t, reqType)
+	for _, prop := range []string{"sourceId", "destinationBucketId", "authorizationId", "tagsetId", "externalId"} {
+		ps := reqType.Properties[prop]
+		require.NotNil(t, ps, "property %s missing", prop)
+		assert.Equal(t, "uuid", ps.Format, "%s must carry format: uuid", prop)
+	}
+
+	// Response split survives http.Error moving into a helper: 200 carries the
+	// response body, 400 stays a text/plain string (issue #36).
+	resp200, ok := pi.Post.Responses["200"]
+	require.True(t, ok, "200 response must be present")
+	assert.Equal(t, "#/components/schemas/json_dto.CopyDocumentResponse",
+		resp200.Content["application/json"].Schema.Ref)
+	resp400, ok := pi.Post.Responses["400"]
+	require.True(t, ok, "400 response must be present")
+	assert.Equal(t, "string", resp400.Content["text/plain; charset=utf-8"].Schema.Type,
+		"400 must remain a plain-text string, not steal the success body schema")
 }
 
 func paramNames(ps []intspec.Parameter) []string {

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -526,6 +526,14 @@ func DefaultChiConfig() *APISpecConfig {
 					TypeArgIndex:  1,
 
 					DefaultContentType: "text/plain; charset=utf-8",
+					// http.Error always writes a text/plain string body. When the
+					// message arg isn't a string literal — e.g. `"invalid "+name`,
+					// the idiom extracted error helpers reach for (issue #36) — the
+					// type can't be read off the arg, leaving BodyType empty. Pin
+					// "string" as the fallback so the response still claims its
+					// status slot instead of reading as a body-less "vacant" slot
+					// that findVacantStatusForBody hands to a later success body.
+					DefaultBodyType: "string",
 				},
 				{BasePattern: BasePattern{CallRegex: `^NotFound$`,
 					// Always 404
@@ -689,6 +697,14 @@ func DefaultEchoConfig() *APISpecConfig {
 					TypeArgIndex:  1,
 
 					DefaultContentType: "text/plain; charset=utf-8",
+					// http.Error always writes a text/plain string body. When the
+					// message arg isn't a string literal — e.g. `"invalid "+name`,
+					// the idiom extracted error helpers reach for (issue #36) — the
+					// type can't be read off the arg, leaving BodyType empty. Pin
+					// "string" as the fallback so the response still claims its
+					// status slot instead of reading as a body-less "vacant" slot
+					// that findVacantStatusForBody hands to a later success body.
+					DefaultBodyType: "string",
 				},
 				{BasePattern: BasePattern{CallRegex: `^NotFound$`,
 					// Always 404
@@ -836,6 +852,14 @@ func DefaultFiberConfig() *APISpecConfig {
 					TypeArgIndex:  1,
 
 					DefaultContentType: "text/plain; charset=utf-8",
+					// http.Error always writes a text/plain string body. When the
+					// message arg isn't a string literal — e.g. `"invalid "+name`,
+					// the idiom extracted error helpers reach for (issue #36) — the
+					// type can't be read off the arg, leaving BodyType empty. Pin
+					// "string" as the fallback so the response still claims its
+					// status slot instead of reading as a body-less "vacant" slot
+					// that findVacantStatusForBody hands to a later success body.
+					DefaultBodyType: "string",
 				},
 				{BasePattern: BasePattern{CallRegex: `^NotFound$`,
 					// Always 404
@@ -1016,6 +1040,14 @@ func DefaultGinConfig() *APISpecConfig {
 					TypeArgIndex:  1,
 
 					DefaultContentType: "text/plain; charset=utf-8",
+					// http.Error always writes a text/plain string body. When the
+					// message arg isn't a string literal — e.g. `"invalid "+name`,
+					// the idiom extracted error helpers reach for (issue #36) — the
+					// type can't be read off the arg, leaving BodyType empty. Pin
+					// "string" as the fallback so the response still claims its
+					// status slot instead of reading as a body-less "vacant" slot
+					// that findVacantStatusForBody hands to a later success body.
+					DefaultBodyType: "string",
 				},
 				{BasePattern: BasePattern{CallRegex: `^NotFound$`,
 					// Always 404
@@ -1205,6 +1237,14 @@ func DefaultMuxConfig() *APISpecConfig {
 					TypeArgIndex:  1,
 
 					DefaultContentType: "text/plain; charset=utf-8",
+					// http.Error always writes a text/plain string body. When the
+					// message arg isn't a string literal — e.g. `"invalid "+name`,
+					// the idiom extracted error helpers reach for (issue #36) — the
+					// type can't be read off the arg, leaving BodyType empty. Pin
+					// "string" as the fallback so the response still claims its
+					// status slot instead of reading as a body-less "vacant" slot
+					// that findVacantStatusForBody hands to a later success body.
+					DefaultBodyType: "string",
 				},
 				{BasePattern: BasePattern{CallRegex: `^NotFound$`,
 					// Always 404
@@ -1332,6 +1372,14 @@ func DefaultHTTPConfig() *APISpecConfig {
 					TypeArgIndex:  1,
 
 					DefaultContentType: "text/plain; charset=utf-8",
+					// http.Error always writes a text/plain string body. When the
+					// message arg isn't a string literal — e.g. `"invalid "+name`,
+					// the idiom extracted error helpers reach for (issue #36) — the
+					// type can't be read off the arg, leaving BodyType empty. Pin
+					// "string" as the fallback so the response still claims its
+					// status slot instead of reading as a body-less "vacant" slot
+					// that findVacantStatusForBody hands to a later success body.
+					DefaultBodyType: "string",
 				},
 				{BasePattern: BasePattern{CallRegex: `^NotFound$`,
 					// Always 404

--- a/internal/spec/field_inference.go
+++ b/internal/spec/field_inference.go
@@ -14,15 +14,47 @@ import (
 	"github.com/antst/go-apispec/internal/metadata"
 )
 
-// applyJSONFieldConverterFormats back-propagates converter-derived OpenAPI
-// schema formats onto a request-body struct's fields.
+// maxFieldInferenceDepth bounds how many helper-call levels the field-format
+// inference follows below the handler. 0 would be the legacy intraprocedural
+// behaviour (handler body only); the call graph is already indexed so each
+// extra level is cheap, but the depth is capped so a pathological graph can't
+// drive unbounded recursion. One or two levels covers the lint-driven helper
+// extraction this guards against (issue #36).
+const maxFieldInferenceDepth = 8
+
+// fieldBinding records, within a single function frame, how that frame's local
+// variables and parameters relate to the request-body struct whose field
+// formats we're inferring:
 //
-// For every edge in the same handler that consumes `<targetVar>.<fieldName>`
-// (directly or behind a unary/star), we look up the callee in
-// paramConverters and write its type/format onto the matching property of
-// the struct schema. The struct's JSON-tag derived property names are
-// resolved from the metadata so the inference doesn't depend on field-name
-// casing conventions.
+//   - structVars: names that currently hold the whole struct, so a selector
+//     `<name>.<Field>` on one of them identifies a struct field.
+//   - fieldVars: names that hold a single field's *value* (because the call
+//     site passed `body.Field` straight into a parameter), mapped to the Go
+//     field name — so a converter applied directly to such a name pins that
+//     field's format.
+type fieldBinding struct {
+	structVars map[string]struct{}
+	fieldVars  map[string]string
+}
+
+func (b fieldBinding) empty() bool {
+	return len(b.structVars) == 0 && len(b.fieldVars) == 0
+}
+
+// applyJSONFieldConverterFormats back-propagates converter-derived OpenAPI
+// schema formats onto a request-body struct's fields, following helper calls
+// through the call graph (issue #36) so that extracting a `uuid.Parse` (or
+// other converter) into a helper no longer silently drops the inferred format.
+//
+// Starting from the handler frame (callerBaseID) with the decode target as the
+// sole struct variable, every outgoing edge is examined: a known converter
+// applied to a tracked struct field (or to a variable that holds a field's
+// value) writes its type/format onto the matching property; a call into an
+// analysable project function is followed one level deeper with the struct/
+// field bindings remapped onto that function's parameters.
+//
+// The struct's JSON-tag derived property names are resolved from the metadata
+// so the inference doesn't depend on field-name casing conventions.
 //
 // Tag-driven overrides (`apispec:"format=..."`) take precedence over flow
 // inference: applyAPISpecTag runs after this and overwrites whatever flow
@@ -44,45 +76,154 @@ func applyJSONFieldConverterFormats(targetVar, bodyType string, callerBaseID str
 		return
 	}
 
-	siblings := route.Metadata.Callers[callerBaseID]
-	for _, sib := range siblings {
-		// The converter lookup depends only on the callee — resolve once per
-		// sibling rather than re-looking-up for each arg. Cuts pool reads
-		// when the same call has many args (rare for converters but free).
-		c := lookupParamConverter(
-			stringFromPool(route.Metadata, sib.Callee.Pkg),
-			stringFromPool(route.Metadata, sib.Callee.Name),
-		)
-		if c == nil {
+	binding := fieldBinding{
+		structVars: map[string]struct{}{targetVar: {}},
+		fieldVars:  map[string]string{},
+	}
+	propagateFieldFormats(callerBaseID, binding, fields, structSchema, route.Metadata, map[string]struct{}{}, 0)
+}
+
+// propagateFieldFormats walks the outgoing edges of one function frame,
+// applying converter formats to bound fields and recursing into project
+// helpers. `onStack` holds the frames currently being expanded so a recursive
+// helper can't loop; it's unwound on return so two sibling calls into the same
+// helper (with different bindings) are both followed.
+func propagateFieldFormats(
+	callerBaseID string,
+	binding fieldBinding,
+	fields map[string]string,
+	structSchema *Schema,
+	meta *metadata.Metadata,
+	onStack map[string]struct{},
+	depth int,
+) {
+	if binding.empty() || depth > maxFieldInferenceDepth {
+		return
+	}
+	if _, busy := onStack[callerBaseID]; busy {
+		return
+	}
+	onStack[callerBaseID] = struct{}{}
+	defer delete(onStack, callerBaseID)
+
+	for _, edge := range meta.Callers[callerBaseID] {
+		// A known converter is a leaf: record the format and stop — it never
+		// also counts as a helper to descend into.
+		if c := lookupParamConverter(
+			stringFromPool(meta, edge.Callee.Pkg),
+			stringFromPool(meta, edge.Callee.Name),
+		); c != nil {
+			for _, arg := range edge.Args {
+				if fieldGoName := fieldNameForArg(arg, binding); fieldGoName != "" {
+					applyConverterToField(structSchema, fields, fieldGoName, c)
+				}
+			}
 			continue
 		}
-		for _, arg := range sib.Args {
-			fieldGoName := selectorFieldOnTarget(arg, targetVar)
-			if fieldGoName == "" {
-				continue
+
+		// Otherwise, if this is an analysable project function that the struct
+		// (or one of its fields) flows into, follow it one level deeper.
+		if depth >= maxFieldInferenceDepth {
+			continue
+		}
+		calleeBase := edge.Callee.BaseID()
+		if len(meta.Callers[calleeBase]) == 0 {
+			continue // external/stdlib/leaf — no body to analyse
+		}
+		if child := childBinding(edge, binding); !child.empty() {
+			propagateFieldFormats(calleeBase, child, fields, structSchema, meta, onStack, depth+1)
+		}
+	}
+}
+
+// fieldNameForArg returns the Go field name an argument refers to under the
+// current binding: a selector `<structVar>.<Field>` (optionally behind a
+// unary/star, covering `*body.Field` for pointer fields), or a bare identifier
+// previously bound to a field's value. Returns "" for anything else.
+func fieldNameForArg(arg *metadata.CallArgument, binding fieldBinding) string {
+	if arg == nil {
+		return ""
+	}
+	switch arg.GetKind() {
+	case metadata.KindUnary, metadata.KindStar:
+		return fieldNameForArg(arg.X, binding)
+	case metadata.KindSelector:
+		if arg.X == nil || arg.Sel == nil || arg.X.GetKind() != metadata.KindIdent {
+			return ""
+		}
+		if _, ok := binding.structVars[arg.X.GetName()]; ok {
+			return arg.Sel.GetName()
+		}
+	case metadata.KindIdent:
+		if f, ok := binding.fieldVars[arg.GetName()]; ok {
+			return f
+		}
+	}
+	return ""
+}
+
+// childBinding projects the caller-frame binding onto a callee's parameters
+// using the edge's parameter→argument map, so the recursion can reason in the
+// callee's own variable names. A parameter receiving the whole struct becomes
+// a struct variable; one receiving `body.Field` (or a variable already bound
+// to a field) becomes a field variable.
+func childBinding(edge *metadata.CallGraphEdge, binding fieldBinding) fieldBinding {
+	child := fieldBinding{structVars: map[string]struct{}{}, fieldVars: map[string]string{}}
+	for param, arg := range edge.ParamArgMap {
+		base := unwrapArgRefs(&arg)
+		if base == nil {
+			continue
+		}
+		switch base.GetKind() {
+		case metadata.KindIdent:
+			if _, ok := binding.structVars[base.GetName()]; ok {
+				child.structVars[param] = struct{}{}
+			} else if f, ok := binding.fieldVars[base.GetName()]; ok {
+				child.fieldVars[param] = f
 			}
-			jsonName, ok := fields[fieldGoName]
-			if !ok {
-				continue
-			}
-			prop, ok := structSchema.Properties[jsonName]
-			if !ok || prop == nil {
-				continue
-			}
-			// Don't clobber an explicit format — flow inference is best-effort
-			// and a previous edge in this loop, the validator tag pass, or a
-			// nested-type pass might have set something more specific.
-			if prop.Format == "" {
-				prop.Format = c.Format
-			}
-			if c.Type != "" && (prop.Type == "" || prop.Type == "string") {
-				// Converters that change the wire type (Atoi → integer) only
-				// apply when the JSON field is currently typed as string —
-				// otherwise the explicit struct-field type wins.
-				prop.Type = c.Type
+		case metadata.KindSelector:
+			if base.X != nil && base.Sel != nil && base.X.GetKind() == metadata.KindIdent {
+				if _, ok := binding.structVars[base.X.GetName()]; ok {
+					child.fieldVars[param] = base.Sel.GetName()
+				}
 			}
 		}
 	}
+	return child
+}
+
+// applyConverterToField writes a converter's type/format onto the schema
+// property of the named Go field, without clobbering an already-set format.
+func applyConverterToField(structSchema *Schema, fields map[string]string, fieldGoName string, c *paramConverter) {
+	jsonName, ok := fields[fieldGoName]
+	if !ok {
+		return
+	}
+	prop, ok := structSchema.Properties[jsonName]
+	if !ok || prop == nil {
+		return
+	}
+	// Don't clobber an explicit format — flow inference is best-effort and a
+	// previous edge, the validator tag pass, or a nested-type pass might have
+	// set something more specific.
+	if prop.Format == "" {
+		prop.Format = c.Format
+	}
+	if c.Type != "" && (prop.Type == "" || prop.Type == "string") {
+		// Converters that change the wire type (Atoi → integer) only apply when
+		// the JSON field is currently typed as string — otherwise the explicit
+		// struct-field type wins.
+		prop.Type = c.Type
+	}
+}
+
+// unwrapArgRefs strips leading unary/star wrappers (`&x`, `*x`) to reach the
+// underlying identifier or selector.
+func unwrapArgRefs(arg *metadata.CallArgument) *metadata.CallArgument {
+	for arg != nil && (arg.GetKind() == metadata.KindUnary || arg.GetKind() == metadata.KindStar) {
+		arg = arg.X
+	}
+	return arg
 }
 
 // selectorFieldOnTarget returns the field name of `<targetVar>.<field>`

--- a/internal/spec/interproc_inference_test.go
+++ b/internal/spec/interproc_inference_test.go
@@ -1,0 +1,461 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// reqStructMeta returns metadata holding a single struct `pkg.Req` with the
+// given Go-field → json-tag pairs, ready for field-inference tests.
+func reqStructMeta(t *testing.T, fields map[string]string) *metadata.Metadata {
+	t.Helper()
+	meta := newTestMeta()
+	fs := make([]metadata.Field, 0, len(fields))
+	for goName, tag := range fields {
+		fs = append(fs, metadata.Field{
+			Name: meta.StringPool.Get(goName),
+			Tag:  meta.StringPool.Get(tag),
+		})
+	}
+	meta.Packages = map[string]*metadata.Package{
+		"pkg": {Files: map[string]*metadata.File{
+			"f.go": {Types: map[string]*metadata.Type{
+				"Req": {Name: meta.StringPool.Get("Req"), Fields: fs},
+			}},
+		}},
+	}
+	return meta
+}
+
+func reqRoute(meta *metadata.Metadata, props map[string]*Schema) *RouteInfo {
+	return &RouteInfo{
+		Metadata: meta,
+		UsedTypes: map[string]*Schema{
+			"pkg.Req": {Type: "object", Properties: props},
+		},
+	}
+}
+
+// setParamArg records a callee parameter → caller argument mapping on an edge,
+// mirroring what metadata's call-graph builder produces.
+func setParamArg(edge *metadata.CallGraphEdge, param string, arg *metadata.CallArgument) {
+	if edge.ParamArgMap == nil {
+		edge.ParamArgMap = map[string]metadata.CallArgument{}
+	}
+	edge.ParamArgMap[param] = *arg
+}
+
+// --- unwrapArgRefs -----------------------------------------------------------
+
+func TestUnwrapArgRefs(t *testing.T) {
+	meta := newTestMeta()
+	assert.Nil(t, unwrapArgRefs(nil))
+
+	ident := makeIdentArg(meta, "body", "pkg.Req")
+	assert.Same(t, ident, unwrapArgRefs(ident), "plain ident is returned unchanged")
+
+	addr := wrapUnary(meta, ident, "&")
+	assert.Same(t, ident, unwrapArgRefs(addr), "&body unwraps to body")
+
+	star := makeCallArg(meta)
+	star.SetKind(metadata.KindStar)
+	star.X = ident
+	assert.Same(t, ident, unwrapArgRefs(star), "*body unwraps to body")
+
+	// Nested *(&body) unwraps both levels.
+	nested := wrapUnary(meta, star, "*")
+	assert.Same(t, ident, unwrapArgRefs(nested))
+}
+
+// --- fieldNameForArg ---------------------------------------------------------
+
+func TestFieldNameForArg(t *testing.T) {
+	meta := newTestMeta()
+	binding := fieldBinding{
+		structVars: map[string]struct{}{"body": {}},
+		fieldVars:  map[string]string{"raw": "SourceID"},
+	}
+
+	// Selector on a struct var.
+	assert.Equal(t, "DestID", fieldNameForArg(mkSelArgPtr(meta, "body", "DestID"), binding))
+	// *body.Opt — pointer-dereferenced selector.
+	assert.Equal(t, "Opt", fieldNameForArg(wrapUnary(meta, mkSelArgPtr(meta, "body", "Opt"), "*"), binding))
+	// Bare ident previously bound to a field's value.
+	assert.Equal(t, "SourceID", fieldNameForArg(makeIdentArg(meta, "raw", "string"), binding))
+
+	// Non-matches.
+	assert.Empty(t, fieldNameForArg(nil, binding))
+	assert.Empty(t, fieldNameForArg(mkSelArgPtr(meta, "other", "X"), binding), "selector on unknown var")
+	assert.Empty(t, fieldNameForArg(makeIdentArg(meta, "unbound", "string"), binding), "ident not in fieldVars")
+	assert.Empty(t, fieldNameForArg(makeLiteralArg(meta, "x"), binding))
+
+	bareSel := makeCallArg(meta)
+	bareSel.SetKind(metadata.KindSelector) // no X/Sel
+	assert.Empty(t, fieldNameForArg(bareSel, binding))
+}
+
+// --- childBinding ------------------------------------------------------------
+
+func TestChildBinding(t *testing.T) {
+	meta := newTestMeta()
+	parent := fieldBinding{
+		structVars: map[string]struct{}{"body": {}},
+		fieldVars:  map[string]string{"src": "SourceID"},
+	}
+
+	edge := makeEdge(meta, "Copy", "pkg", "helper", "pkg", nil)
+	// param "whole" receives the whole struct (&body) → struct var in child.
+	setParamArg(&edge, "whole", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&"))
+	// param "field" receives body.AuthID (a selector) → field var in child.
+	setParamArg(&edge, "field", mkSelArgPtr(meta, "body", "AuthID"))
+	// param "passthru" receives src (already a field var) → field var in child.
+	setParamArg(&edge, "passthru", makeIdentArg(meta, "src", "string"))
+	// param "unrelated" receives an unknown var → ignored.
+	setParamArg(&edge, "unrelated", makeIdentArg(meta, "w", "http.ResponseWriter"))
+
+	child := childBinding(&edge, parent)
+
+	_, isStruct := child.structVars["whole"]
+	assert.True(t, isStruct, "whole-struct arg makes the param a struct var")
+	assert.Equal(t, "AuthID", child.fieldVars["field"], "selector arg binds param to that field")
+	assert.Equal(t, "SourceID", child.fieldVars["passthru"], "field-var arg carries its field through")
+	_, unrelatedStruct := child.structVars["unrelated"]
+	_, unrelatedField := child.fieldVars["unrelated"]
+	assert.False(t, unrelatedStruct || unrelatedField, "unrelated arg is dropped")
+}
+
+// --- propagateFieldFormats (interprocedural) ---------------------------------
+
+// TestApplyJSONFieldConverterFormats_FieldPassedHelper covers issue #36 Repro 1
+// (field-passed): the handler passes body.SourceID into a helper that runs
+// uuid.Parse on the parameter. format=uuid must propagate back to sourceId.
+func TestApplyJSONFieldConverterFormats_FieldPassedHelper(t *testing.T) {
+	meta := reqStructMeta(t, map[string]string{"SourceID": `json:"sourceId"`})
+
+	// Copy → validateUUID(body.SourceID)
+	callHelper := makeEdge(meta, "Copy", "pkg", "validateUUID", "pkg",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "SourceID")})
+	setParamArg(&callHelper, "raw", mkSelArgPtr(meta, "body", "SourceID"))
+	// validateUUID → uuid.Parse(raw)
+	callParse := makeEdge(meta, "validateUUID", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{makeIdentArg(meta, "raw", "string")})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		callHelper.Caller.BaseID(): {&callHelper},
+		callParse.Caller.BaseID():  {&callParse},
+	}
+
+	route := reqRoute(meta, map[string]*Schema{"sourceId": {Type: "string"}})
+	applyJSONFieldConverterFormats("body", "pkg.Req", callHelper.Caller.BaseID(), route)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["sourceId"].Format,
+		"format must follow body.SourceID into the helper that parses it")
+}
+
+// TestApplyJSONFieldConverterFormats_StructPassedHelper covers issue #36
+// Repro 1 (struct-passed): the handler passes the whole body into a helper that
+// selects fields and runs uuid.Parse on them.
+func TestApplyJSONFieldConverterFormats_StructPassedHelper(t *testing.T) {
+	meta := reqStructMeta(t, map[string]string{
+		"DestID":   `json:"destId"`,
+		"TagsetID": `json:"tagsetId,omitempty"`,
+	})
+
+	// Copy → resolveIDs(body)
+	callHelper := makeEdge(meta, "Copy", "pkg", "resolveIDs", "pkg",
+		[]*metadata.CallArgument{makeIdentArg(meta, "body", "pkg.Req")})
+	setParamArg(&callHelper, "in", makeIdentArg(meta, "body", "pkg.Req"))
+	// resolveIDs → uuid.Parse(in.DestID) and uuid.Parse(*in.TagsetID)
+	callParseDest := makeEdge(meta, "resolveIDs", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "in", "DestID")})
+	callParseTagset := makeEdge(meta, "resolveIDs", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{wrapUnary(meta, mkSelArgPtr(meta, "in", "TagsetID"), "*")})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		callHelper.Caller.BaseID():    {&callHelper},
+		callParseDest.Caller.BaseID(): {&callParseDest, &callParseTagset},
+	}
+
+	route := reqRoute(meta, map[string]*Schema{
+		"destId":   {Type: "string"},
+		"tagsetId": {Type: "string"},
+	})
+	applyJSONFieldConverterFormats("body", "pkg.Req", callHelper.Caller.BaseID(), route)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["destId"].Format)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["tagsetId"].Format,
+		"pointer-dereferenced field selected inside the helper still resolves")
+}
+
+// TestApplyJSONFieldConverterFormats_SameHelperTwice verifies sibling calls into
+// the same helper with different field bindings are both followed (the on-stack
+// guard is unwound between siblings).
+func TestApplyJSONFieldConverterFormats_SameHelperTwice(t *testing.T) {
+	meta := reqStructMeta(t, map[string]string{
+		"A": `json:"a"`,
+		"B": `json:"b"`,
+	})
+
+	callA := makeEdge(meta, "Copy", "pkg", "check", "pkg",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "A")})
+	setParamArg(&callA, "v", mkSelArgPtr(meta, "body", "A"))
+	callB := makeEdge(meta, "Copy", "pkg", "check", "pkg",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "B")})
+	setParamArg(&callB, "v", mkSelArgPtr(meta, "body", "B"))
+	parseInCheck := makeEdge(meta, "check", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{makeIdentArg(meta, "v", "string")})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		callA.Caller.BaseID():        {&callA, &callB},
+		parseInCheck.Caller.BaseID(): {&parseInCheck},
+	}
+
+	route := reqRoute(meta, map[string]*Schema{
+		"a": {Type: "string"},
+		"b": {Type: "string"},
+	})
+	applyJSONFieldConverterFormats("body", "pkg.Req", callA.Caller.BaseID(), route)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["a"].Format)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["b"].Format,
+		"second call into the same helper must also be followed")
+}
+
+// TestApplyJSONFieldConverterFormats_RecursiveHelperTerminates ensures a helper
+// that (transitively) calls itself can't drive infinite recursion.
+func TestApplyJSONFieldConverterFormats_RecursiveHelperTerminates(t *testing.T) {
+	meta := reqStructMeta(t, map[string]string{"ID": `json:"id"`})
+
+	// Copy → recur(body); recur → recur(in); recur → uuid.Parse(in.ID)
+	callHelper := makeEdge(meta, "Copy", "pkg", "recur", "pkg",
+		[]*metadata.CallArgument{makeIdentArg(meta, "body", "pkg.Req")})
+	setParamArg(&callHelper, "in", makeIdentArg(meta, "body", "pkg.Req"))
+	selfCall := makeEdge(meta, "recur", "pkg", "recur", "pkg",
+		[]*metadata.CallArgument{makeIdentArg(meta, "in", "pkg.Req")})
+	setParamArg(&selfCall, "in", makeIdentArg(meta, "in", "pkg.Req"))
+	parse := makeEdge(meta, "recur", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "in", "ID")})
+
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		callHelper.Caller.BaseID(): {&callHelper},
+		selfCall.Caller.BaseID():   {&selfCall, &parse},
+	}
+
+	route := reqRoute(meta, map[string]*Schema{"id": {Type: "string"}})
+	// Must terminate (and still pick up the format on the first visit).
+	applyJSONFieldConverterFormats("body", "pkg.Req", callHelper.Caller.BaseID(), route)
+	assert.Equal(t, "uuid", route.UsedTypes["pkg.Req"].Properties["id"].Format)
+}
+
+// TestPropagateFieldFormats_DepthGuards exercises the empty-binding and
+// depth-limit early returns directly.
+func TestPropagateFieldFormats_DepthGuards(t *testing.T) {
+	meta := reqStructMeta(t, map[string]string{"ID": `json:"id"`})
+	parse := makeEdge(meta, "Copy", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "body", "ID")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{parse.Caller.BaseID(): {&parse}}
+	schema := &Schema{Type: "object", Properties: map[string]*Schema{"id": {Type: "string"}}}
+	fields := map[string]string{"ID": "id"}
+	full := fieldBinding{structVars: map[string]struct{}{"body": {}}, fieldVars: map[string]string{}}
+
+	// Empty binding → no-op.
+	propagateFieldFormats(parse.Caller.BaseID(), fieldBinding{}, fields, schema, meta, map[string]struct{}{}, 0)
+	assert.Empty(t, schema.Properties["id"].Format)
+
+	// Over the depth limit → no-op.
+	propagateFieldFormats(parse.Caller.BaseID(), full, fields, schema, meta, map[string]struct{}{}, maxFieldInferenceDepth+1)
+	assert.Empty(t, schema.Properties["id"].Format)
+
+	// In-bounds → applies.
+	propagateFieldFormats(parse.Caller.BaseID(), full, fields, schema, meta, map[string]struct{}{}, 0)
+	assert.Equal(t, "uuid", schema.Properties["id"].Format)
+}
+
+// TestPropagateFieldFormats_DepthCapStopsDescent verifies that at the maximum
+// depth a converter is still recorded but helper calls are no longer followed.
+func TestPropagateFieldFormats_DepthCapStopsDescent(t *testing.T) {
+	meta := reqStructMeta(t, map[string]string{"ID": `json:"id"`})
+	// Copy → helper(body); helper → uuid.Parse(in.ID)
+	callHelper := makeEdge(meta, "Copy", "pkg", "helper", "pkg",
+		[]*metadata.CallArgument{makeIdentArg(meta, "body", "pkg.Req")})
+	setParamArg(&callHelper, "in", makeIdentArg(meta, "body", "pkg.Req"))
+	parse := makeEdge(meta, "helper", "pkg", "Parse", "github.com/google/uuid",
+		[]*metadata.CallArgument{mkSelArgPtr(meta, "in", "ID")})
+	meta.Callers = map[string][]*metadata.CallGraphEdge{
+		callHelper.Caller.BaseID(): {&callHelper},
+		parse.Caller.BaseID():      {&parse},
+	}
+	schema := &Schema{Type: "object", Properties: map[string]*Schema{"id": {Type: "string"}}}
+	binding := fieldBinding{structVars: map[string]struct{}{"body": {}}, fieldVars: map[string]string{}}
+
+	// At the cap, the Copy→helper edge must not be descended into.
+	propagateFieldFormats(callHelper.Caller.BaseID(), binding, map[string]string{"ID": "id"},
+		schema, meta, map[string]struct{}{}, maxFieldInferenceDepth)
+	assert.Empty(t, schema.Properties["id"].Format, "helper descent is capped at maxFieldInferenceDepth")
+}
+
+func TestChildBinding_NilUnwrapSkipped(t *testing.T) {
+	meta := newTestMeta()
+	edge := makeEdge(meta, "Copy", "pkg", "helper", "pkg", nil)
+	bareUnary := makeCallArg(meta)
+	bareUnary.SetKind(metadata.KindUnary) // no X → unwrap yields nil
+	setParamArg(&edge, "p", bareUnary)
+	child := childBinding(&edge, fieldBinding{structVars: map[string]struct{}{"body": {}}})
+	assert.True(t, child.empty(), "a param whose arg unwraps to nil is skipped")
+}
+
+// TestResolveBodyTypeThroughCallSite_WalksPastNonMatchingAncestors covers the
+// loop's continue branches: an edge-less node and a non-matching call between
+// the decode node and the real call site.
+func TestResolveBodyTypeThroughCallSite_WalksPastNonMatchingAncestors(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+
+	decodeEdge := makeEdge(meta, "decodeStrictJSON", "pkg", "Decode", "encoding/json",
+		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
+	// Immediate parent: a node with no edge (skipped).
+	edgeless := &TrackerNode{}
+	// Next: a non-matching call (NewDecoder, not decodeStrictJSON) — skipped.
+	other := makeEdge(meta, "decodeStrictJSON", "pkg", "NewDecoder", "encoding/json", nil)
+	// Finally: the real call site Copy → decodeStrictJSON(&body).
+	callSite := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+	setParamArg(&callSite, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&"))
+
+	decodeNode := makeTrackerNode(&decodeEdge)
+	otherNode := makeTrackerNode(&other)
+	otherNode.Parent = makeTrackerNode(&callSite)
+	edgeless.Parent = otherNode
+	decodeNode.Parent = edgeless
+
+	bodyType, varName, baseID := resolveBodyTypeThroughCallSite(decodeNode, "dst", cp)
+	assert.Equal(t, "pkg.Req", bodyType)
+	assert.Equal(t, "body", varName)
+	assert.Equal(t, callSite.Caller.BaseID(), baseID)
+}
+
+// --- isFreeFormBodyType ------------------------------------------------------
+
+func TestIsFreeFormBodyType(t *testing.T) {
+	for _, s := range []string{"", "any", "interface{}", "interface {}", "object", "  any  "} {
+		assert.Truef(t, isFreeFormBodyType(s), "%q is free-form", s)
+	}
+	for _, s := range []string{"pkg.Req", "string", "[]byte", "map[string]any"} {
+		assert.Falsef(t, isFreeFormBodyType(s), "%q is concrete", s)
+	}
+}
+
+// --- resolveBodyTypeThroughCallSite -----------------------------------------
+
+// TestResolveBodyTypeThroughCallSite covers issue #36 Repro 2: the decode lives
+// in decodeStrictJSON(dst any); walking up to the call site recovers the
+// concrete &body argument and its type.
+func TestResolveBodyTypeThroughCallSite(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+
+	// Tree: Copy → decodeStrictJSON(&body) → json.Decode(dst)
+	callHelper := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg",
+		[]*metadata.CallArgument{wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&")})
+	setParamArg(&callHelper, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&"))
+	decodeEdge := makeEdge(meta, "decodeStrictJSON", "pkg", "Decode", "encoding/json",
+		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
+
+	parent := makeTrackerNode(&callHelper)
+	decodeNode := makeTrackerNode(&decodeEdge)
+	decodeNode.Parent = parent
+
+	bodyType, varName, baseID := resolveBodyTypeThroughCallSite(decodeNode, "dst", cp)
+	assert.Equal(t, "pkg.Req", bodyType, "concrete type recovered from the call site")
+	assert.Equal(t, "body", varName, "re-anchored onto the caller's variable")
+	assert.Equal(t, callHelper.Caller.BaseID(), baseID, "field inference runs in the caller frame")
+}
+
+func TestResolveBodyTypeThroughCallSite_Guards(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+
+	// Nil node / empty param.
+	bt, _, _ := resolveBodyTypeThroughCallSite(nil, "dst", cp)
+	assert.Empty(t, bt)
+	decodeEdge := makeEdge(meta, "helper", "pkg", "Decode", "encoding/json", nil)
+	node := makeTrackerNode(&decodeEdge)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node, "", cp)
+	assert.Empty(t, bt)
+
+	// No ancestor edge invokes the enclosing helper → unresolved.
+	bt, _, _ = resolveBodyTypeThroughCallSite(node, "dst", cp)
+	assert.Empty(t, bt)
+
+	// Ancestor calls the helper but maps the param to a non-ident (call expr) →
+	// unresolved rather than wrong.
+	callHelper := makeEdge(meta, "Copy", "pkg", "helper", "pkg", nil)
+	complexArg := makeCallArg(meta)
+	complexArg.SetKind(metadata.KindCall)
+	setParamArg(&callHelper, "dst", complexArg)
+	node.Parent = makeTrackerNode(&callHelper)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node, "dst", cp)
+	assert.Empty(t, bt, "non-ident mapped argument is not resolved")
+
+	// Ancestor calls the helper but has no mapping for the param → unresolved.
+	callHelper2 := makeEdge(meta, "Copy", "pkg", "helper", "pkg", nil)
+	node2 := makeTrackerNode(&decodeEdge)
+	node2.Parent = makeTrackerNode(&callHelper2)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node2, "dst", cp)
+	assert.Empty(t, bt, "missing ParamArgMap entry → unresolved")
+}
+
+// TestRefineBodyTypeThroughHelper exercises the matcher-level wrapper that
+// drives the interprocedural body-type fallback during request extraction.
+func TestRefineBodyTypeThroughHelper(t *testing.T) {
+	meta := newTestMeta()
+	cfg := DefaultChiConfig()
+	matcher := NewRequestPatternMatcher(RequestBodyPattern{}, cfg, NewContextProvider(meta),
+		NewTypeResolver(meta, cfg, NewSchemaMapper(cfg)))
+
+	// Already concrete → returned unchanged, reqInfo untouched.
+	concrete := &RequestInfo{BodyType: "pkg.Req", DecodeTargetVar: "body"}
+	bt, frame := matcher.refineBodyTypeThroughHelper(nil, concrete, "pkg.Req", "frameA")
+	assert.Equal(t, "pkg.Req", bt)
+	assert.Equal(t, "frameA", frame)
+	assert.Equal(t, "body", concrete.DecodeTargetVar)
+
+	// Free-form but unresolvable (nil node) → returned unchanged.
+	unresolved := &RequestInfo{BodyType: "any", DecodeTargetVar: "dst"}
+	bt, frame = matcher.refineBodyTypeThroughHelper(nil, unresolved, "any", "frameB")
+	assert.Equal(t, "any", bt)
+	assert.Equal(t, "frameB", frame)
+	assert.Equal(t, "any", unresolved.BodyType)
+
+	// Free-form and resolvable through the call site → upgraded in place.
+	decodeEdge := makeEdge(meta, "decodeStrictJSON", "pkg", "Decode", "encoding/json",
+		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
+	callSite := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+	setParamArg(&callSite, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&"))
+	decodeNode := makeTrackerNode(&decodeEdge)
+	decodeNode.Parent = makeTrackerNode(&callSite)
+
+	upgraded := &RequestInfo{BodyType: "any", DecodeTargetVar: "dst"}
+	bt, frame = matcher.refineBodyTypeThroughHelper(decodeNode, upgraded, "any", "frameC")
+	assert.Equal(t, "pkg.Req", bt)
+	assert.Equal(t, callSite.Caller.BaseID(), frame)
+	assert.Equal(t, "pkg.Req", upgraded.BodyType)
+	assert.Equal(t, "body", upgraded.DecodeTargetVar, "decode target re-anchored to the caller var")
+}
+
+func TestResolveBodyTypeThroughCallSite_NoEdgeNode(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	// A node with no edge returns empty.
+	bare := &TrackerNode{}
+	bt, _, _ := resolveBodyTypeThroughCallSite(bare, "dst", cp)
+	require.Empty(t, bt)
+}

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -541,6 +541,11 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 		ContentType: r.cfg.Defaults.RequestContentType,
 	}
 
+	// Frame whose call graph drives field-format inference. Defaults to the
+	// function holding the decode call, but is re-anchored to the caller when
+	// the decode is resolved through an extracted helper (issue #36).
+	fieldFrameBaseID := edge.Caller.BaseID()
+
 	if r.pattern.TypeFromArg && len(edge.Args) > r.pattern.TypeArgIndex {
 		arg := edge.Args[r.pattern.TypeArgIndex]
 		bodyType := r.contextProvider.GetArgumentInfo(arg)
@@ -570,6 +575,12 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 
 		reqInfo.BodyType = preprocessingBodyType(bodyType)
 		reqInfo.DecodeTargetVar = decodeTargetVarName(arg)
+
+		// Interprocedural fallback (issue #36): when the decode lives in an
+		// extracted helper, recover the concrete type from the call site and
+		// re-anchor the decode target + field-inference frame onto the caller.
+		bodyType, fieldFrameBaseID = r.refineBodyTypeThroughHelper(node, reqInfo, bodyType, fieldFrameBaseID)
+
 		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
 		reqInfo.Schema = schema
 	}
@@ -583,20 +594,102 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 	// handler then 400s on. Marking required:true reflects that contract.
 	reqInfo.Required = true
 
-	// Walk the rest of the handler for `<targetVar>.<field>` accesses fed into
-	// known converters and back-propagate their schema formats onto the struct
-	// fields. Cheap (we already have the call graph indexed by caller) and
-	// strictly additive — never erases existing information.
+	// Walk the handler (and one or more levels of extracted helpers) for
+	// `<targetVar>.<field>` accesses fed into known converters and back-
+	// propagate their schema formats onto the struct fields. Cheap (we already
+	// have the call graph indexed by caller) and strictly additive — never
+	// erases existing information.
 	if reqInfo.DecodeTargetVar != "" && route.Metadata != nil {
 		applyJSONFieldConverterFormats(
 			reqInfo.DecodeTargetVar,
 			reqInfo.BodyType,
-			edge.Caller.BaseID(),
+			fieldFrameBaseID,
 			route,
 		)
 	}
 
 	return reqInfo
+}
+
+// refineBodyTypeThroughHelper upgrades a free-form decode binding (issue #36):
+// when the decode call lives in an extracted helper — `func decode(dst any)` —
+// the type-arg resolves only to the helper's `any` parameter. It walks up to
+// the call site that invoked the helper, recovers the concrete argument
+// (`&body`), and re-anchors the decode target onto the caller's variable so
+// field inference runs in the handler frame rather than the helper's. reqInfo
+// is mutated in place; the returned (bodyType, fieldFrameBaseID) replace the
+// caller's locals for schema generation and field inference. A no-op when the
+// body type already resolved concretely or no call site could be found.
+func (r *RequestPatternMatcherImpl) refineBodyTypeThroughHelper(node TrackerNodeInterface, reqInfo *RequestInfo, bodyType, fieldFrameBaseID string) (string, string) {
+	if !isFreeFormBodyType(reqInfo.BodyType) {
+		return bodyType, fieldFrameBaseID
+	}
+	bt, varName, frameBaseID := resolveBodyTypeThroughCallSite(node, reqInfo.DecodeTargetVar, r.contextProvider)
+	if bt == "" || isFreeFormBodyType(bt) {
+		return bodyType, fieldFrameBaseID
+	}
+	reqInfo.BodyType = preprocessingBodyType(bt)
+	reqInfo.DecodeTargetVar = varName
+	return bt, frameBaseID
+}
+
+// maxCallSiteDepth bounds how far up the tracker tree resolveBodyTypeThroughCallSite
+// walks looking for the call site that invoked the decode helper.
+const maxCallSiteDepth = 16
+
+// isFreeFormBodyType reports whether a resolved body type carries no concrete
+// schema — the empty string or a bare interface. These are the only cases the
+// interprocedural fallback should try to refine; a genuine `any` body that
+// can't be resolved is left free-form.
+func isFreeFormBodyType(t string) bool {
+	switch strings.TrimSpace(t) {
+	case "", "any", "interface{}", "interface {}", "object":
+		return true
+	}
+	return false
+}
+
+// resolveBodyTypeThroughCallSite handles the interprocedural decode case
+// (issue #36): the matched decode call lives in a helper whose decode target is
+// a parameter (typically typed `any`), so intraprocedural resolution yields no
+// concrete type. It walks up the tracker tree to the nearest ancestor edge that
+// invoked the enclosing helper, maps the decode parameter to the concrete
+// argument passed at that call site, and returns the resolved body type, the
+// caller-frame variable name (so downstream field inference runs in the right
+// frame), and that frame's base ID.
+func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string, cp ContextProvider) (bodyType, varName, callerBaseID string) {
+	if node == nil || paramName == "" {
+		return "", "", ""
+	}
+	edge := node.GetEdge()
+	if edge == nil {
+		return "", "", ""
+	}
+	// The function enclosing the decode call (e.g. decodeStrictJSON); we look
+	// for the ancestor edge that called it.
+	enclosingName := edge.Caller.Name
+	enclosingPkg := edge.Caller.Pkg
+
+	for depth, cur := 0, node.GetParent(); cur != nil && depth < maxCallSiteDepth; cur, depth = cur.GetParent(), depth+1 {
+		anc := cur.GetEdge()
+		if anc == nil {
+			continue
+		}
+		if anc.Callee.Name != enclosingName || anc.Callee.Pkg != enclosingPkg {
+			continue
+		}
+		callArg, ok := anc.ParamArgMap[paramName]
+		if !ok {
+			return "", "", ""
+		}
+		base := unwrapArgRefs(&callArg)
+		if base == nil || base.GetKind() != metadata.KindIdent {
+			return "", "", ""
+		}
+		resolved := strings.TrimPrefix(cp.GetArgumentInfo(base), "*")
+		return resolved, base.GetName(), anc.Caller.BaseID()
+	}
+	return "", "", ""
 }
 
 // decodeTargetVarName returns the local variable name that the decode call's

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Per-package statement-coverage gate.
+#
+# Enforces the repo's documented ≥95%-per-package target (see CLAUDE.md) from a
+# Go coverage profile, so a change that drops a package below its floor fails CI
+# rather than silently eroding coverage.
+#
+# Usage:
+#   scripts/check-coverage.sh [coverage-profile]
+# The profile defaults to coverage.out and must be produced with
+# `go test -coverprofile=<profile> ./...`.
+#
+# The CLI entrypoint packages (cmd/*) carry their own lower floors: they are
+# thin main()/flag glue, not the analysis library the 95% target is about.
+# These floors are a no-regression ratchet — raise them as coverage improves,
+# never lower them.
+
+set -euo pipefail
+
+PROFILE="${1:-coverage.out}"
+DEFAULT_MIN=95.0
+
+# Package import path -> minimum percent. Anything not listed uses DEFAULT_MIN.
+declare -A FLOOR=(
+	["github.com/antst/go-apispec/cmd/apispec"]=90.0
+	["github.com/antst/go-apispec/cmd/apidiag"]=92.0
+)
+
+if [[ ! -f "$PROFILE" ]]; then
+	echo "coverage profile not found: $PROFILE" >&2
+	echo "produce it with: go test -coverprofile=$PROFILE ./..." >&2
+	exit 2
+fi
+
+# Aggregate covered/total statements per package from the profile. Each data
+# line is "<importpath>/<file>.go:<pos> <numStatements> <hitCount>"; the package
+# is the directory portion of the file path.
+pkg_pcts="$(awk '
+	/^mode:/ { next }
+	{
+		file = $1
+		sub(/:[0-9].*$/, "", file)          # strip ":line.col,line.col"
+		# Package import path = dirname(file). Built by re-joining all path
+		# components except the trailing filename (avoids a slash inside a
+		# regex class, which is non-portable across awk implementations).
+		n = split(file, parts, "/")
+		pkg = parts[1]
+		for (i = 2; i < n; i++) pkg = pkg "/" parts[i]
+		stmts = $(NF - 1)
+		hits  = $NF
+		total[pkg] += stmts
+		if (hits > 0) covered[pkg] += stmts
+	}
+	END {
+		for (p in total) {
+			pct = (total[p] > 0) ? (covered[p] * 100.0 / total[p]) : 100.0
+			printf "%s %.1f\n", p, pct
+		}
+	}
+' "$PROFILE" | sort)"
+
+if [[ -z "$pkg_pcts" ]]; then
+	echo "no coverage data found in $PROFILE" >&2
+	exit 2
+fi
+
+fail=0
+printf '%-55s %8s %8s   %s\n' "PACKAGE" "COVERAGE" "FLOOR" "STATUS"
+while read -r pkg pct; do
+	min="${FLOOR[$pkg]:-$DEFAULT_MIN}"
+	if awk "BEGIN{exit !($pct + 0 < $min + 0)}"; then
+		status="FAIL"
+		fail=1
+	else
+		status="ok"
+	fi
+	printf '%-55s %7s%% %7s%%   %s\n' "${pkg#github.com/antst/go-apispec/}" "$pct" "$min" "$status"
+done <<<"$pkg_pcts"
+
+echo
+if [[ "$fail" -ne 0 ]]; then
+	echo "coverage gate FAILED: one or more packages are below their floor (default ${DEFAULT_MIN}%)." >&2
+	echo "Add tests for the net-new logic, or — for an intentional, justified floor change — update scripts/check-coverage.sh." >&2
+	exit 1
+fi
+echo "coverage gate passed: every package meets its floor (default ${DEFAULT_MIN}%)."

--- a/testdata/json_dto_helpers/expected_openapi.json
+++ b/testdata/json_dto_helpers/expected_openapi.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/copy": {
+      "post": {
+        "summary": "Copy decodes and validates the request body entirely through helpers.",
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/json_dto.CopyDocumentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "externalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tagsetId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId",
+          "authorizationId",
+          "externalId",
+          "expiresAt"
+        ]
+      },
+      "json_dto.CopyDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ownerEmail": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "ownerEmail"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/json_dto_helpers/expected_openapi_legacy.json
+++ b/testdata/json_dto_helpers/expected_openapi_legacy.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/documents/copy": {
+      "post": {
+        "summary": "Copy decodes and validates the request body entirely through helpers.",
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/json_dto.CopyDocumentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "externalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tagsetId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId",
+          "authorizationId",
+          "externalId",
+          "expiresAt"
+        ]
+      },
+      "json_dto.CopyDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ownerEmail": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "ownerEmail"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/json_dto_helpers/go.mod
+++ b/testdata/json_dto_helpers/go.mod
@@ -1,0 +1,8 @@
+module json_dto
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
+)

--- a/testdata/json_dto_helpers/go.sum
+++ b/testdata/json_dto_helpers/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/json_dto_helpers/main.go
+++ b/testdata/json_dto_helpers/main.go
@@ -1,0 +1,113 @@
+// Package main is the interprocedural counterpart of the json_dto fixture: it
+// exercises the same request-body inference (requestBody.required, per-field
+// format: uuid) but after the lint-driven helper extractions described in
+// issue #36, where the literal patterns no longer sit inside the handler body.
+//
+// It guards three interprocedural shapes:
+//
+//   - Repro 2 — the strict-decode boilerplate is extracted into decodeStrictJSON,
+//     whose decode target is an `any` parameter. Binding must follow the call
+//     site to recover the concrete CopyDocumentRequest type.
+//   - Repro 1 (field-passed) — the handler passes body.SourceID into a helper
+//     that runs uuid.Parse on it; format: uuid must propagate back to sourceId.
+//   - Repro 1 (struct-passed) — the handler passes the whole body into a helper
+//     that selects fields and runs uuid.Parse on them; format: uuid must
+//     propagate back to destinationBucketId, authorizationId and tagsetId.
+//
+// The generated schema is expected to match the json_dto fixture's
+// CopyDocumentRequest byte-for-byte (modulo operationId/summary).
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// CopyDocumentRequest mirrors the json_dto fixture: string-typed UUID fields
+// validated at runtime via uuid.Parse, plus two tag-pinned fields.
+type CopyDocumentRequest struct {
+	SourceID            string  `json:"sourceId"`
+	DestinationBucketID string  `json:"destinationBucketId"`
+	AuthorizationID     string  `json:"authorizationId"`
+	TagsetID            *string `json:"tagsetId,omitempty"`
+
+	ExternalID string `json:"externalId" apispec:"format=uuid"`
+	ExpiresAt  string `json:"expiresAt" apispec:"format=date-time"`
+}
+
+// CopyDocumentResponse is returned on success; its fields are pinned via tags.
+type CopyDocumentResponse struct {
+	ID         string `json:"id" apispec:"format=uuid"`
+	CreatedAt  string `json:"createdAt" apispec:"format=date-time"`
+	OwnerEmail string `json:"ownerEmail" apispec:"format=email"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Post("/documents/copy", Copy)
+	http.ListenAndServe(":3000", r)
+}
+
+// decodeStrictJSON is the extracted strict-decode helper (issue #36, Repro 2).
+// dst is typed any, so the decode target type is only knowable at the call site.
+func decodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// parseSourceID is a field-passed helper: it receives a single field's value
+// (body.SourceID) and runs uuid.Parse on it (issue #36, Repro 1).
+func parseSourceID(raw string) (uuid.UUID, error) {
+	return uuid.Parse(raw)
+}
+
+// resolveBucketIDs is a struct-passed helper: it receives the whole request
+// struct and selects fields to validate as UUIDs (issue #36, Repro 1).
+func resolveBucketIDs(body CopyDocumentRequest) error {
+	if _, err := uuid.Parse(body.DestinationBucketID); err != nil {
+		return err
+	}
+	if _, err := uuid.Parse(body.AuthorizationID); err != nil {
+		return err
+	}
+	if body.TagsetID != nil {
+		if _, err := uuid.Parse(*body.TagsetID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Copy decodes and validates the request body entirely through helpers.
+func Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+
+	if _, err := parseSourceID(body.SourceID); err != nil {
+		http.Error(w, "invalid sourceId", http.StatusBadRequest)
+		return
+	}
+	if err := resolveBucketIDs(body); err != nil {
+		http.Error(w, "invalid bucket id", http.StatusBadRequest)
+		return
+	}
+
+	resp := CopyDocumentResponse{
+		ID:         uuid.NewString(),
+		CreatedAt:  time.Now().Format(time.RFC3339),
+		OwnerEmail: "owner@example.com",
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}


### PR DESCRIPTION
Closes #36.

## Problem

Request-body type binding, field-format inference (`uuid.Parse` → `format: uuid`), and `http.Error` response typing were all **intraprocedural** — they keyed on patterns appearing literally inside the handler body. A single level of helper extraction (the most common gocyclo/DRY refactor) silently degraded the generated spec with no warning.

Reproduced deterministically:
- **Repro 2** — extracting the strict-decode boilerplate into `decodeStrictJSON(dst any)` collapsed the request body to free-form `type: object` and deleted the component schema.
- **Repro 1** — extracting `uuid.Parse` into a helper (field-passed `helper(body.Field)` or struct-passed `helper(body)`) dropped `format: uuid`.
- **Response mis-attribution** (found while fixing the above) — *not* helper-specific: `http.Error` reads its body type from the message arg, so a non-literal message like `"invalid "+name` (exactly what extracted error helpers build) left the type unresolved, the 400 slot read as "vacant", and `findVacantStatusForBody` let the inline success `Encode` body steal it — the `200` vanished and the response schema mis-attached to `400`.

## Fix (root cause, strictly additive — never clobbers existing info)

- **`field_inference.go`** — `applyJSONFieldConverterFormats` now drives a recursive `propagateFieldFormats` that follows the call graph through `CallGraphEdge.ParamArgMap`, projecting a struct/field binding onto each helper's parameters. Handles field-passed and struct-passed helpers. Bounded by depth 8 + an on-stack cycle guard unwound between siblings.
- **`pattern_matchers.go`** — when a decode lands in a helper with an `any` parameter, `resolveBodyTypeThroughCallSite` walks up the tracker tree to the call site, recovers the concrete `&body` argument, and re-anchors the decode target + field-inference frame onto the caller (`refineBodyTypeThroughHelper`).
- **`config.go`** — pinned `DefaultBodyType: "string"` on all six `http.Error` patterns (its body is always a text/plain string), so the status slot is claimed even when the message arg can't be typed.

## Verification

- New fixture `testdata/json_dto_helpers` reproduces the issue's refactors; its golden is **byte-identical in schema/responses** to the inline `json_dto` fixture.
- **All existing golden files unchanged** (`TestUpdateGolden` reports every other fixture "unchanged") — confirms the change is purely additive.
- New unit tests + an e2e assertion. New code at 100% coverage; `internal/spec` package at 95.5%. Full suite, `go vet`, `golangci-lint`, and `-race` all pass.

## Notes

This implements the issue's option 1 (follow the call graph) — the root-cause fix — rather than the annotation escape-hatch or `--check` guard, which treat the symptom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interprocedural inference to accurately determine request/response body types through helper functions
  * Enhanced field format detection for UUID, date-time, and email types across helper calls

* **Bug Fixes**
  * Improved error response type handling for consistent schema generation
  * Fixed response body type resolution when processing through nested helpers

* **Tests**
  * Added comprehensive regression test suite for interprocedural type inference validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->