### PR TITLE
fix: drop in:path params with no matching template placeholder (#35)

### DIFF
--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -45,6 +45,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "echo", inputDir: "../../testdata/echo", configFn: spec.DefaultEchoConfig},
 		{name: "fiber", inputDir: "../../testdata/fiber", configFn: spec.DefaultFiberConfig},
 		{name: "mux", inputDir: "../../testdata/mux", configFn: spec.DefaultMuxConfig},
+		{name: "map_index_path", inputDir: "../../testdata/map_index_path", configFn: spec.DefaultMuxConfig},
 		{name: "response_patterns", inputDir: "../../testdata/response_patterns", configFn: spec.DefaultChiConfig},
 		{name: "nested_http", inputDir: "../../testdata/nested_http", configFn: spec.DefaultHTTPConfig},
 		{name: "error_helpers", inputDir: "../../testdata/error_helpers", configFn: spec.DefaultChiConfig},
@@ -484,6 +485,39 @@ func TestE2E_JSONDtoHelpers_InterproceduralInference(t *testing.T) {
 	require.NotNil(t, resp400Schema)
 	assert.Equal(t, "string", resp400Schema.Type,
 		"400 must remain a plain-text string, not steal the success body schema")
+}
+
+// TestE2E_MapIndexPath_NoPhantomPathParams asserts issue #35: a string-literal
+// index into a plain map (fields["displayName"]) must not become an in:path
+// parameter on a route with no placeholders, while a genuine mux.Vars read that
+// matches a {placeholder} must still be emitted.
+func TestE2E_MapIndexPath_NoPhantomPathParams(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/map_index_path", spec.DefaultMuxConfig())
+	eng := NewEngine(cfg)
+	result, err := eng.GenerateOpenAPI()
+	require.NoError(t, err)
+
+	// Bug case: no path params on a placeholder-free route.
+	file, ok := result.Paths["/internal/file"]
+	require.True(t, ok, "/internal/file must be present")
+	require.NotNil(t, file.Post)
+	for _, p := range file.Post.Parameters {
+		assert.NotEqualf(t, "path", p.In,
+			"no path parameter expected on /internal/file, got %q (issue #35)", p.Name)
+	}
+
+	// Control: the legitimate {id} path param must survive.
+	widget, ok := result.Paths["/widgets/{id}"]
+	require.True(t, ok, "/widgets/{id} must be present")
+	require.NotNil(t, widget.Get)
+	var pathParams []string
+	for _, p := range widget.Get.Parameters {
+		if p.In == "path" {
+			pathParams = append(pathParams, p.Name)
+		}
+	}
+	assert.Equal(t, []string{"id"}, pathParams,
+		"the {id} placeholder read via mux.Vars must remain a path parameter")
 }
 
 func paramNames(ps []intspec.Parameter) []string {

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -443,6 +443,7 @@ func buildPathsFromRoutes(routes []*RouteInfo, cfg *APISpecConfig) map[string]Pa
 		} else {
 			operation.Parameters = nil
 		}
+		operation.Parameters = dropPhantomPathParams(openAPIPath, operation.Parameters)
 		operation.Parameters = ensureAllPathParams(openAPIPath, operation.Parameters)
 
 		// Attach security scheme + drop the now-redundant Authorization
