### PR TITLE
fix: resolve shared/generic decode helpers per call site (#39)

### DIFF
--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -52,6 +52,8 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "form_value_var", inputDir: "../../testdata/form_value_var", configFn: spec.DefaultChiConfig},
 		{name: "json_dto", inputDir: "../../testdata/json_dto", configFn: spec.DefaultChiConfig},
 		{name: "json_dto_helpers", inputDir: "../../testdata/json_dto_helpers", configFn: spec.DefaultChiConfig},
+		{name: "shared_decode_any", inputDir: "../../testdata/shared_decode_any", configFn: spec.DefaultChiConfig},
+		{name: "shared_decode_generic", inputDir: "../../testdata/shared_decode_generic", configFn: spec.DefaultChiConfig},
 		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
 		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 		{name: "security_bearer", inputDir: "../../testdata/security_bearer", configFn: spec.DefaultHTTPConfig},
@@ -518,6 +520,45 @@ func TestE2E_MapIndexPath_NoPhantomPathParams(t *testing.T) {
 	}
 	assert.Equal(t, []string{"id"}, pathParams,
 		"the {id} placeholder read via mux.Vars must remain a path parameter")
+}
+
+// TestE2E_SharedDecodeHelper_PerCallSiteBodyTypes asserts issue #39: a decode
+// helper shared by two handlers with different DTOs resolves each endpoint to
+// its own request type and keeps per-field format: uuid — for both the
+// any-typed and the generic helper forms.
+func TestE2E_SharedDecodeHelper_PerCallSiteBodyTypes(t *testing.T) {
+	for _, dir := range []string{"shared_decode_any", "shared_decode_generic"} {
+		t.Run(dir, func(t *testing.T) {
+			cfg := newDefaultCfg("../../testdata/"+dir, spec.DefaultChiConfig())
+			result, err := NewEngine(cfg).GenerateOpenAPI()
+			require.NoError(t, err)
+
+			refOf := func(path string) string {
+				pi, ok := result.Paths[path]
+				require.True(t, ok, "%s missing", path)
+				require.NotNil(t, pi.Post)
+				require.NotNil(t, pi.Post.RequestBody)
+				mt, ok := pi.Post.RequestBody.Content["application/json"]
+				require.True(t, ok, "%s json content missing", path)
+				require.NotNil(t, mt.Schema)
+				return mt.Schema.Ref
+			}
+			assert.Equal(t, "#/components/schemas/json_dto.CopyDocumentRequest", refOf("/copy"),
+				"copy endpoint must keep its own DTO")
+			assert.Equal(t, "#/components/schemas/json_dto.UpdateDocumentRequest", refOf("/update"),
+				"update endpoint must keep its own DTO (not collapse onto copy's)")
+
+			// Both schemas exist and retain their flow-inferred uuid formats.
+			schemas := result.Components.Schemas
+			copyReq := schemas["json_dto.CopyDocumentRequest"]
+			require.NotNil(t, copyReq)
+			assert.Equal(t, "uuid", copyReq.Properties["sourceId"].Format)
+			assert.Equal(t, "uuid", copyReq.Properties["destinationBucketId"].Format)
+			updateReq := schemas["json_dto.UpdateDocumentRequest"]
+			require.NotNil(t, updateReq)
+			assert.Equal(t, "uuid", updateReq.Properties["storageBucketId"].Format)
+		})
+	}
 }
 
 func paramNames(ps []intspec.Parameter) []string {

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -549,14 +549,18 @@ func TestE2E_SharedDecodeHelper_PerCallSiteBodyTypes(t *testing.T) {
 				"update endpoint must keep its own DTO (not collapse onto copy's)")
 
 			// Both schemas exist and retain their flow-inferred uuid formats.
+			require.NotNil(t, result.Components, "components missing")
 			schemas := result.Components.Schemas
-			copyReq := schemas["json_dto.CopyDocumentRequest"]
-			require.NotNil(t, copyReq)
-			assert.Equal(t, "uuid", copyReq.Properties["sourceId"].Format)
-			assert.Equal(t, "uuid", copyReq.Properties["destinationBucketId"].Format)
-			updateReq := schemas["json_dto.UpdateDocumentRequest"]
-			require.NotNil(t, updateReq)
-			assert.Equal(t, "uuid", updateReq.Properties["storageBucketId"].Format)
+			assertUUIDField := func(typeName, prop string) {
+				schema := schemas[typeName]
+				require.NotNil(t, schema, "schema %s missing", typeName)
+				ps := schema.Properties[prop]
+				require.NotNil(t, ps, "property %s.%s missing", typeName, prop)
+				assert.Equal(t, "uuid", ps.Format, "%s.%s format", typeName, prop)
+			}
+			assertUUIDField("json_dto.CopyDocumentRequest", "sourceId")
+			assertUUIDField("json_dto.CopyDocumentRequest", "destinationBucketId")
+			assertUUIDField("json_dto.UpdateDocumentRequest", "storageBucketId")
 		})
 	}
 }

