### PR TITLE
fix: resolve closure/selector-registered handlers in shared any-decode (#41)

### DIFF
--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -55,6 +55,7 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "shared_decode_any", inputDir: "../../testdata/shared_decode_any", configFn: spec.DefaultChiConfig},
 		{name: "shared_decode_generic", inputDir: "../../testdata/shared_decode_generic", configFn: spec.DefaultChiConfig},
 		{name: "shared_decode_methods", inputDir: "../../testdata/shared_decode_methods", configFn: spec.DefaultChiConfig},
+		{name: "shared_decode_router", inputDir: "../../testdata/shared_decode_router", configFn: spec.DefaultChiConfig},
 		{name: "json_patch", inputDir: "../../testdata/json_patch", configFn: spec.DefaultChiConfig},
 		{name: "servemux_methods", inputDir: "../../testdata/servemux_methods", configFn: spec.DefaultHTTPConfig},
 		{name: "security_bearer", inputDir: "../../testdata/security_bearer", configFn: spec.DefaultHTTPConfig},
@@ -563,6 +564,39 @@ func TestE2E_SharedDecodeHelper_PerCallSiteBodyTypes(t *testing.T) {
 			assertUUIDField("json_dto.CopyDocumentRequest", "destinationBucketId")
 			assertUUIDField("json_dto.UpdateDocumentRequest", "storageBucketId")
 		})
+	}
+}
+
+// TestE2E_SharedDecodeRouter_ClosureRegisteredMethods asserts issue #41's
+// residual case: method handlers registered via a deps-struct selector inside an
+// r.Route(...) closure, sharing a free-function any-typed decode helper, must
+// still resolve each endpoint to its own DTO with per-field format: uuid.
+func TestE2E_SharedDecodeRouter_ClosureRegisteredMethods(t *testing.T) {
+	cfg := newDefaultCfg("../../testdata/shared_decode_router", spec.DefaultChiConfig())
+	result, err := NewEngine(cfg).GenerateOpenAPI()
+	require.NoError(t, err)
+
+	refOf := func(path, method string) string {
+		pi, ok := result.Paths[path]
+		require.True(t, ok, "%s missing", path)
+		op := map[string]*intspec.Operation{"POST": pi.Post, "PATCH": pi.Patch}[method]
+		require.NotNil(t, op, "%s %s missing", method, path)
+		require.NotNil(t, op.RequestBody)
+		mt, ok := op.RequestBody.Content["application/json"]
+		require.True(t, ok)
+		require.NotNil(t, mt.Schema)
+		return mt.Schema.Ref
+	}
+	assert.Equal(t, "#/components/schemas/handlers.CopyDocumentRequest", refOf("/internal/file/copy", "POST"))
+	assert.Equal(t, "#/components/schemas/handlers.UpdateDocumentRequest", refOf("/internal/file/{id}", "PATCH"))
+
+	require.NotNil(t, result.Components)
+	copyReq := result.Components.Schemas["handlers.CopyDocumentRequest"]
+	require.NotNil(t, copyReq, "CopyDocumentRequest schema must not be dropped")
+	for _, p := range []string{"sourceId", "destinationBucketId", "authorizationId"} {
+		ps := copyReq.Properties[p]
+		require.NotNil(t, ps, "property %s missing", p)
+		assert.Equal(t, "uuid", ps.Format, "%s format", p)
 	}
 }
 

--- a/internal/spec/interproc_inference_test.go
+++ b/internal/spec/interproc_inference_test.go
@@ -382,6 +382,80 @@ func TestEdgeCallerIsRouteHandler(t *testing.T) {
 	assert.False(t, edgeCallerIsRouteHandler(&nameless, &RouteInfo{Metadata: meta, Function: "zzz"}))
 }
 
