### PR TITLE
fix: match method handlers in shared any-decode resolution (#41)

### DIFF
--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -54,6 +54,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "json_dto_helpers", inputDir: "../../testdata/json_dto_helpers", configFn: spec.DefaultChiConfig},
 		{name: "shared_decode_any", inputDir: "../../testdata/shared_decode_any", configFn: spec.DefaultChiConfig},
 		{name: "shared_decode_generic", inputDir: "../../testdata/shared_decode_generic", configFn: spec.DefaultChiConfig},
+		{name: "shared_decode_methods", inputDir: "../../testdata/shared_decode_methods", configFn: spec.DefaultChiConfig},
 		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
 		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 		{name: "security_bearer", inputDir: "../../testdata/security_bearer", configFn: spec.DefaultHTTPConfig},
@@ -527,7 +528,7 @@ func TestE2E_MapIndexPath_NoPhantomPathParams(t *testing.T) {
 // its own request type and keeps per-field format: uuid — for both the
 // any-typed and the generic helper forms.
 func TestE2E_SharedDecodeHelper_PerCallSiteBodyTypes(t *testing.T) {
-	for _, dir := range []string{"shared_decode_any", "shared_decode_generic"} {
+	for _, dir := range []string{"shared_decode_any", "shared_decode_generic", "shared_decode_methods"} {
 		t.Run(dir, func(t *testing.T) {
 			cfg := newDefaultCfg("../../testdata/"+dir, spec.DefaultChiConfig())
 			result, err := NewEngine(cfg).GenerateOpenAPI()

--- a/internal/spec/interproc_inference_test.go
+++ b/internal/spec/interproc_inference_test.go
@@ -358,13 +358,17 @@ func TestIsFreeFormBodyType(t *testing.T) {
 func TestEdgeCallerIsRouteHandler(t *testing.T) {
 	meta := newTestMeta()
 	edge := makeEdge(meta, "Copy", "pkg", "decodeStrictJSON", "pkg", nil)
+	callerBase := edge.Caller.BaseID()
 
-	// Bare function name + matching package.
+	// Free-function form: route.Function is the caller's base ID.
+	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: callerBase}))
+	// Method form: route.Function is the base ID behind a TypeSep prefix
+	// (e.g. "pkg-->pkg.RecvType.Method") — issue #41. The prefix is stripped.
+	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "pkg" + TypeSep + callerBase}))
+	// Bare function name + matching package (fallback).
 	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Copy", Package: "pkg"}))
 	// Bare name with no package recorded on the route still matches.
 	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Copy"}))
-	// Package-qualified function name.
-	assert.True(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "pkg.Copy"}))
 	// Bare name but wrong package → no match.
 	assert.False(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: "Copy", Package: "other"}))
 	// Different handler.
@@ -372,9 +376,10 @@ func TestEdgeCallerIsRouteHandler(t *testing.T) {
 	// Guards.
 	assert.False(t, edgeCallerIsRouteHandler(&edge, nil))
 	assert.False(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{}))
-	// Caller with an empty name never matches.
+	assert.False(t, edgeCallerIsRouteHandler(&edge, &RouteInfo{Metadata: meta, Function: ""}))
+	// Non-matching Function with an empty caller name exercises the name=="" path.
 	nameless := makeEdge(meta, "", "pkg", "h", "pkg", nil)
-	assert.False(t, edgeCallerIsRouteHandler(&nameless, &RouteInfo{Metadata: meta, Function: ""}))
+	assert.False(t, edgeCallerIsRouteHandler(&nameless, &RouteInfo{Metadata: meta, Function: "zzz"}))
 }
 
 func TestConcreteTypeFromParamArg(t *testing.T) {

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -730,22 +730,33 @@ func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string,
 }
 
 // edgeCallerIsRouteHandler reports whether the edge's caller is the route's
