### PR TITLE
fix: spec-quality batch — method doc comments, validate-required, override description, empty license

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -557,10 +557,11 @@ func (e *Engine) applyConfigDefaults(apispecConfig *spec.APISpecConfig) {
 			Email: e.config.ContactEmail,
 		}
 	}
-	// Only emit a license block when one is actually configured — otherwise the
-	// pointer stays nil and omitempty drops it, instead of producing a
-	// meaningless `license: {name: ""}` (issue #47).
-	if apispecConfig.Info.License == nil && (e.config.LicenseName != "" || e.config.LicenseURL != "") {
+	// Only emit a license block when a license NAME is configured (issue #47):
+	// the pointer otherwise stays nil and omitempty drops it. OpenAPI requires
+	// license.name, so a URL without a name can't form a valid block — gate on
+	// the name alone (URL remains an optional addition).
+	if apispecConfig.Info.License == nil && e.config.LicenseName != "" {
 		apispecConfig.Info.License = &intspec.License{
 			Name: e.config.LicenseName,
 			URL:  e.config.LicenseURL,

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -557,7 +557,10 @@ func (e *Engine) applyConfigDefaults(apispecConfig *spec.APISpecConfig) {
 			Email: e.config.ContactEmail,
 		}
 	}
-	if apispecConfig.Info.License == nil {
+	// Only emit a license block when one is actually configured — otherwise the
+	// pointer stays nil and omitempty drops it, instead of producing a
+	// meaningless `license: {name: ""}` (issue #47).
+	if apispecConfig.Info.License == nil && (e.config.LicenseName != "" || e.config.LicenseURL != "") {
 		apispecConfig.Info.License = &intspec.License{
 			Name: e.config.LicenseName,
 			URL:  e.config.LicenseURL,

--- a/internal/engine/license_gating_test.go
+++ b/internal/engine/license_gating_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antst/go-apispec/spec"
+)
+
+// TestApplyConfigDefaults_LicenseGating covers issue #47 and its edge case
+// (raised by Copilot review): a license block is emitted only when a license
+// NAME is configured, since OpenAPI requires license.name. A URL without a name
+// must NOT produce an invalid `license: {name: ""}`.
+func TestApplyConfigDefaults_LicenseGating(t *testing.T) {
+	t.Run("no license configured -> no block", func(t *testing.T) {
+		e := NewEngine(&EngineConfig{})
+		cfg := &spec.APISpecConfig{}
+		e.applyConfigDefaults(cfg)
+		assert.Nil(t, cfg.Info.License, "empty license must not be emitted")
+	})
+
+	t.Run("URL only, no name -> no block (name is required in OpenAPI)", func(t *testing.T) {
+		e := NewEngine(&EngineConfig{LicenseURL: "https://example.com/license"})
+		cfg := &spec.APISpecConfig{}
+		e.applyConfigDefaults(cfg)
+		assert.Nil(t, cfg.Info.License, "URL without a name can't form a valid license block")
+	})
+
+	t.Run("name set -> block emitted with name and url", func(t *testing.T) {
+		e := NewEngine(&EngineConfig{LicenseName: "MIT", LicenseURL: "https://opensource.org/licenses/MIT"})
+		cfg := &spec.APISpecConfig{}
+		e.applyConfigDefaults(cfg)
+		require.NotNil(t, cfg.Info.License)
+		assert.Equal(t, "MIT", cfg.Info.License.Name)
+		assert.Equal(t, "https://opensource.org/licenses/MIT", cfg.Info.License.URL)
+	})
+}

--- a/internal/metadata/local_types_test.go
+++ b/internal/metadata/local_types_test.go
@@ -127,6 +127,30 @@ func other() {
 	require.Equal(t, []string{"A"}, fieldNames, "package-level Conf not shadowed by local Conf")
 }
 
+// TestMethodDocCommentsCaptured covers issue #45: doc comments on method
+// declarations are captured into the type's Method records (previously
+// processFunctions skipped methods, so method handler summaries were empty).
+func TestMethodDocCommentsCaptured(t *testing.T) {
+	meta := metaFromModule(t, map[string]interface{}{
+		"h.go": `package app
+
+type Handler struct{}
+
+// GetUser returns a user by ID.
+func (h *Handler) GetUser() {}
+`,
+	})
+	typ := findType(meta, "app", "Handler")
+	require.NotNil(t, typ)
+	var got string
+	for _, m := range typ.Methods {
+		if meta.StringPool.GetString(m.Name) == "GetUser" {
+			got = meta.StringPool.GetString(m.Comments)
+		}
+	}
+	require.Contains(t, got, "returns a user by ID")
+}
+
 // TestProcessLocalTypes_CrossFileShadow verifies the shadow guard is
 // package-scoped: a function-local type in one file must not overwrite a
 // package-level type of the same name declared in a *different* file (the

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -306,6 +306,7 @@ func GenerateMetadataWithLogger(pkgs map[string]map[string]*ast.File, fileToInfo
 					Signature:     *ExprToCallArgument(fn.Type, info, pkgName, fset, metadata),
 					Position:      metadata.StringPool.Get(getFuncPosition(fn, fset)),
 					Scope:         metadata.StringPool.Get(getScope(fn.Name.Name)),
+					Comments:      metadata.StringPool.Get(getComments(fn)),
 					AssignmentMap: assignmentsInFunc,
 					TypeParams:    typeParams,
 					ReturnVars:    returnVars,

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1992,6 +1992,11 @@ func (o *OverrideApplierImpl) ApplyOverrides(routeInfo *RouteInfo) {
 			if override.Summary != "" {
 				routeInfo.Summary = override.Summary
 			}
+			// Description was parsed from config but never applied (issue #46);
+			// a config override wins over the doc-comment-derived description.
+			if override.Description != "" {
+				routeInfo.Description = override.Description
+			}
 			if res, exists := routeInfo.Response[fmt.Sprintf("%d", override.ResponseStatus)]; exists && override.ResponseStatus != 0 && routeInfo.Response != nil {
 				res.StatusCode = override.ResponseStatus
 			}

--- a/internal/spec/mapper.go
+++ b/internal/spec/mapper.go
@@ -1186,21 +1186,22 @@ func generateStructSchema(usedTypes map[string]*Schema, key string, typ *metadat
 			}
 		}
 
-		// Apply validation constraints to the schema
+		// Required inference composes (issue #48): a field is required by Go
+		// default when its json tag has no omitempty (the zero value is always
+		// serialized), and a `validate:"required"` constraint forces it. A
+		// validate tag *without* required (e.g. `oneof=...`, `min=0`) must add
+		// its constraints without suppressing the omitempty-based inference —
+		// the previous either/else silently dropped such fields from required.
+		fieldTag := getStringFromPool(meta, field.Tag)
+		required := !hasOmitempty(fieldTag)
 		if validationConstraints != nil {
 			applyValidationConstraints(fieldSchema, validationConstraints)
-
-			// Add to required fields if marked as required
 			if validationConstraints.Required {
-				schema.Required = append(schema.Required, fieldName)
+				required = true
 			}
-		} else {
-			// Fields without omitempty and without a "-" json tag are required
-			// by default in Go (zero-value is always serialized).
-			fieldTag := getStringFromPool(meta, field.Tag)
-			if !hasOmitempty(fieldTag) {
-				schema.Required = append(schema.Required, fieldName)
-			}
+		}
+		if required {
+			schema.Required = append(schema.Required, fieldName)
 		}
 
 		// `apispec:"..."` is the user's explicit override — applied last so it
@@ -2331,11 +2332,34 @@ func parseArraySize(sizeStr string) *int {
 // and splits it into summary (first sentence) and description (full text).
 // Returns empty strings if no comment is found.
 // lookupFuncComment searches a package for a function's doc comment.
-func lookupFuncComment(pkg *metadata.Package, funcName string, sp *metadata.StringPool) (string, string) {
+func lookupFuncComment(pkg *metadata.Package, funcName, recvType string, sp *metadata.StringPool) (string, string) {
 	for _, file := range pkg.Files {
+		// Free functions are recorded in file.Functions.
 		if fn, exists := file.Functions[funcName]; exists {
 			if comment := sp.GetString(fn.Comments); comment != "" {
 				return splitDocComment(comment)
+			}
+		}
+		// Method handlers live on their receiver type, not in file.Functions —
+		// resolve the comment via the type's method records. recvType (the
+		// handler's receiver) is matched case-insensitively because the function
+		// path renders it lower-cased ("handler"), while the type is "Handler";
+		// an empty recvType (free-function route) matches no type, so the scan
+		// is a no-op there.
+		if recvType == "" {
+			continue
+		}
+		for _, typ := range file.Types {
+			if !strings.EqualFold(sp.GetString(typ.Name), recvType) {
+				continue
+			}
+			for i := range typ.Methods {
+				if sp.GetString(typ.Methods[i].Name) != funcName {
+					continue
+				}
+				if comment := sp.GetString(typ.Methods[i].Comments); comment != "" {
+					return splitDocComment(comment)
+				}
 			}
 		}
 	}
@@ -2365,10 +2389,24 @@ func extractDocComment(route *RouteInfo) (summary, description string) {
 	funcName, pkgPrefix := parseFuncNameAndPackage(route.Function)
 	sp := route.Metadata.StringPool
 
+	// For a method handler the receiver type follows the TypeSep in the
+	// function path (e.g. ".../echo-->handler.GetUsers" -> "handler"); used to
+	// resolve the method's doc comment off its type. The package path itself
+	// contains dots, so split on TypeSep first, then take the final dot-segment
+	// (handles "...-->main.deps.DocumentHandler").
+	recvType := pkgPrefix
+	if i := strings.LastIndex(recvType, TypeSep); i >= 0 {
+		recvType = recvType[i+len(TypeSep):]
+	}
+	if i := strings.LastIndex(recvType, "."); i >= 0 {
+		recvType = recvType[i+1:]
+	}
+	recvType = strings.TrimPrefix(recvType, "*")
+
 	// First pass: use route.Package if available (most precise).
 	if route.Package != "" {
 		if pkg, ok := route.Metadata.Packages[route.Package]; ok {
-			if s, d := lookupFuncComment(pkg, funcName, sp); s != "" || d != "" {
+			if s, d := lookupFuncComment(pkg, funcName, recvType, sp); s != "" || d != "" {
 				return s, d
 			}
 		}
@@ -2381,7 +2419,7 @@ func extractDocComment(route *RouteInfo) (summary, description string) {
 			if !strings.HasSuffix(pkgPrefix, pkgName) && !strings.HasSuffix(pkgName, pkgPrefix) {
 				continue
 			}
-			if s, d := lookupFuncComment(pkg, funcName, sp); s != "" || d != "" {
+			if s, d := lookupFuncComment(pkg, funcName, recvType, sp); s != "" || d != "" {
 				return s, d
 			}
 		}
@@ -2389,7 +2427,7 @@ func extractDocComment(route *RouteInfo) (summary, description string) {
 
 	// Fallback: search all packages (for cases where package prefix doesn't match)
 	for _, pkg := range route.Metadata.Packages {
-		if s, d := lookupFuncComment(pkg, funcName, sp); s != "" || d != "" {
+		if s, d := lookupFuncComment(pkg, funcName, recvType, sp); s != "" || d != "" {
 			return s, d
 		}
 	}

--- a/internal/spec/spec_quality_test.go
+++ b/internal/spec/spec_quality_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// TestExtractDocComment_MethodHandler covers issue #45: a method handler's doc
+// comment is resolved via the receiver type's method records (methods aren't in
+// file.Functions), and the receiver is matched through the TypeSep'd, lower-cased
+// function path ("app-->userhandler.GetUser" against type "UserHandler").
+func TestExtractDocComment_MethodHandler(t *testing.T) {
+	meta := &metadata.Metadata{StringPool: metadata.NewStringPool(), Packages: map[string]*metadata.Package{}}
+	sp := meta.StringPool
+	meta.Packages["app"] = &metadata.Package{
+		Files: map[string]*metadata.File{
+			"h.go": {
+				Functions: map[string]*metadata.Function{
+					"freeHandler": {Name: sp.Get("freeHandler"), Comments: sp.Get("freeHandler is a free function. With detail.")},
+				},
+				Types: map[string]*metadata.Type{
+					"UserHandler": {
+						Name: sp.Get("UserHandler"),
+						Methods: []metadata.Method{
+							{Name: sp.Get("GetUser"), Comments: sp.Get("GetUser returns a user by ID. It supports caching.")},
+							{Name: sp.Get("Other"), Comments: sp.Get("Other does something else.")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Free function: resolved via file.Functions; recvType ("app") matches no
+	// type so the method scan is a no-op.
+	free := &RouteInfo{Function: "app.freeHandler", Package: "app", Metadata: meta}
+	fs, _ := extractDocComment(free)
+	assert.Equal(t, "freeHandler is a free function.", fs)
+
+	// Bare function name (empty prefix) exercises the recvType=="" path.
+	bare := &RouteInfo{Function: "freeHandler", Package: "app", Metadata: meta}
+	bs, _ := extractDocComment(bare)
+	assert.Equal(t, "freeHandler is a free function.", bs)
+
+	// Receiver rendered lower-case after the TypeSep, as the real pipeline does.
+	route := &RouteInfo{Function: "app-->userhandler.GetUser", Package: "app", Metadata: meta}
+	s, d := extractDocComment(route)
+	assert.Equal(t, "GetUser returns a user by ID.", s)
+	assert.Contains(t, d, "caching")
+
+	// A receiver that matches no type yields nothing (and doesn't pick a
+	// same-named method off an unrelated type).
+	none := &RouteInfo{Function: "app-->nosuchtype.GetUser", Package: "app", Metadata: meta}
+	s2, d2 := extractDocComment(none)
+	assert.Empty(t, s2)
+	assert.Empty(t, d2)
+
+	// Resolving the second method exercises the method-name-mismatch skip.
+	other := &RouteInfo{Function: "app-->userhandler.Other", Package: "app", Metadata: meta}
+	os, _ := extractDocComment(other)
+	assert.Equal(t, "Other does something else.", os)
+
+	// An unknown bare function (no prefix → empty recvType, not in Functions)
+	// exercises the recvType=="" skip and falls through to no comment.
+	unknown := &RouteInfo{Function: "unknownBare", Package: "app", Metadata: meta}
+	us, _ := extractDocComment(unknown)
+	assert.Empty(t, us)
+}
+
+// TestApplyOverrides_Description covers issue #46: a config override's
+// description is applied to the operation (previously parsed but ignored).
+func TestApplyOverrides_Description(t *testing.T) {
+	applier := &OverrideApplierImpl{cfg: &APISpecConfig{
+		Overrides: []Override{{FunctionName: "GetThing", Description: "Override description."}},
+	}}
+	route := &RouteInfo{Function: "GetThing", Description: "old"}
+	applier.ApplyOverrides(route)
+	assert.Equal(t, "Override description.", route.Description)
+
+	// No description in the override leaves the existing one untouched.
+	applier2 := &OverrideApplierImpl{cfg: &APISpecConfig{
+		Overrides: []Override{{FunctionName: "GetThing", Summary: "S"}},
+	}}
+	route2 := &RouteInfo{Function: "GetThing", Description: "keep"}
+	applier2.ApplyOverrides(route2)
+	assert.Equal(t, "keep", route2.Description)
+}

--- a/testdata/bodyless_status/expected_openapi.json
+++ b/testdata/bodyless_status/expected_openapi.json
@@ -7,14 +7,13 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
     "/document/{id}": {
       "get": {
+        "summary": "GetDocument has four branches landing on four distinct status codes:\n\n\t?slow=1     → 102 Processing                  (bodyless 1xx)\n\t?delete=1   → 204 No Content                  (bodyless)\n\tmatching ETag → 304 Not Modified              (bodyless)\n\tdefault     → 200 OK with octet-stream body   (body-bearing control)\n\nThe default branch also calls Header().Set(\"Content-Type\", ...) to exercise\nthe route-level content-type detection.",
+        "description": "GetDocument has four branches landing on four distinct status codes:\n\n\t?slow=1     → 102 Processing                  (bodyless 1xx)\n\t?delete=1   → 204 No Content                  (bodyless)\n\tmatching ETag → 304 Not Modified              (bodyless)\n\tdefault     → 200 OK with octet-stream body   (body-bearing control)\n\nThe default branch also calls Header().Set(\"Content-Type\", ...) to exercise\nthe route-level content-type detection. Before the issue #33 fix, that\ndetected content-type would leak onto the 1xx/204/304 entries via the\nmapper's unconditional Content emission.",
         "operationId": "Handler.GetDocument",
         "parameters": [
           {

--- a/testdata/bodyless_status/expected_openapi_legacy.json
+++ b/testdata/bodyless_status/expected_openapi_legacy.json
@@ -7,14 +7,13 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
     "/document/{id}": {
       "get": {
+        "summary": "GetDocument has four branches landing on four distinct status codes:\n\n\t?slow=1     → 102 Processing                  (bodyless 1xx)\n\t?delete=1   → 204 No Content                  (bodyless)\n\tmatching ETag → 304 Not Modified              (bodyless)\n\tdefault     → 200 OK with octet-stream body   (body-bearing control)\n\nThe default branch also calls Header().Set(\"Content-Type\", ...) to exercise\nthe route-level content-type detection.",
+        "description": "GetDocument has four branches landing on four distinct status codes:\n\n\t?slow=1     → 102 Processing                  (bodyless 1xx)\n\t?delete=1   → 204 No Content                  (bodyless)\n\tmatching ETag → 304 Not Modified              (bodyless)\n\tdefault     → 200 OK with octet-stream body   (body-bearing control)\n\nThe default branch also calls Header().Set(\"Content-Type\", ...) to exercise\nthe route-level content-type detection. Before the issue #33 fix, that\ndetected content-type would leak onto the 1xx/204/304 entries via the\nmapper's unconditional Content emission.",
         "operationId": "github.com/antst/go-apispec/testdata/bodyless_status.Handler.GetDocument",
         "parameters": [
           {

--- a/testdata/chi/expected_openapi.json
+++ b/testdata/chi/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/chi/expected_openapi_legacy.json
+++ b/testdata/chi/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/echo/expected_openapi.json
+++ b/testdata/echo/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -60,6 +57,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "GetUsers returns a list of users using the UserService interface.",
         "operationId": "handler.GetUsers",
         "responses": {
           "200": {
@@ -81,6 +79,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "CreateUser creates a new user.",
         "operationId": "handler.CreateUser",
         "requestBody": {
           "content": {
@@ -137,6 +136,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "GetUser returns a single user by ID.",
         "operationId": "handler.GetUser",
         "parameters": [
           {
@@ -188,6 +188,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "UpdateUser updates an existing user.",
         "operationId": "handler.UpdateUser",
         "parameters": [
           {
@@ -259,6 +260,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "DeleteUser deletes a user by ID.",
         "operationId": "handler.DeleteUser",
         "parameters": [
           {
@@ -326,7 +328,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "age"
         ]
       },
       "echo.ErrorResponse": {

--- a/testdata/echo/expected_openapi_legacy.json
+++ b/testdata/echo/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -60,6 +57,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "GetUsers returns a list of users using the UserService interface.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.handler.GetUsers",
         "responses": {
           "200": {
@@ -81,6 +79,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "CreateUser creates a new user.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.handler.CreateUser",
         "requestBody": {
           "content": {
@@ -137,6 +136,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "GetUser returns a single user by ID.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.handler.GetUser",
         "parameters": [
           {
@@ -188,6 +188,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "UpdateUser updates an existing user.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.handler.UpdateUser",
         "parameters": [
           {
@@ -259,6 +260,7 @@
         "tags": [
           "/v1/users"
         ],
+        "summary": "DeleteUser deletes a user by ID.",
         "operationId": "github.com/antst/go-apispec/testdata/echo.handler.DeleteUser",
         "parameters": [
           {
@@ -326,7 +328,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "age"
         ]
       },
       "github.com_antst_go-apispec_testdata_echo.ErrorResponse": {

--- a/testdata/echo_handler_factory/expected_openapi.json
+++ b/testdata/echo_handler_factory/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/echo_handler_factory/expected_openapi_legacy.json
+++ b/testdata/echo_handler_factory/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/error_helpers/expected_openapi.json
+++ b/testdata/error_helpers/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/error_helpers/expected_openapi_legacy.json
+++ b/testdata/error_helpers/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/error_switch_file_service/expected_openapi.json
+++ b/testdata/error_switch_file_service/expected_openapi.json
@@ -7,14 +7,12 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
     "/documents/{id}/content": {
       "put": {
+        "summary": "ReplaceContent: PUT /documents/{id}/content — the full file-service shape.",
         "operationId": "DocumentHandler.ReplaceContent",
         "parameters": [
           {

--- a/testdata/error_switch_file_service/expected_openapi_legacy.json
+++ b/testdata/error_switch_file_service/expected_openapi_legacy.json
@@ -7,14 +7,12 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
     "/documents/{id}/content": {
       "put": {
+        "summary": "ReplaceContent: PUT /documents/{id}/content — the full file-service shape.",
         "operationId": "github.com/antst/go-apispec/testdata/error_switch_file_service.DocumentHandler.ReplaceContent",
         "parameters": [
           {

--- a/testdata/error_switch_minimal/expected_openapi.json
+++ b/testdata/error_switch_minimal/expected_openapi.json
@@ -7,14 +7,13 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
     "/documents/{id}/content": {
       "put": {
+        "summary": "ReplaceContent is the buggy shape: 422 has both a helper-write AND a\nstruct-method-write.",
+        "description": "ReplaceContent is the buggy shape: 422 has both a helper-write AND a\nstruct-method-write. Pre-fix, RejectedContentResponse leaks to 400.",
         "operationId": "Handler.ReplaceContent",
         "parameters": [
           {

--- a/testdata/error_switch_minimal/expected_openapi_legacy.json
+++ b/testdata/error_switch_minimal/expected_openapi_legacy.json
@@ -7,14 +7,13 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
     "/documents/{id}/content": {
       "put": {
+        "summary": "ReplaceContent is the buggy shape: 422 has both a helper-write AND a\nstruct-method-write.",
+        "description": "ReplaceContent is the buggy shape: 422 has both a helper-write AND a\nstruct-method-write. Pre-fix, RejectedContentResponse leaks to 400.",
         "operationId": "github.com/antst/go-apispec/testdata/error_switch_minimal.Handler.ReplaceContent",
         "parameters": [
           {

--- a/testdata/fiber/expected_openapi.json
+++ b/testdata/fiber/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/fiber/expected_openapi_legacy.json
+++ b/testdata/fiber/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/form_value_var/expected_openapi.json
+++ b/testdata/form_value_var/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/form_value_var/expected_openapi_legacy.json
+++ b/testdata/form_value_var/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/gin/expected_openapi.json
+++ b/testdata/gin/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/gin/expected_openapi_legacy.json
+++ b/testdata/gin/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/json_dto/expected_openapi.json
+++ b/testdata/json_dto/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/json_dto/expected_openapi_legacy.json
+++ b/testdata/json_dto/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/json_dto_helpers/expected_openapi.json
+++ b/testdata/json_dto_helpers/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/json_dto_helpers/expected_openapi_legacy.json
+++ b/testdata/json_dto_helpers/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/json_patch/expected_openapi.json
+++ b/testdata/json_patch/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/json_patch/expected_openapi_legacy.json
+++ b/testdata/json_patch/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/map_index_path/expected_openapi.json
+++ b/testdata/map_index_path/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/map_index_path/expected_openapi_legacy.json
+++ b/testdata/map_index_path/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/mux/expected_openapi.json
+++ b/testdata/mux/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/mux/expected_openapi_legacy.json
+++ b/testdata/mux/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/nested_http/expected_openapi.json
+++ b/testdata/nested_http/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/nested_http/expected_openapi_legacy.json
+++ b/testdata/nested_http/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/response_patterns/expected_openapi.json
+++ b/testdata/response_patterns/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -794,7 +791,8 @@
         },
         "required": [
           "name",
-          "emails"
+          "emails",
+          "tags"
         ]
       },
       "response_patterns.PaginatedResponse": {

--- a/testdata/response_patterns/expected_openapi_legacy.json
+++ b/testdata/response_patterns/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -794,7 +791,8 @@
         },
         "required": [
           "name",
-          "emails"
+          "emails",
+          "tags"
         ]
       },
       "github.com_antst_go-apispec_testdata_response_patterns.PaginatedResponse": {

--- a/testdata/security_bearer/expected_openapi.json
+++ b/testdata/security_bearer/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/security_bearer/expected_openapi_legacy.json
+++ b/testdata/security_bearer/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/servemux_methods/expected_openapi.json
+++ b/testdata/servemux_methods/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -51,6 +48,8 @@
     },
     "/matrix/check-room": {
       "post": {
+        "summary": "handleCheckRoom decodes the body into dto.CheckRoomHTTPRequest, talks to\nan internal RPC layer (whose Request/Response types share a confusing\n\"CheckRoom\" prefix with the HTTP ones), and writes back the\ndto.CheckRoomHTTPResponse.",
+        "description": "handleCheckRoom decodes the body into dto.CheckRoomHTTPRequest, talks to\nan internal RPC layer (whose Request/Response types share a confusing\n\"CheckRoom\" prefix with the HTTP ones), and writes back the\ndto.CheckRoomHTTPResponse. The bug surfaces when apispec follows the\ntype tracer through the RPC variables and reports CheckRoomResponse as\nthe request body.",
         "operationId": "CheckRoomHandler.handleCheckRoom",
         "requestBody": {
           "content": {

--- a/testdata/servemux_methods/expected_openapi_legacy.json
+++ b/testdata/servemux_methods/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -51,6 +48,8 @@
     },
     "/matrix/check-room": {
       "post": {
+        "summary": "handleCheckRoom decodes the body into dto.CheckRoomHTTPRequest, talks to\nan internal RPC layer (whose Request/Response types share a confusing\n\"CheckRoom\" prefix with the HTTP ones), and writes back the\ndto.CheckRoomHTTPResponse.",
+        "description": "handleCheckRoom decodes the body into dto.CheckRoomHTTPRequest, talks to\nan internal RPC layer (whose Request/Response types share a confusing\n\"CheckRoom\" prefix with the HTTP ones), and writes back the\ndto.CheckRoomHTTPResponse. The bug surfaces when apispec follows the\ntype tracer through the RPC variables and reports CheckRoomResponse as\nthe request body.",
         "operationId": "servemux_methods.servemux_methods.CheckRoomHandler.handleCheckRoom",
         "requestBody": {
           "content": {

--- a/testdata/shared_decode_any/expected_openapi.json
+++ b/testdata/shared_decode_any/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/shared_decode_any/expected_openapi_legacy.json
+++ b/testdata/shared_decode_any/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/shared_decode_generic/expected_openapi.json
+++ b/testdata/shared_decode_generic/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/shared_decode_generic/expected_openapi_legacy.json
+++ b/testdata/shared_decode_generic/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/shared_decode_methods/expected_openapi.json
+++ b/testdata/shared_decode_methods/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/shared_decode_methods/expected_openapi_legacy.json
+++ b/testdata/shared_decode_methods/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/shared_decode_router/expected_openapi.json
+++ b/testdata/shared_decode_router/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -18,6 +15,7 @@
         "tags": [
           "/internal"
         ],
+        "summary": "Copy handles POST /internal/file/copy.",
         "operationId": "DocumentHandler.Copy",
         "requestBody": {
           "content": {
@@ -50,6 +48,7 @@
         "tags": [
           "/internal"
         ],
+        "summary": "Update handles PATCH /internal/file/{id}.",
         "operationId": "DocumentHandler.Update",
         "parameters": [
           {

--- a/testdata/shared_decode_router/expected_openapi_legacy.json
+++ b/testdata/shared_decode_router/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {
@@ -18,6 +15,7 @@
         "tags": [
           "/internal"
         ],
+        "summary": "Copy handles POST /internal/file/copy.",
         "operationId": "shared_decode_router/handlers.shared_decode_router.shared_decode_router.deps.DocumentHandler.Copy",
         "requestBody": {
           "content": {
@@ -50,6 +48,7 @@
         "tags": [
           "/internal"
         ],
+        "summary": "Update handles PATCH /internal/file/{id}.",
         "operationId": "shared_decode_router/handlers.shared_decode_router.shared_decode_router.deps.DocumentHandler.Update",
         "parameters": [
           {

--- a/testdata/wrapped_response/expected_openapi.json
+++ b/testdata/wrapped_response/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/wrapped_response/expected_openapi_legacy.json
+++ b/testdata/wrapped_response/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/writejson_helper/expected_openapi.json
+++ b/testdata/writejson_helper/expected_openapi.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {

--- a/testdata/writejson_helper/expected_openapi_legacy.json
+++ b/testdata/writejson_helper/expected_openapi_legacy.json
@@ -7,9 +7,6 @@
       "name": "Anton Starikov",
       "url": "https://github.com/antst/go-apispec",
       "email": "antst@gmail.com"
-    },
-    "license": {
-      "name": ""
     }
   },
   "paths": {


### PR DESCRIPTION
Four verified bugs (filed from real method-handler usage on kratos-webhooks /
file-service), fixed **structurally** — root causes, not symptom patches.

Closes #45, closes #46, closes #47, closes #48.

## Fixes
- **#45 method-handler doc comments** — `processFunctions` skipped `fn.Recv != nil`, so the flagship doc-extraction feature was a silent no-op for *every method handler*. Now captures method comments into `Method.Comments` and resolves them at the route via the receiver type (TypeSep-aware, case-insensitive, since the function path renders the receiver lower-cased).
- **#48 validate tag suppressing `required`** — the omitempty-based required inference sat in the `else` of `validationConstraints != nil`, so a `validate:` tag without `required` (`oneof=…`, `min=0`, `dive`) silently dropped a non-omitempty field from `required`. Required now **composes**: Go default (no json omitempty) refined by validate, instead of either/or.
- **#46 override description** — `ApplyOverrides` set Summary/Status/Type/Tags but not Description; now applied (config wins over doc comments).
- **#47 empty license block** — engine always built `Info.License` → `license: {name: ""}`; now only built when a name/URL is configured, so `omitempty` drops it.

## Golden review (50 files)
Each change individually verified, not blind-regenerated:
- method summaries/descriptions match the source comments;
- required additions (`echo` `Age` via `min=0,max=150`; `response_patterns` `Tags` via `dive,min=1,max=50`) are non-omitempty validate-without-required fields — `UpdateUserRequest` (json omitempty) correctly stays unmarked, so no over-marking;
- empty `license` blocks removed everywhere;
- no path/operationId/schema-ref changes.

New code at 100% coverage (`lookupFuncComment`, `extractDocComment`, `ApplyOverrides`); per-package gate + lint green; full suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * License info is now omitted from generated OpenAPI documents unless it’s fully configured, preventing empty/invalid license blocks.
  * Configuration-based operation descriptions now apply correctly, taking precedence over documentation comments when provided.
  * Method documentation comments are now captured and included in generated metadata.
  * Schema `required` inference now better respects `omitempty` while still honoring validation constraints.
* **Tests**
  * Added coverage for method doc-comment capture and description override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->