--- a/internal/spec/interproc_inference_test.go
+++ b/internal/spec/interproc_inference_test.go
@@ -336,7 +336,7 @@ func TestResolveBodyTypeThroughCallSite_WalksPastNonMatchingAncestors(t *testing
 	edgeless.Parent = otherNode
 	decodeNode.Parent = edgeless
 
-	bodyType, varName, baseID := resolveBodyTypeThroughCallSite(decodeNode, "dst", cp)
+	bodyType, varName, baseID := resolveBodyTypeThroughCallSite(decodeNode, "dst", noRoute, cp)
 	assert.Equal(t, "pkg.Req", bodyType)
 	assert.Equal(t, "body", varName)
 	assert.Equal(t, callSite.Caller.BaseID(), baseID)
@@ -353,12 +353,63 @@ func TestIsFreeFormBodyType(t *testing.T) {
 	}
 }
 
+// --- edgeCallerIsRouteHandler / concreteTypeFromParamArg --------------------
+
+func TestEdgeCallerIsRouteHandler(t *testing.T) {
+	meta := newTestMeta()
+	edge := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+
+	// Bare function name + matching package.
+	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Copy", Package: "pkg"}))
+	// Bare name with no package recorded on the route still matches.
+	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Copy"}))
+	// Package-qualified function name.
+	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "pkg.Copy"}))
+	// Bare name but wrong package → no match.
+	assert.False(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Copy", Package: "other"}))
+	// Different handler.
+	assert.False(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Update", Package: "pkg"}))
+	// Guards.
+	assert.False(t, edgeCallerIsRouteHandler(&edge, nil))
+	assert.False(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{}))
+	// Caller with an empty name never matches.
+	nameless := makeEdge(meta, "", "pkg", "h", "pkg", nil)
+	assert.False(t, edgeCallerIsRouteHandler(&nameless, &RouteInfo{Metadata: meta, Function: ""}))
+}
+
+func TestConcreteTypeFromParamArg(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	edge := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+	setParamArg(&edge, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&"))
+
+	bt, vn := concreteTypeFromParamArg(&edge, "dst", cp)
+	assert.Equal(t, "pkg.Req", bt)
+	assert.Equal(t, "body", vn)
+
+	// Missing param mapping → empty.
+	bt, _ = concreteTypeFromParamArg(&edge, "missing", cp)
+	assert.Empty(t, bt)
+
+	// Non-ident argument (call expr) → empty.
+	other := makeEdge(meta, "Copy", "pkg", "h", "pkg", nil)
+	call := makeCallArg(meta)
+	call.SetKind(metadata.KindCall)
+	setParamArg(&other, "dst", call)
+	bt, _ = concreteTypeFromParamArg(&other, "dst", cp)
+	assert.Empty(t, bt)
+}
+
 // --- resolveBodyTypeThroughCallSite -----------------------------------------
 
-// TestResolveBodyTypeThroughCallSite covers issue #36 Repro 2: the decode lives
-// in decodeStrictJSON(dst any); walking up to the call site recovers the
-// concrete &body argument and its type.
-func TestResolveBodyTypeThroughCallSite(t *testing.T) {
+// noRoute forces the tracker-tree fallback by exposing no route metadata, so
+// the route-handler disambiguation path is skipped.
+var noRoute *RouteInfo
+
+// TestResolveBodyTypeThroughCallSite_TreeWalk covers issue #36 Repro 2: the
+// decode lives in decodeStrictJSON(dst any); walking up the tree to the call
+// site recovers the concrete &body argument and its type.
+func TestResolveBodyTypeThroughCallSite_TreeWalk(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)
 
@@ -369,14 +420,48 @@ func TestResolveBodyTypeThroughCallSite(t *testing.T) {
 	decodeEdge := makeEdge(meta, "decodeStrictJSON", "pkg", "Decode", "encoding/json",
 		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
 
-	parent := makeTrackerNode(&callHelper)
 	decodeNode := makeTrackerNode(&decodeEdge)
-	decodeNode.Parent = parent
+	decodeNode.Parent = makeTrackerNode(&callHelper)
 
-	bodyType, varName, baseID := resolveBodyTypeThroughCallSite(decodeNode, "dst", cp)
+	bodyType, varName, baseID := resolveBodyTypeThroughCallSite(decodeNode, "dst", noRoute, cp)
 	assert.Equal(t, "pkg.Req", bodyType, "concrete type recovered from the call site")
 	assert.Equal(t, "body", varName, "re-anchored onto the caller's variable")
 	assert.Equal(t, callHelper.Caller.BaseID(), baseID, "field inference runs in the caller frame")
+}
+
+// TestResolveBodyTypeThroughCallSite_RouteHandler covers issue #39: a strict
+// decode helper shared by two handlers is one tracker-tree node whose parent
+// points at a single caller. Resolution must instead pick the call edge whose
+// caller is the route being extracted.
+func TestResolveBodyTypeThroughCallSite_RouteHandler(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+
+	copyEdge := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+	setParamArg(&copyEdge, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.CopyReq"), "&"))
+	updateEdge := makeEdge(meta, "Update", "pkg", "decodeStrictJSON", "pkg", nil)
+	setParamArg(&updateEdge, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.UpdateReq"), "&"))
+	decodeEdge := makeEdge(meta, "decodeStrictJSON", "pkg", "Decode", "encoding/json",
+		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
+	meta.Callees = map[string][]*metadata.CallGraphEdge{
+		decodeEdge.Caller.BaseID(): {&copyEdge, &updateEdge},
+	}
+
+	// Tracker-tree parent deliberately points at Update (the shared-node bug).
+	decodeNode := makeTrackerNode(&decodeEdge)
+	decodeNode.Parent = makeTrackerNode(&updateEdge)
+
+	// Copy route → CopyReq (not the tree-parent's UpdateReq).
+	bt, vn, base := resolveBodyTypeThroughCallSite(decodeNode, "dst",
+		&RouteInfo{Metadata: meta, Function: "Copy", Package: "pkg"}, cp)
+	assert.Equal(t, "pkg.CopyReq", bt, "route-handler disambiguation beats the shared tree parent")
+	assert.Equal(t, "body", vn)
+	assert.Equal(t, copyEdge.Caller.BaseID(), base)
+
+	// Update route → UpdateReq.
+	bt, _, _ = resolveBodyTypeThroughCallSite(decodeNode, "dst",
+		&RouteInfo{Metadata: meta, Function: "Update", Package: "pkg"}, cp)
+	assert.Equal(t, "pkg.UpdateReq", bt)
 }
 
 func TestResolveBodyTypeThroughCallSite_Guards(t *testing.T) {
@@ -384,15 +469,15 @@ func TestResolveBodyTypeThroughCallSite_Guards(t *testing.T) {
 	cp := NewContextProvider(meta)
 
 	// Nil node / empty param.
-	bt, _, _ := resolveBodyTypeThroughCallSite(nil, "dst", cp)
+	bt, _, _ := resolveBodyTypeThroughCallSite(nil, "dst", noRoute, cp)
 	assert.Empty(t, bt)
 	decodeEdge := makeEdge(meta, "helper", "pkg", "Decode", "encoding/json", nil)
 	node := makeTrackerNode(&decodeEdge)
-	bt, _, _ = resolveBodyTypeThroughCallSite(node, "", cp)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node, "", noRoute, cp)
 	assert.Empty(t, bt)
 
 	// No ancestor edge invokes the enclosing helper → unresolved.
-	bt, _, _ = resolveBodyTypeThroughCallSite(node, "dst", cp)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node, "dst", noRoute, cp)
 	assert.Empty(t, bt)
 
 	// Ancestor calls the helper but maps the param to a non-ident (call expr) →
@@ -402,53 +487,75 @@ func TestResolveBodyTypeThroughCallSite_Guards(t *testing.T) {
 	complexArg.SetKind(metadata.KindCall)
 	setParamArg(&callHelper, "dst", complexArg)
 	node.Parent = makeTrackerNode(&callHelper)
-	bt, _, _ = resolveBodyTypeThroughCallSite(node, "dst", cp)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node, "dst", noRoute, cp)
 	assert.Empty(t, bt, "non-ident mapped argument is not resolved")
 
 	// Ancestor calls the helper but has no mapping for the param → unresolved.
 	callHelper2 := makeEdge(meta, "Copy", "pkg", "helper", "pkg", nil)
 	node2 := makeTrackerNode(&decodeEdge)
 	node2.Parent = makeTrackerNode(&callHelper2)
-	bt, _, _ = resolveBodyTypeThroughCallSite(node2, "dst", cp)
+	bt, _, _ = resolveBodyTypeThroughCallSite(node2, "dst", noRoute, cp)
 	assert.Empty(t, bt, "missing ParamArgMap entry → unresolved")
 }
 
 // TestRefineBodyTypeThroughHelper exercises the matcher-level wrapper that
-// drives the interprocedural body-type fallback during request extraction.
+// drives interprocedural decode resolution during request extraction.
 func TestRefineBodyTypeThroughHelper(t *testing.T) {
 	meta := newTestMeta()
 	cfg := DefaultChiConfig()
 	matcher := NewRequestPatternMatcher(RequestBodyPattern{}, cfg, NewContextProvider(meta),
 		NewTypeResolver(meta, cfg, NewSchemaMapper(cfg)))
 
-	// Already concrete → returned unchanged, reqInfo untouched.
+	// Nil node or no route metadata → returned unchanged.
 	concrete := &RequestInfo{BodyType: "pkg.Req", DecodeTargetVar: "body"}
-	bt, frame := matcher.refineBodyTypeThroughHelper(nil, concrete, "pkg.Req", "frameA")
+	bt, frame := matcher.refineBodyTypeThroughHelper(nil, concrete, "pkg.Req", "frameA", &RouteInfo{Metadata: meta})
 	assert.Equal(t, "pkg.Req", bt)
 	assert.Equal(t, "frameA", frame)
 	assert.Equal(t, "body", concrete.DecodeTargetVar)
 
-	// Free-form but unresolvable (nil node) → returned unchanged.
-	unresolved := &RequestInfo{BodyType: "any", DecodeTargetVar: "dst"}
-	bt, frame = matcher.refineBodyTypeThroughHelper(nil, unresolved, "any", "frameB")
+	// Node with no edge → returned unchanged.
+	noEdge := &RequestInfo{BodyType: "any", DecodeTargetVar: "dst"}
+	bt, frame = matcher.refineBodyTypeThroughHelper(&TrackerNode{}, noEdge, "any", "frameNoEdge", &RouteInfo{Metadata: meta})
 	assert.Equal(t, "any", bt)
-	assert.Equal(t, "frameB", frame)
-	assert.Equal(t, "any", unresolved.BodyType)
+	assert.Equal(t, "frameNoEdge", frame)
 
-	// Free-form and resolvable through the call site → upgraded in place.
+	// Inline decode (the decode's enclosing func IS the route handler) → no-op.
+	inlineEdge := makeEdge(meta, "Copy", "pkg", "Decode", "encoding/json",
+		[]*metadata.CallArgument{wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&")})
+	inlineNode := makeTrackerNode(&inlineEdge)
+	inlineReq := &RequestInfo{BodyType: "pkg.Req", DecodeTargetVar: "body"}
+	bt, frame = matcher.refineBodyTypeThroughHelper(inlineNode, inlineReq, "pkg.Req", "frameInline",
+		&RouteInfo{Metadata: meta, Function: "Copy", Package: "pkg"})
+	assert.Equal(t, "pkg.Req", bt)
+	assert.Equal(t, "frameInline", frame, "inline decode is not re-anchored")
+
+	// Build a shared-helper decode node for the next two cases.
+	copyEdge := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+	setParamArg(&copyEdge, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.CopyReq"), "&"))
 	decodeEdge := makeEdge(meta, "decodeStrictJSON", "pkg", "Decode", "encoding/json",
 		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
-	callSite := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
-	setParamArg(&callSite, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "pkg.Req"), "&"))
+	meta.Callees = map[string][]*metadata.CallGraphEdge{
+		decodeEdge.Caller.BaseID(): {&copyEdge},
+	}
 	decodeNode := makeTrackerNode(&decodeEdge)
-	decodeNode.Parent = makeTrackerNode(&callSite)
+	copyRoute := &RouteInfo{Metadata: meta, Function: "Copy", Package: "pkg"}
 
-	upgraded := &RequestInfo{BodyType: "any", DecodeTargetVar: "dst"}
-	bt, frame = matcher.refineBodyTypeThroughHelper(decodeNode, upgraded, "any", "frameC")
-	assert.Equal(t, "pkg.Req", bt)
-	assert.Equal(t, callSite.Caller.BaseID(), frame)
-	assert.Equal(t, "pkg.Req", upgraded.BodyType)
-	assert.Equal(t, "body", upgraded.DecodeTargetVar, "decode target re-anchored to the caller var")
+	// Variant A: free-form `any` → body type overridden AND frame re-anchored.
+	varA := &RequestInfo{BodyType: "any", DecodeTargetVar: "dst"}
+	bt, frame = matcher.refineBodyTypeThroughHelper(decodeNode, varA, "any", "helperFrame", copyRoute)
+	assert.Equal(t, "pkg.CopyReq", bt)
+	assert.Equal(t, "pkg.CopyReq", varA.BodyType, "free-form type upgraded")
+	assert.Equal(t, "body", varA.DecodeTargetVar, "decode target re-anchored to the caller var")
+	assert.Equal(t, copyEdge.Caller.BaseID(), frame, "field inference re-anchored to the handler frame")
+
+	// Variant B: concrete generic type already resolved → type kept, but the
+	// field-inference frame is still re-anchored onto the handler.
+	varB := &RequestInfo{BodyType: "pkg.CopyReq", DecodeTargetVar: "dst"}
+	bt, frame = matcher.refineBodyTypeThroughHelper(decodeNode, varB, "pkg.CopyReq", "helperFrame", copyRoute)
+	assert.Equal(t, "pkg.CopyReq", bt, "concrete generic type is not overridden")
+	assert.Equal(t, "pkg.CopyReq", varB.BodyType)
+	assert.Equal(t, "body", varB.DecodeTargetVar, "frame re-anchored even when type already concrete")
+	assert.Equal(t, copyEdge.Caller.BaseID(), frame)
 }
 
 func TestResolveBodyTypeThroughCallSite_NoEdgeNode(t *testing.T) {
@@ -456,6 +563,6 @@ func TestResolveBodyTypeThroughCallSite_NoEdgeNode(t *testing.T) {
 	cp := NewContextProvider(meta)
 	// A node with no edge returns empty.
 	bare := &TrackerNode{}
-	bt, _, _ := resolveBodyTypeThroughCallSite(bare, "dst", cp)
+	bt, _, _ := resolveBodyTypeThroughCallSite(bare, "dst", noRoute, cp)
 	require.Empty(t, bt)
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -576,10 +576,11 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 		reqInfo.BodyType = preprocessingBodyType(bodyType)
 		reqInfo.DecodeTargetVar = decodeTargetVarName(arg)
 
-		// Interprocedural fallback (issue #36): when the decode lives in an
-		// extracted helper, recover the concrete type from the call site and
-		// re-anchor the decode target + field-inference frame onto the caller.
-		bodyType, fieldFrameBaseID = r.refineBodyTypeThroughHelper(node, reqInfo, bodyType, fieldFrameBaseID)
+		// Interprocedural fallback (issues #36, #39): when the decode lives in an
+		// extracted (possibly shared or generic) helper, recover the concrete
+		// type from the route handler's call site and re-anchor the decode
+		// target + field-inference frame onto the handler.
+		bodyType, fieldFrameBaseID = r.refineBodyTypeThroughHelper(node, reqInfo, bodyType, fieldFrameBaseID, route)
 
 		schema, _ := mapGoTypeToOpenAPISchema(route.UsedTypes, bodyType, route.Metadata, r.cfg, nil)
 		reqInfo.Schema = schema
@@ -611,26 +612,49 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 	return reqInfo
 }
 
-// refineBodyTypeThroughHelper upgrades a free-form decode binding (issue #36):
-// when the decode call lives in an extracted helper — `func decode(dst any)` —
-// the type-arg resolves only to the helper's `any` parameter. It walks up to
-// the call site that invoked the helper, recovers the concrete argument
-// (`&body`), and re-anchors the decode target onto the caller's variable so
-// field inference runs in the handler frame rather than the helper's. reqInfo
-// is mutated in place; the returned (bodyType, fieldFrameBaseID) replace the
-// caller's locals for schema generation and field inference. A no-op when the
-// body type already resolved concretely or no call site could be found.
-func (r *RequestPatternMatcherImpl) refineBodyTypeThroughHelper(node TrackerNodeInterface, reqInfo *RequestInfo, bodyType, fieldFrameBaseID string) (string, string) {
-	if !isFreeFormBodyType(reqInfo.BodyType) {
+// refineBodyTypeThroughHelper resolves a decode that lives in an extracted
+// helper through the route handler's call site (issues #36, #39).
+//
+// When the decode call sits directly in the route handler there is nothing
+// interprocedural to do. Otherwise it resolves the decode target parameter to
+// the concrete argument the handler passed (`&body`) and:
+//
+//   - re-anchors the field-inference frame and decode-target variable onto the
+//     handler — needed even when the body type already resolved concretely via
+//     a generic type parameter (issue #39 Variant B), because the converter
+//     calls (uuid.Parse(body.X)) live in the handler, not the helper; and
+//   - overrides the body type only when the current one is free-form (an `any`
+//     parameter — issue #39 Variant A); a concrete generic instantiation wins.
+//
+// reqInfo is mutated in place; the returned (bodyType, fieldFrameBaseID) replace
+// the caller's locals for schema generation and field inference.
+func (r *RequestPatternMatcherImpl) refineBodyTypeThroughHelper(node TrackerNodeInterface, reqInfo *RequestInfo, bodyType, fieldFrameBaseID string, route *RouteInfo) (string, string) {
+	if node == nil || route == nil || route.Metadata == nil {
 		return bodyType, fieldFrameBaseID
 	}
-	bt, varName, frameBaseID := resolveBodyTypeThroughCallSite(node, reqInfo.DecodeTargetVar, r.contextProvider)
-	if bt == "" || isFreeFormBodyType(bt) {
+	edge := node.GetEdge()
+	if edge == nil {
 		return bodyType, fieldFrameBaseID
 	}
-	reqInfo.BodyType = preprocessingBodyType(bt)
+	// Inline decode: the decode call sits directly in the route handler, so the
+	// frame is already correct — nothing to resolve across a call boundary.
+	if edgeCallerIsRouteHandler(edge, route) {
+		return bodyType, fieldFrameBaseID
+	}
+
+	resolved, varName, frameBaseID := resolveBodyTypeThroughCallSite(node, reqInfo.DecodeTargetVar, route, r.contextProvider)
+	if resolved == "" {
+		return bodyType, fieldFrameBaseID
+	}
+
 	reqInfo.DecodeTargetVar = varName
-	return bt, frameBaseID
+	fieldFrameBaseID = frameBaseID
+
+	if isFreeFormBodyType(reqInfo.BodyType) && !isFreeFormBodyType(resolved) {
+		reqInfo.BodyType = preprocessingBodyType(resolved)
+		bodyType = resolved
+	}
+	return bodyType, fieldFrameBaseID
 }
 
 // maxCallSiteDepth bounds how far up the tracker tree resolveBodyTypeThroughCallSite
@@ -649,15 +673,19 @@ func isFreeFormBodyType(t string) bool {
 	return false
 }
 
-// resolveBodyTypeThroughCallSite handles the interprocedural decode case
-// (issue #36): the matched decode call lives in a helper whose decode target is
-// a parameter (typically typed `any`), so intraprocedural resolution yields no
-// concrete type. It walks up the tracker tree to the nearest ancestor edge that
-// invoked the enclosing helper, maps the decode parameter to the concrete
-// argument passed at that call site, and returns the resolved body type, the
-// caller-frame variable name (so downstream field inference runs in the right
-// frame), and that frame's base ID.
-func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string, cp ContextProvider) (bodyType, varName, callerBaseID string) {
+// resolveBodyTypeThroughCallSite resolves a decode that lives in an extracted
+// helper to the concrete body type passed at the call site, returning that type
+// plus the caller-frame variable name and base ID (so downstream field
+// inference runs in the right frame).
+//
+// It first disambiguates by the route's own handler (issue #39): a strict-decode
+// helper shared by several handlers is deduplicated to a single tracker-tree
+// node whose parent points at just one caller, so the parent walk alone resolves
+// every route to that one caller's type. Resolving through the call edge whose
+// caller IS this route's handler picks the right one. The tracker-tree walk
+// remains as a fallback for single-caller helpers reached through deeper chains
+// (issue #36).
+func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string, route *RouteInfo, cp ContextProvider) (bodyType, varName, callerBaseID string) {
 	if node == nil || paramName == "" {
 		return "", "", ""
 	}
@@ -665,11 +693,25 @@ func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string,
 	if edge == nil {
 		return "", "", ""
 	}
-	// The function enclosing the decode call (e.g. decodeStrictJSON); we look
-	// for the ancestor edge that called it.
+
+	// (1) Route-handler disambiguation: among every edge that calls the
+	// enclosing helper, pick the one whose caller is this route's handler.
+	if route != nil && route.Metadata != nil {
+		helperBaseID := edge.Caller.BaseID()
+		for _, e := range route.Metadata.Callees[helperBaseID] {
+			if !edgeCallerIsRouteHandler(e, route) {
+				continue
+			}
+			if bt, vn := concreteTypeFromParamArg(e, paramName, cp); bt != "" {
+				return bt, vn, e.Caller.BaseID()
+			}
+		}
+	}
+
+	// (2) Fallback: walk the tracker tree to the nearest ancestor edge that
+	// invoked the enclosing helper.
 	enclosingName := edge.Caller.Name
 	enclosingPkg := edge.Caller.Pkg
-
 	for depth, cur := 0, node.GetParent(); cur != nil && depth < maxCallSiteDepth; cur, depth = cur.GetParent(), depth+1 {
 		anc := cur.GetEdge()
 		if anc == nil {
@@ -678,18 +720,48 @@ func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string,
 		if anc.Callee.Name != enclosingName || anc.Callee.Pkg != enclosingPkg {
 			continue
 		}
-		callArg, ok := anc.ParamArgMap[paramName]
-		if !ok {
+		bt, vn := concreteTypeFromParamArg(anc, paramName, cp)
+		if bt == "" {
 			return "", "", ""
 		}
-		base := unwrapArgRefs(&callArg)
-		if base == nil || base.GetKind() != metadata.KindIdent {
-			return "", "", ""
-		}
-		resolved := strings.TrimPrefix(cp.GetArgumentInfo(base), "*")
-		return resolved, base.GetName(), anc.Caller.BaseID()
+		return bt, vn, anc.Caller.BaseID()
 	}
 	return "", "", ""
+}
+
+// edgeCallerIsRouteHandler reports whether the edge's caller is the route's
+// handler function. RouteInfo.Function may be stored either bare ("Copy") or
+// package-qualified ("json_dto.Copy"), so both forms are accepted; the bare
+// form additionally checks the package to avoid cross-package collisions.
+func edgeCallerIsRouteHandler(e *metadata.CallGraphEdge, route *RouteInfo) bool {
+	if route == nil || route.Metadata == nil {
+		return false
+	}
+	name := stringFromPool(route.Metadata, e.Caller.Name)
+	if name == "" {
+		return false
+	}
+	pkg := stringFromPool(route.Metadata, e.Caller.Pkg)
+	if route.Function == name {
+		return route.Package == "" || route.Package == pkg
+	}
+	return route.Function == pkg+"."+name
+}
+
+// concreteTypeFromParamArg resolves the concrete body type and caller-frame
+// variable name from a call edge's mapping of paramName to the argument the
+// caller passed (e.g. dst -> &body). Returns "","" when that argument isn't a
+// plain identifier, optionally wrapped in a single &/* (covering `&body`).
+func concreteTypeFromParamArg(edge *metadata.CallGraphEdge, paramName string, cp ContextProvider) (bodyType, varName string) {
+	callArg, ok := edge.ParamArgMap[paramName]
+	if !ok {
+		return "", ""
+	}
+	base := unwrapArgRefs(&callArg)
+	if base == nil || base.GetKind() != metadata.KindIdent {
+		return "", ""
+	}
+	return strings.TrimPrefix(cp.GetArgumentInfo(base), "*"), base.GetName()
 }
 
 // decodeTargetVarName returns the local variable name that the decode call's

--- a/testdata/shared_decode_any/expected_openapi.json
+++ b/testdata/shared_decode_any/expected_openapi.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/copy": {
+      "post": {
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "operationId": "json_dto.Update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId"
+        ]
+      },
+      "json_dto.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "storageBucketId",
+          "displayName"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_any/expected_openapi_legacy.json
+++ b/testdata/shared_decode_any/expected_openapi_legacy.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/copy": {
+      "post": {
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "operationId": "json_dto.Update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId"
+        ]
+      },
+      "json_dto.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "storageBucketId",
+          "displayName"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_any/go.mod
+++ b/testdata/shared_decode_any/go.mod
@@ -1,0 +1,8 @@
+module json_dto
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
+)

--- a/testdata/shared_decode_any/go.sum
+++ b/testdata/shared_decode_any/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/shared_decode_any/main.go
+++ b/testdata/shared_decode_any/main.go
@@ -1,0 +1,61 @@
+// Package main guards issue #39 Variant A: a strict-decode helper typed
+// `dst any`, shared by two handlers with *different* concrete request DTOs.
+// Each endpoint's requestBody must $ref its own DTO and keep the per-field
+// format: uuid that flow analysis derives from the handler's uuid.Parse calls —
+// rather than both endpoints collapsing onto a single body type.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type CopyDocumentRequest struct {
+	SourceID            string `json:"sourceId"`
+	DestinationBucketID string `json:"destinationBucketId"`
+}
+
+type UpdateDocumentRequest struct {
+	StorageBucketID string `json:"storageBucketId"`
+	DisplayName     string `json:"displayName"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Post("/copy", Copy)
+	r.Post("/update", Update)
+	http.ListenAndServe(":3000", r)
+}
+
+// decodeStrictJSON is the shared any-typed decode helper called by both handlers.
+func decodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		http.Error(w, "bad", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	_, _ = uuid.Parse(body.SourceID)
+	_, _ = uuid.Parse(body.DestinationBucketID)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func Update(w http.ResponseWriter, r *http.Request) {
+	var body UpdateDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	_, _ = uuid.Parse(body.StorageBucketID)
+	w.WriteHeader(http.StatusOK)
+}

--- a/testdata/shared_decode_generic/expected_openapi.json
+++ b/testdata/shared_decode_generic/expected_openapi.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/copy": {
+      "post": {
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "operationId": "json_dto.Update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId"
+        ]
+      },
+      "json_dto.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "storageBucketId",
+          "displayName"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_generic/expected_openapi_legacy.json
+++ b/testdata/shared_decode_generic/expected_openapi_legacy.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/copy": {
+      "post": {
+        "operationId": "json_dto.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "operationId": "json_dto.Update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId"
+        ]
+      },
+      "json_dto.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "storageBucketId",
+          "displayName"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_generic/go.mod
+++ b/testdata/shared_decode_generic/go.mod
@@ -1,0 +1,8 @@
+module json_dto
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
+)

--- a/testdata/shared_decode_generic/go.sum
+++ b/testdata/shared_decode_generic/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/shared_decode_generic/main.go
+++ b/testdata/shared_decode_generic/main.go
@@ -1,0 +1,62 @@
+// Package main guards issue #39 Variant B: a generic strict-decode helper
+// `decodeStrictJSON[T any](..., dst *T)`, shared by two handlers. The type
+// parameter lets struct identities resolve per call site, but the per-field
+// format: uuid enrichment must also survive the generic boundary — it is
+// re-anchored onto each handler's frame so the handler's uuid.Parse calls are
+// seen.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type CopyDocumentRequest struct {
+	SourceID            string `json:"sourceId"`
+	DestinationBucketID string `json:"destinationBucketId"`
+}
+
+type UpdateDocumentRequest struct {
+	StorageBucketID string `json:"storageBucketId"`
+	DisplayName     string `json:"displayName"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Post("/copy", Copy)
+	r.Post("/update", Update)
+	http.ListenAndServe(":3000", r)
+}
+
+// decodeStrictJSON is the shared generic decode helper called by both handlers.
+func decodeStrictJSON[T any](w http.ResponseWriter, r *http.Request, dst *T) bool {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		http.Error(w, "bad", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	_, _ = uuid.Parse(body.SourceID)
+	_, _ = uuid.Parse(body.DestinationBucketID)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func Update(w http.ResponseWriter, r *http.Request) {
+	var body UpdateDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	_, _ = uuid.Parse(body.StorageBucketID)
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
Closes #39.

## Problem

Residual gap after #36. A **single-caller** decode helper resolves correctly, but a **shared** strict-decode helper — one `decodeStrictJSON` called by ≥2 handlers with *different* concrete request DTOs — degraded the spec. This is the most common DRY shape in HTTP handlers, so it bites as soon as a package de-duplicates decoding.

- **Variant A — `dst any` shared helper:** both endpoints collapse onto a single body type. One request schema is dropped entirely and the other endpoint's `requestBody` mis-`$ref`s the wrong DTO.
- **Variant B — generic `[T any]` shared helper:** struct identities resolve correctly via the type parameter, but every field-level `format: uuid` is lost.

## Root cause

The interprocedural decode resolution from #36 disambiguated only via the tracker tree's **parent chain**. A shared helper is deduplicated to a single tree node whose `.Parent` points at just **one** caller (the last one built), so every route resolves to that caller. For Variant A the `any` parameter erases the type at the boundary (→ wrong/dropped type). For Variant B the body type is recovered via the generic instantiation, but field inference stays anchored in the **helper** frame, so the handler's `uuid.Parse(body.X)` calls are never seen (→ formats lost).

## Fix

Resolve the decode through the call edge whose **caller is the route's own handler** (`meta.Callees[helperBaseID]` + `edgeCallerIsRouteHandler`), instead of the shared tree parent. `refineBodyTypeThroughHelper` now:

- re-anchors the field-inference frame + decode-target variable onto the handler **even when the body type already resolved concretely** (fixes Variant B), and
- overrides the body type only when it is free-form `any` (fixes Variant A) — a concrete generic instantiation wins.

The tracker-tree walk remains as a fallback for single-caller helpers reached through deeper chains (#36). `RouteInfo.Function` can be bare or package-qualified, so the handler match accepts both forms.

## Verification

- New `shared_decode_any` and `shared_decode_generic` fixtures: each routes two handlers (`Copy`→`CopyDocumentRequest`, `Update`→`UpdateDocumentRequest`) through one shared helper. Both now emit per-endpoint `$ref`s and retain per-field `format: uuid`.
- **All existing goldens unchanged**, including the #36 single-caller `json_dto_helpers` fixture.
- Unit tests for `resolveBodyTypeThroughCallSite` (route-handler + tree-walk paths), `edgeCallerIsRouteHandler`, `concreteTypeFromParamArg`, and both refine variants, plus an e2e assertion. New code at 100% coverage; full suite, coverage gate, lint, vet, gofmt all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test coverage with new shared decode helper scenarios.
  * Added comprehensive unit tests for interprocedural type resolution and route handler disambiguation.
  * Enhanced guards testing with additional edge-case coverage.

* **Chores**
  * Added test fixtures and supporting modules for shared decode patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->