-// handler function. RouteInfo.Function may be stored either bare ("Copy") or
-// package-qualified ("json_dto.Copy"), so both forms are accepted; the bare
-// form additionally checks the package to avoid cross-package collisions.
+// handler. RouteInfo.Function carries the handler identity in several forms:
+//
+//	free function: "pkg.Func"                       (== caller BaseID)
+//	method:        "pkg-->pkg.RecvType.Method"      (TypeSep-prefixed BaseID)
+//	bare:          "Func"                           (with Package set separately)
+//
+// The first two both end in the caller's BaseID, so the primary check compares
+// against e.Caller.BaseID() after stripping any TypeSep prefix — this is what
+// lets method handlers (issue #41) be matched, not just free functions. The
+// bare form is handled as a fallback.
 func edgeCallerIsRouteHandler(e *metadata.CallGraphEdge, route *RouteInfo) bool {
-	if route == nil || route.Metadata == nil {
+	if route == nil || route.Metadata == nil || route.Function == "" {
 		return false
+	}
+	want := route.Function
+	if idx := strings.Index(want, TypeSep); idx >= 0 {
+		want = want[idx+len(TypeSep):]
+	}
+	if e.Caller.BaseID() == want {
+		return true
 	}
 	name := stringFromPool(route.Metadata, e.Caller.Name)
 	if name == "" {
 		return false
 	}
-	pkg := stringFromPool(route.Metadata, e.Caller.Pkg)
-	if route.Function == name {
-		return route.Package == "" || route.Package == pkg
-	}
-	return route.Function == pkg+"."+name
+	return route.Function == name &&
+		(route.Package == "" || route.Package == stringFromPool(route.Metadata, e.Caller.Pkg))
 }
 
 // concreteTypeFromParamArg resolves the concrete body type and caller-frame

--- a/testdata/shared_decode_methods/expected_openapi.json
+++ b/testdata/shared_decode_methods/expected_openapi.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/copy": {
+      "post": {
+        "operationId": "DocumentHandler.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "operationId": "DocumentHandler.Update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId"
+        ]
+      },
+      "json_dto.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "storageBucketId",
+          "displayName"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_methods/expected_openapi_legacy.json
+++ b/testdata/shared_decode_methods/expected_openapi_legacy.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/copy": {
+      "post": {
+        "operationId": "json_dto.json_dto.DocumentHandler.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/update": {
+      "post": {
+        "operationId": "json_dto.json_dto.DocumentHandler.Update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/json_dto.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "json_dto.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId"
+        ]
+      },
+      "json_dto.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "storageBucketId",
+          "displayName"
+        ]
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_methods/go.mod
+++ b/testdata/shared_decode_methods/go.mod
@@ -1,0 +1,8 @@
+module json_dto
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
+)

--- a/testdata/shared_decode_methods/go.sum
+++ b/testdata/shared_decode_methods/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/shared_decode_methods/main.go
+++ b/testdata/shared_decode_methods/main.go
@@ -1,0 +1,66 @@
+// Package main guards issue #41: the any-typed shared decode helper, but with
+// the handlers declared as METHODS on a handler struct (as in real codebases
+// such as alkem-io/file-service) rather than free functions. The per-call-site
+// resolution must recognise a method handler — matched by the caller's base ID,
+// not just a bare/package-qualified function name — so each endpoint keeps its
+// own request DTO and per-field format: uuid.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type CopyDocumentRequest struct {
+	SourceID            string `json:"sourceId"`
+	DestinationBucketID string `json:"destinationBucketId"`
+}
+
+type UpdateDocumentRequest struct {
+	StorageBucketID string `json:"storageBucketId"`
+	DisplayName     string `json:"displayName"`
+}
+
+// DocumentHandler carries the route handlers as methods.
+type DocumentHandler struct{}
+
+func main() {
+	h := &DocumentHandler{}
+	r := chi.NewRouter()
+	r.Post("/copy", h.Copy)
+	r.Post("/update", h.Update)
+	http.ListenAndServe(":3000", r)
+}
+
+// decodeStrictJSON is the shared any-typed decode helper called by both methods.
+func decodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		http.Error(w, "bad", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	_, _ = uuid.Parse(body.SourceID)
+	_, _ = uuid.Parse(body.DestinationBucketID)
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
+	var body UpdateDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	_, _ = uuid.Parse(body.StorageBucketID)
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
Closes #41. Follow-up to #39 (v0.4.19).

## Problem

v0.4.19 resolved shared `any`/generic decode helpers per call site, but only for **free-function** handlers. The `any`-typed form still collapsed when the handlers were **methods** — the common real-world shape (e.g. `alkem-io/file-service`'s `DocumentHandler.Copy`/`Update`). One request schema was dropped and the other endpoint's `requestBody` `$ref` mis-pointed; both endpoints resolved to a single body type. (The generic form already worked because the type parameter carries the concrete type regardless of handler kind.)

Reproduced against v0.4.19 with method handlers: `/copy` and `/update` both `$ref`'d `UpdateDocumentRequest`, and `CopyDocumentRequest` was dropped.

## Root cause

`edgeCallerIsRouteHandler` (added in #39) matched `RouteInfo.Function` only against the caller's bare name (`"Copy"`) or `"pkg.Copy"`. For a method handler, `RouteInfo.Function` is a `TypeSep`-prefixed base ID — `"pkg-->pkg.RecvType.Method"` — while the caller's `BaseID()` is `"pkg.RecvType.Method"`. Neither bare-name check matched, so per-call-site resolution fell back to the shared tracker-tree parent (which points at a single caller) → collapse.

## Fix

Compare against the caller's `BaseID()` after stripping any `TypeSep` prefix from `Function`. This covers both forms:

- free function: `Function == "pkg.Func"` == `BaseID`
- method: `Function == "pkg-->pkg.RecvType.Method"` → strip prefix → `"pkg.RecvType.Method"` == `BaseID`

The bare-name + package match is kept as a fallback.

## Verification

- New `shared_decode_methods` fixture: method handlers (`DocumentHandler.Copy`/`Update`) sharing one `any`-typed `decodeStrictJSON`. Each endpoint now `$ref`s its own DTO and retains per-field `format: uuid`. The e2e assertion covers it alongside the free-function `any`/generic fixtures.
- **All existing goldens unchanged.**
- `edgeCallerIsRouteHandler` at 100% coverage (incl. the method/`TypeSep` form). Full suite, coverage gate, lint, vet, gofmt all pass.