+func TestLastDotSegment(t *testing.T) {
+	assert.Equal(t, "Copy", lastDotSegment("main"+TypeSep+"main.deps.DocumentHandler.Copy"))
+	assert.Equal(t, "Copy", lastDotSegment("pkg.Copy"))
+	assert.Equal(t, "Copy", lastDotSegment("Copy"))
+	assert.Equal(t, "", lastDotSegment("pkg."))
+}
+
+func TestCallerMatchesHandlerByPkgName(t *testing.T) {
+	meta := newTestMeta()
+	edge := makeEdge(meta, "Copy", "api", "decodeStrictJSON", "api", nil)
+	closureForm := "main" + TypeSep + "main.deps.DocumentHandler.Copy"
+
+	// Selector-chain registration form: package matches, method name is the last
+	// segment (issue #41).
+	assert.True(t, callerMatchesHandlerByPkgName(&edge, &RouteInfo{Metadata: meta, Function: closureForm, Package: "api"}))
+	// Plain qualified form also matches by (pkg, name).
+	assert.True(t, callerMatchesHandlerByPkgName(&edge, &RouteInfo{Metadata: meta, Function: "api.Copy", Package: "api"}))
+	// Wrong package.
+	assert.False(t, callerMatchesHandlerByPkgName(&edge, &RouteInfo{Metadata: meta, Function: closureForm, Package: "other"}))
+	// Wrong method (last segment).
+	assert.False(t, callerMatchesHandlerByPkgName(&edge, &RouteInfo{Metadata: meta, Function: "main" + TypeSep + "main.deps.DocumentHandler.Update", Package: "api"}))
+	// Requires a package on the route.
+	assert.False(t, callerMatchesHandlerByPkgName(&edge, &RouteInfo{Metadata: meta, Function: "api.Copy"}))
+	// Guards.
+	assert.False(t, callerMatchesHandlerByPkgName(&edge, nil))
+	assert.False(t, callerMatchesHandlerByPkgName(&edge, &RouteInfo{Metadata: meta, Function: "", Package: "api"}))
+	nameless := makeEdge(meta, "", "api", "h", "api", nil)
+	assert.False(t, callerMatchesHandlerByPkgName(&nameless, &RouteInfo{Metadata: meta, Function: "x.Copy", Package: "api"}))
+}
+
+func TestUniquePkgNameHandler(t *testing.T) {
+	meta := newTestMeta()
+	copyE := makeEdge(meta, "Copy", "api", "decodeStrictJSON", "api", nil)
+	updateE := makeEdge(meta, "Update", "api", "decodeStrictJSON", "api", nil)
+	cands := []*metadata.CallGraphEdge{&copyE, &updateE}
+	copyRoute := &RouteInfo{Metadata: meta, Function: "main" + TypeSep + "main.deps.DocumentHandler.Copy", Package: "api"}
+
+	got := uniquePkgNameHandler(cands, copyRoute)
+	require.NotNil(t, got)
+	assert.Equal(t, "Copy", stringFromPool(meta, got.Caller.Name))
+
+	// No candidate matches → nil.
+	assert.Nil(t, uniquePkgNameHandler(cands, &RouteInfo{Metadata: meta, Function: "main" + TypeSep + "x.Delete", Package: "api"}))
+
+	// Two candidates with the same method name → ambiguous → nil (no mis-bind).
+	copy2 := makeEdge(meta, "Copy", "api", "decodeStrictJSON", "api", nil)
+	assert.Nil(t, uniquePkgNameHandler([]*metadata.CallGraphEdge{&copyE, &copy2}, copyRoute))
+}
+
+// TestResolveBodyTypeThroughCallSite_RouteHandlerByPkgName covers the issue #41
+// closure/selector-chain registration: route.Function is the registration-site
+// form (not the method BaseID), so resolution must fall to the (package, name)
+// pass and still pick the right endpoint despite a shared tree parent.
+func TestResolveBodyTypeThroughCallSite_RouteHandlerByPkgName(t *testing.T) {
+	meta := newTestMeta()
+	cp := NewContextProvider(meta)
+	copyEdge := makeEdge(meta, "Copy", "api", "decodeStrictJSON", "api", nil)
+	setParamArg(&copyEdge, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "api.CopyReq"), "&"))
+	updateEdge := makeEdge(meta, "Update", "api", "decodeStrictJSON", "api", nil)
+	setParamArg(&updateEdge, "dst", wrapUnary(meta, makeIdentArg(meta, "body", "api.UpdateReq"), "&"))
+	decodeEdge := makeEdge(meta, "decodeStrictJSON", "api", "Decode", "encoding/json",
+		[]*metadata.CallArgument{makeIdentArg(meta, "dst", "any")})
+	meta.Callees = map[string][]*metadata.CallGraphEdge{
+		decodeEdge.Caller.BaseID(): {&copyEdge, &updateEdge},
+	}
+	decodeNode := makeTrackerNode(&decodeEdge)
+	decodeNode.Parent = makeTrackerNode(&updateEdge) // shared parent points at Update
+
+	bt, vn, _ := resolveBodyTypeThroughCallSite(decodeNode, "dst",
+		&RouteInfo{Metadata: meta, Function: "main" + TypeSep + "main.deps.DocumentHandler.Copy", Package: "api"}, cp)
+	assert.Equal(t, "api.CopyReq", bt, "closure-registered handler resolves to its own DTO")
+	assert.Equal(t, "body", vn)
+}
+
 func TestConcreteTypeFromParamArg(t *testing.T) {
 	meta := newTestMeta()
 	cp := NewContextProvider(meta)

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -697,11 +697,26 @@ func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string,
 	// (1) Route-handler disambiguation: among every edge that calls the
 	// enclosing helper, pick the one whose caller is this route's handler.
 	if route != nil && route.Metadata != nil {
-		helperBaseID := edge.Caller.BaseID()
-		for _, e := range route.Metadata.Callees[helperBaseID] {
-			if !edgeCallerIsRouteHandler(e, route) {
+		candidates := route.Metadata.Callees[edge.Caller.BaseID()]
+		// Pass 1 — exact handler identity (free functions and methods registered
+		// directly, e.g. r.Post("/x", h.Copy)).
+		for _, e := range candidates {
+			if !callerMatchesHandlerExact(e, route) {
 				continue
 			}
+			if bt, vn := concreteTypeFromParamArg(e, paramName, cp); bt != "" {
+				return bt, vn, e.Caller.BaseID()
+			}
+		}
+		// Pass 2 — selector-chain registration (issue #41 / file-service):
+		// handlers wired as `deps.DocumentHandler.Copy` inside an r.Route(...)
+		// closure leave route.Function in registration-site form
+		// ("main-->main.deps.DocumentHandler.Copy"), which never equals the
+		// method's own BaseID ("pkg/api.DocumentHandler.Copy"). route.Package
+		// still names the handler's package, so fall back to a (package, method
+		// name) match — accepted only when it resolves to a single candidate so
+		// same-named methods can't mis-bind.
+		if e := uniquePkgNameHandler(candidates, route); e != nil {
 			if bt, vn := concreteTypeFromParamArg(e, paramName, cp); bt != "" {
 				return bt, vn, e.Caller.BaseID()
 			}
@@ -730,17 +745,24 @@ func resolveBodyTypeThroughCallSite(node TrackerNodeInterface, paramName string,
 }
 
 // edgeCallerIsRouteHandler reports whether the edge's caller is the route's
-// handler. RouteInfo.Function carries the handler identity in several forms:
+// handler, by exact identity or a (package, method-name) match. Used to detect
+// an inline decode (the decode call sitting directly in the handler).
+func edgeCallerIsRouteHandler(e *metadata.CallGraphEdge, route *RouteInfo) bool {
+	return callerMatchesHandlerExact(e, route) || callerMatchesHandlerByPkgName(e, route)
+}
+
+// callerMatchesHandlerExact matches the edge's caller against the route's
+// handler by exact identity. RouteInfo.Function carries the handler in several
+// forms:
 //
 //	free function: "pkg.Func"                       (== caller BaseID)
 //	method:        "pkg-->pkg.RecvType.Method"      (TypeSep-prefixed BaseID)
 //	bare:          "Func"                           (with Package set separately)
 //
 // The first two both end in the caller's BaseID, so the primary check compares
-// against e.Caller.BaseID() after stripping any TypeSep prefix — this is what
-// lets method handlers (issue #41) be matched, not just free functions. The
-// bare form is handled as a fallback.
-func edgeCallerIsRouteHandler(e *metadata.CallGraphEdge, route *RouteInfo) bool {
+// against e.Caller.BaseID() after stripping any TypeSep prefix; the bare form
+// is handled as a fallback.
+func callerMatchesHandlerExact(e *metadata.CallGraphEdge, route *RouteInfo) bool {
 	if route == nil || route.Metadata == nil || route.Function == "" {
 		return false
 	}
@@ -757,6 +779,51 @@ func edgeCallerIsRouteHandler(e *metadata.CallGraphEdge, route *RouteInfo) bool 
 	}
 	return route.Function == name &&
 		(route.Package == "" || route.Package == stringFromPool(route.Metadata, e.Caller.Pkg))
+}
+
+// callerMatchesHandlerByPkgName matches the edge's caller against the route's
+// handler by (package, function/method name). This recovers the handler when it
+// is registered through a selector chain (e.g. `deps.DocumentHandler.Copy`
+// inside an r.Route(...) closure), where RouteInfo.Function is the registration
+// expression rather than the method's own identity but RouteInfo.Package still
+// names the handler's defining package. Deliberately ignores the receiver type,
+// which the registration form does not carry reliably (it uses the field name).
+func callerMatchesHandlerByPkgName(e *metadata.CallGraphEdge, route *RouteInfo) bool {
+	if route == nil || route.Metadata == nil || route.Function == "" || route.Package == "" {
+		return false
+	}
+	name := stringFromPool(route.Metadata, e.Caller.Name)
+	if name == "" || route.Package != stringFromPool(route.Metadata, e.Caller.Pkg) {
+		return false
+	}
+	return lastDotSegment(route.Function) == name
+}
+
+// uniquePkgNameHandler returns the single candidate whose caller matches the
+// route handler by (package, name), or nil when zero or more than one match —
+// the uniqueness guard prevents two same-named methods that share a decode
+// helper from binding to the wrong endpoint.
+func uniquePkgNameHandler(candidates []*metadata.CallGraphEdge, route *RouteInfo) *metadata.CallGraphEdge {
+	var match *metadata.CallGraphEdge
+	for _, e := range candidates {
+		if !callerMatchesHandlerByPkgName(e, route) {
+			continue
+		}
+		if match != nil {
+			return nil // ambiguous
+		}
+		match = e
+	}
+	return match
+}
+
+// lastDotSegment returns the substring after the final '.', or s when there is
+// none — i.e. the function/method name from a dotted identifier.
+func lastDotSegment(s string) string {
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		return s[i+1:]
+	}
+	return s
 }
 
 // concreteTypeFromParamArg resolves the concrete body type and caller-frame

--- a/testdata/shared_decode_router/expected_openapi.json
+++ b/testdata/shared_decode_router/expected_openapi.json
@@ -1,0 +1,129 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/internal/file/copy": {
+      "post": {
+        "tags": [
+          "/internal"
+        ],
+        "operationId": "DocumentHandler.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/handlers.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/internal/file/{id}": {
+      "patch": {
+        "tags": [
+          "/internal"
+        ],
+        "operationId": "DocumentHandler.Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/handlers.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "handlers.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId",
+          "authorizationId"
+        ]
+      },
+      "handlers.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_router/expected_openapi_legacy.json
+++ b/testdata/shared_decode_router/expected_openapi_legacy.json
@@ -1,0 +1,129 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    },
+    "license": {
+      "name": ""
+    }
+  },
+  "paths": {
+    "/internal/file/copy": {
+      "post": {
+        "tags": [
+          "/internal"
+        ],
+        "operationId": "shared_decode_router/handlers.shared_decode_router.shared_decode_router.deps.DocumentHandler.Copy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/shared_decode_router_handlers.CopyDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/internal/file/{id}": {
+      "patch": {
+        "tags": [
+          "/internal"
+        ],
+        "operationId": "shared_decode_router/handlers.shared_decode_router.shared_decode_router.deps.DocumentHandler.Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/shared_decode_router_handlers.UpdateDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "shared_decode_router_handlers.CopyDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "authorizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "destinationBucketId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "sourceId",
+          "destinationBucketId",
+          "authorizationId"
+        ]
+      },
+      "shared_decode_router_handlers.UpdateDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "storageBucketId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/shared_decode_router/go.mod
+++ b/testdata/shared_decode_router/go.mod
@@ -1,0 +1,8 @@
+module shared_decode_router
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
+)

--- a/testdata/shared_decode_router/go.sum
+++ b/testdata/shared_decode_router/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testdata/shared_decode_router/handlers/handlers.go
+++ b/testdata/shared_decode_router/handlers/handlers.go
@@ -1,0 +1,86 @@
+// Package handlers mirrors the alkem-io/file-service shape from issue #41: the
+// route handlers are methods on a handler struct, in a package separate from
+// where routes are registered, and they share a free-function any-typed decode
+// helper. The handler struct is reached at the registration site through a
+// dependency-struct field selector inside an r.Route(...) closure, so
+// RouteInfo.Function ends up in registration-site form. Per-call-site
+// resolution must still bind each endpoint to its own request DTO via the
+// (package, method-name) match.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+type CopyDocumentRequest struct {
+	SourceID            string `json:"sourceId"`
+	DestinationBucketID string `json:"destinationBucketId"`
+	AuthorizationID     string `json:"authorizationId"`
+}
+
+type UpdateDocumentRequest struct {
+	StorageBucketID *string `json:"storageBucketId,omitempty"`
+	DisplayName     *string `json:"displayName,omitempty"`
+}
+
+// DocumentHandler carries the route handlers as methods.
+type DocumentHandler struct{}
+
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.WriteHeader(code)
+	_, _ = w.Write([]byte(msg))
+}
+
+// decodeStrictJSON is the shared, free-function, any-typed decode helper.
+func decodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return false
+	}
+	if dec.More() {
+		writeJSONError(w, http.StatusBadRequest, "trailing data")
+		return false
+	}
+	return true
+}
+
+// Copy handles POST /internal/file/copy.
+func (h *DocumentHandler) Copy(w http.ResponseWriter, r *http.Request) {
+	var body CopyDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	if _, err := uuid.Parse(body.SourceID); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid sourceId")
+		return
+	}
+	if _, err := uuid.Parse(body.DestinationBucketID); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid destinationBucketId")
+		return
+	}
+	if _, err := uuid.Parse(body.AuthorizationID); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid authorizationId")
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+// Update handles PATCH /internal/file/{id}.
+func (h *DocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
+	var body UpdateDocumentRequest
+	if !decodeStrictJSON(w, r, &body) {
+		return
+	}
+	if body.StorageBucketID != nil {
+		if _, err := uuid.Parse(*body.StorageBucketID); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid storageBucketId")
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/testdata/shared_decode_router/main.go
+++ b/testdata/shared_decode_router/main.go
@@ -1,0 +1,27 @@
+// Package main wires the handlers through a dependency struct and an
+// r.Route(...) closure, the registration shape that left issue #41 broken
+// after v0.4.20 (handler reached via deps.DocumentHandler.Copy inside the
+// closure rather than a direct h.Copy).
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"shared_decode_router/handlers"
+)
+
+type deps struct {
+	DocumentHandler *handlers.DocumentHandler
+}
+
+func main() {
+	d := &deps{DocumentHandler: &handlers.DocumentHandler{}}
+	r := chi.NewRouter()
+	r.Route("/internal", func(r chi.Router) {
+		r.Post("/file/copy", d.DocumentHandler.Copy)
+		r.Patch("/file/{id}", d.DocumentHandler.Update)
+	})
+	http.ListenAndServe(":3000", r)
+}


### PR DESCRIPTION
Re-fixes the residual case in #41 (which v0.4.20 marked closed but did **not** fully fix).

## Confirmed regression
A downstream report (alkem-io/file-service) said v0.4.20 still collapses the `any`-typed shared-decode case. I reproduced it **on the actual file-service code** with a verified v0.4.20 binary: `http.CopyDocumentRequest` dropped, `POST /internal/file/copy` `$ref` collapsed onto `http.UpdateDocumentRequest`.

My `shared_decode_methods` fixture missed it because it registered handlers directly. The real trigger is the **registration shape**: handlers wired through a dependency-struct selector inside an `r.Route(...)` closure —
```go
r.Route("/internal", func(r chi.Router) {
    r.Post("/file/copy", deps.DocumentHandler.Copy)
    r.Patch("/file/{id}", deps.DocumentHandler.Update)
})
```

## Root cause
With selector-chain registration, `RouteInfo.Function` is the registration-site expression — `"main-->main.deps.DocumentHandler.Copy"` — which never equals the handler method's `BaseID` (`"pkg/api.DocumentHandler.Copy"`). The exact-identity match added in v0.4.20 therefore missed it, and resolution fell back to the shared tracker-tree parent → both endpoints collapsed onto a single DTO. Crucially, `RouteInfo.Package` *does* still name the handler's defining package.

## Fix
A second resolution pass matches the helper-call edge by **(package, method name)** — `route.Package` vs the caller's package, and the method name as the last dotted segment of `route.Function` — accepted **only when it resolves to a single candidate**, so two same-named methods that share a decode helper can't mis-bind. The exact-identity pass still runs first and handles free functions and directly-registered methods unchanged.

## Verification
- Regenerating file-service's `openapi.yaml` with the fixed binary is **byte-identical to its baseline (empty `git diff`)**.
- New `shared_decode_router` fixture: deps-struct + `r.Route` closure + handlers in a separate package. Each endpoint resolves its own DTO with per-field `format: uuid`.
- **All existing goldens unchanged**, including v0.4.19/v0.4.20's shared-decode fixtures.
- Unit tests for the new (package, name) matcher + uniqueness guard, plus an e2e assertion. New code at 100% coverage; full suite, coverage gate, lint, vet, gofmt all pass.

Note: I have **not** reopened #41 — flagging for your call on tracker hygiene (reopen #41 vs. file fresh). This PR is ready either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test for OpenAPI specification generation with advanced route-handler matching.
  * Added unit tests validating route-handler registration patterns and fallback resolution logic.

* **Chores**
  * Added comprehensive test fixtures and testdata for shared_decode_router scenarios with sample API definitions and expected OpenAPI outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->