@@ -499,6 +500,45 @@ func dropAuthorizationHeaderParam(params []Parameter) []Parameter {
 	for _, p := range params {
 		if p.In == "header" && strings.EqualFold(p.Name, "Authorization") {
 			continue
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// pathTemplatePlaceholders returns the set of {name} placeholder names declared
+// in an OpenAPI path template (e.g. "/users/{id}/posts/{postId}" yields id and
+// postId). Mirrors the placeholder grammar ensureAllPathParams emits against.
+func pathTemplatePlaceholders(openAPIPath string) map[string]struct{} {
+	re := getCachedMapperRegex(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+	out := make(map[string]struct{})
+	for _, m := range re.FindAllStringSubmatch(openAPIPath, -1) {
+		out[m[1]] = struct{}{}
+	}
+	return out
+}
+
+// dropPhantomPathParams removes in:path parameters whose name has no matching
+// {placeholder} in the path template. An OpenAPI path parameter must appear in
+// the URL template, so one that doesn't is invalid — and is almost always a
+// static-analysis false positive: a string-literal index on a plain map
+// (`fields["displayName"]`) misread as a router var on a route with no path
+// placeholders (issue #35). Query, header, cookie, and form parameters pass
+// through untouched, as do path params that do match a placeholder.
+func dropPhantomPathParams(openAPIPath string, params []Parameter) []Parameter {
+	if len(params) == 0 {
+		return params
+	}
+	declared := pathTemplatePlaceholders(openAPIPath)
+	out := params[:0]
+	for _, p := range params {
+		if p.In == "path" {
+			if _, ok := declared[p.Name]; !ok {
+				continue
+			}
 		}
 		out = append(out, p)
 	}

--- a/internal/spec/mapper_naming_test.go
+++ b/internal/spec/mapper_naming_test.go
@@ -1334,6 +1334,54 @@ func TestEnsureAllPathParams(t *testing.T) {
 	assert.True(t, postIDParam.Required)
 }
 
+func TestPathTemplatePlaceholders(t *testing.T) {
+	got := pathTemplatePlaceholders("/users/{id}/posts/{postId}")
+	require.Len(t, got, 2)
+	_, hasID := got["id"]
+	_, hasPostID := got["postId"]
+	assert.True(t, hasID)
+	assert.True(t, hasPostID)
+
+	assert.Empty(t, pathTemplatePlaceholders("/internal/file"), "no placeholders → empty set")
+	assert.Empty(t, pathTemplatePlaceholders(""), "empty path → empty set")
+}
+
+func TestDropPhantomPathParams(t *testing.T) {
+	// A path param that matches a placeholder is kept; one that doesn't (issue
+	// #35: a map-index misread) is dropped; query/header params pass through.
+	params := []Parameter{
+		{Name: "id", In: "path", Required: true, Schema: &Schema{Type: "string"}},
+		{Name: "displayName", In: "path", Required: true, Schema: &Schema{Type: "string"}},
+		{Name: "q", In: "query"},
+		{Name: "X-Token", In: "header"},
+	}
+	got := dropPhantomPathParams("/widgets/{id}", params)
+
+	names := func(ps []Parameter) []string {
+		out := make([]string, 0, len(ps))
+		for _, p := range ps {
+			out = append(out, p.In+":"+p.Name)
+		}
+		return out
+	}
+	assert.Equal(t, []string{"path:id", "query:q", "header:X-Token"}, names(got),
+		"phantom path:displayName dropped; matching path:id and non-path params kept")
+}
+
+func TestDropPhantomPathParams_EdgeCases(t *testing.T) {
+	// Empty input is returned as-is.
+	assert.Nil(t, dropPhantomPathParams("/x", nil))
+
+	// All path params phantom (route has no placeholders) → nil, not empty slice,
+	// so the mapper emits no parameters block.
+	only := []Parameter{{Name: "displayName", In: "path"}}
+	assert.Nil(t, dropPhantomPathParams("/internal/file", only))
+
+	// A non-path param on a placeholder-free route is preserved.
+	q := []Parameter{{Name: "q", In: "query"}}
+	assert.Equal(t, q, dropPhantomPathParams("/internal/file", q))
+}
+
 func TestDefaultAPISpecConfig_Naming(t *testing.T) {
 	cfg := DefaultAPISpecConfig()
 	require.NotNil(t, cfg)

--- a/testdata/map_index_path/expected_openapi.json
+++ b/testdata/map_index_path/expected_openapi.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/internal/file": {
+      "post": {
+        "summary": "CreateFile buffers multipart fields into a map and hands them to a helper.",
+        "operationId": "mux.CreateFile",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/widgets/{id}": {
+      "get": {
+        "summary": "GetWidget reads a genuine router var that matches the {id} placeholder.",
+        "operationId": "mux.GetWidget",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/map_index_path/expected_openapi_legacy.json
+++ b/testdata/map_index_path/expected_openapi_legacy.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/internal/file": {
+      "post": {
+        "summary": "CreateFile buffers multipart fields into a map and hands them to a helper.",
+        "operationId": "testdata/mux.CreateFile",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/widgets/{id}": {
+      "get": {
+        "summary": "GetWidget reads a genuine router var that matches the {id} placeholder.",
+        "operationId": "testdata/mux.GetWidget",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/map_index_path/go.mod
+++ b/testdata/map_index_path/go.mod
@@ -1,0 +1,5 @@
+module testdata/mux
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.1

--- a/testdata/map_index_path/go.sum
+++ b/testdata/map_index_path/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/testdata/map_index_path/main.go
+++ b/testdata/map_index_path/main.go
@@ -1,0 +1,59 @@
+// Package main guards issue #35: string-literal indexes into a plain
+// map[string]string (e.g. multipart form fields buffered into a map) must NOT
+// be misinferred as in:path parameters. Only map indexes that correspond to a
+// real {placeholder} in the route template are path parameters.
+//
+// Two routes exercise both sides of the invariant:
+//
+//   - POST /internal/file has no path placeholders. Its handler reads
+//     fields["displayName"] from a plain map inside a helper. The generated
+//     operation must have no path parameters (the #35 false positive).
+//   - GET /widgets/{id} reads mux.Vars(r)["id"], which matches the {id}
+//     placeholder, so that path parameter must still be emitted (the control —
+//     the fix must not over-prune legitimate router-var reads).
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/internal/file", CreateFile).Methods("POST")
+	r.HandleFunc("/widgets/{id}", GetWidget).Methods("GET")
+	http.ListenAndServe(":8080", r)
+}
+
+// buildInput reads string-literal keys from a plain field map (issue #35). The
+// map does not originate from mux.Vars, and the route has no placeholders, so
+// none of these keys are path parameters.
+func buildInput(fields map[string]string) (string, string) {
+	displayName := fields["displayName"]
+	bucket := fields["storageBucketId"]
+	return displayName, bucket
+}
+
+// CreateFile buffers multipart fields into a map and hands them to a helper.
+func CreateFile(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseMultipartForm(1 << 20)
+	fields := map[string]string{}
+	for k, v := range r.MultipartForm.Value {
+		if len(v) > 0 {
+			fields[k] = v[0]
+		}
+	}
+	name, bucket := buildInput(fields)
+	_ = name
+	_ = bucket
+	w.WriteHeader(http.StatusCreated)
+}
+
+// GetWidget reads a genuine router var that matches the {id} placeholder.
+func GetWidget(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+	_ = id
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
Closes #35.

## Problem

The map-index path-parameter heuristic (`extractParamsFromAssignmentMaps`) turns any `x := someMap["literal"]` into an `in: path` parameter, regardless of whether the map provably comes from a router vars call. A handler that buffers multipart form fields into a plain `map[string]string` and reads `fields["displayName"]` (commonly inside a helper like `buildCreateInput(fields map[string]string)`) therefore emits a bogus parameter on a route with **no** path placeholders:

```yaml
# POST /internal/file  (no {placeholders} in the template)
parameters:
  - in: path
    name: displayName
    required: true
    schema: { type: string }
```

Reproduced against current `main`/v0.4.17.

## Root cause & fix

Nothing enforced the OpenAPI invariant that **a path parameter must appear in the URL template**. The map-index heuristic is one source of violations, but the right place to enforce the invariant is the single authoritative reconciliation point in the mapper.

`dropPhantomPathParams` removes any `in: path` parameter whose name has no matching `{placeholder}` in the (mount-joined, `convertPathToOpenAPI`'d) path template. It runs just before the existing `ensureAllPathParams` (which adds template placeholders missing from the params), so together they make the path-param set exactly equal to the template's placeholders. Query/header/cookie/form params and path params that *do* match a placeholder are untouched — legitimate `mux.Vars` / `chi.URLParam` / `c.Param` reads survive.

This is framework-agnostic and fixes any phantom-path-param source, not just the map index.

## Verification

- The `map_index_path` regression fixture exercises both sides: `POST /internal/file` (plain-map read in a helper → **no** path param) and `GET /widgets/{id}` (genuine `mux.Vars(r)["id"]` matching the placeholder → **kept**).
- **All existing golden files are unchanged** — the invariant filter drops nothing legitimate across chi/gin/echo/fiber/mux (which all have real `{id}`-style params).
- Unit tests for `dropPhantomPathParams` / `pathTemplatePlaceholders` (100% coverage) plus an e2e assertion. Full suite, coverage gate, lint, vet, and gofmt all pass.

Implements the issue's suggested remedy ("require the operation's route template to contain a matching placeholder before emitting an in:path parameter").