### PR TITLE
fix: validate decode data-source traces to the request body (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ testdata/security_bearer/security_bearer
 testdata/error_switch_minimal/error_switch_minimal
 testdata/error_switch_file_service/error_switch_file_service
 testdata/bodyless_status/bodyless_status
+testdata/multipart_overreach/multipart_overreach

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -65,6 +65,9 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "bodyless_status", inputDir: "../../testdata/bodyless_status", configFn: spec.DefaultHTTPConfig},
 		{name: "wrapped_response", inputDir: "../../testdata/wrapped_response", configFn: spec.DefaultHTTPConfig},
 		{name: "echo_handler_factory", inputDir: "../../testdata/echo_handler_factory", configFn: spec.DefaultEchoConfig},
+		// Regression for #52: a multipart handler must not get a request body
+		// inferred from an unrelated json.Unmarshal deep in its call graph.
+		{name: "multipart_overreach", inputDir: "../../testdata/multipart_overreach", configFn: spec.DefaultChiConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {
@@ -1216,6 +1219,47 @@ func TestGolden_AllFrameworks_Legacy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := generateGoldenSpec(t, tc, true)
 			compareGolden(t, tc, true, got)
+		})
+	}
+}
+
+// TestGolden_Deterministic regenerates every fixture's spec several times in a
+// fresh engine and asserts byte-identical output across runs. Go randomises map
+// iteration order on each range, so successive in-process generations exercise
+// different orderings — catching non-deterministic inference (e.g. the
+// map-ordering-dependent request-body attribution of issue #52) that would
+// otherwise silently break the "identical output across runs" guarantee that
+// downstream CI staleness gates depend on. Both the default and legacy snapshots
+// are covered, since both are part of the golden-regression CI contract.
+func TestGolden_Deterministic(t *testing.T) {
+	const runs = 5
+	assertStable := func(t *testing.T, tc frameworkTestCase, legacy bool) {
+		t.Helper()
+		mode := "default"
+		if legacy {
+			mode = "legacy"
+		}
+		first := string(generateGoldenSpec(t, tc, legacy))
+		for i := 2; i <= runs; i++ {
+			got := string(generateGoldenSpec(t, tc, legacy))
+			if got == first {
+				continue
+			}
+			fl := strings.Split(first, "\n")
+			gl := strings.Split(got, "\n")
+			for j := 0; j < len(fl) && j < len(gl); j++ {
+				if fl[j] != gl[j] {
+					t.Fatalf("non-deterministic %s output for %s on run %d, first diff at line %d:\n  run 1: %s\n  run %d: %s",
+						mode, tc.name, i, j+1, fl[j], i, gl[j])
+				}
+			}
+			t.Fatalf("non-deterministic %s output for %s on run %d: %d lines vs %d lines", mode, tc.name, i, len(fl), len(gl))
+		}
+	}
+	for _, tc := range allFrameworks(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			assertStable(t, tc, false)
+			assertStable(t, tc, true)
 		})
 	}
 }

--- a/internal/spec/pattern_matchers.go
+++ b/internal/spec/pattern_matchers.go
@@ -522,19 +522,11 @@ func (r *RequestPatternMatcherImpl) GetPriority() int {
 
 // ExtractRequest extracts request information from a matched node
 func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, route *RouteInfo) *RequestInfo {
-	// For chained Decode calls (e.g., json.NewDecoder(r.Body).Decode(&user)),
-	// check if the parent call's first argument is r.Body. If not, this isn't
-	// a request body decode and should be skipped.
+	// Reject decode calls that don't actually read the HTTP request body
+	// (wrong decoder source, or an unrelated arg-sourced json.Unmarshal).
 	edge := node.GetEdge()
-	if edge != nil && edge.ChainParent != nil {
-		parentName := r.contextProvider.GetString(edge.ChainParent.Callee.Name)
-		if parentName == "NewDecoder" && len(edge.ChainParent.Args) > 0 {
-			parentArg := r.contextProvider.GetArgumentInfo(edge.ChainParent.Args[0])
-			// Only accept r.Body or request.Body as the decoder source
-			if !strings.Contains(parentArg, "Body") {
-				return nil
-			}
-		}
+	if !r.decodeReadsRequestBody(node, edge) {
+		return nil
 	}
 
 	reqInfo := &RequestInfo{
@@ -610,6 +602,102 @@ func (r *RequestPatternMatcherImpl) ExtractRequest(node TrackerNodeInterface, ro
 	}
 
 	return reqInfo
+}
+
+// decodeReadsRequestBody reports whether a matched decode call actually reads
+// the HTTP request body, filtering out two false positives:
+//
+//   - a chained json.NewDecoder(x).Decode(&v) whose decoder source x isn't
+//     r.Body (the parent call's first arg); and
+//   - an arg-sourced decode — json.Unmarshal(data, &v), render.DecodeJSON(r, &v)
+//     — whose data argument doesn't trace to the request. Otherwise an unrelated
+//     json.Unmarshal reachable deep in the handler's call graph (e.g. a DB-column
+//     parse) is misattributed as the request body and, depending on call-graph
+//     map ordering, flaps run-to-run (issue #52).
+func (r *RequestPatternMatcherImpl) decodeReadsRequestBody(node TrackerNodeInterface, edge *metadata.CallGraphEdge) bool {
+	if edge == nil {
+		return true
+	}
+	if edge.ChainParent != nil {
+		parentName := r.contextProvider.GetString(edge.ChainParent.Callee.Name)
+		if parentName == "NewDecoder" && len(edge.ChainParent.Args) > 0 {
+			parentArg := r.contextProvider.GetArgumentInfo(edge.ChainParent.Args[0])
+			if !strings.Contains(parentArg, "Body") {
+				return false
+			}
+		}
+	}
+	if r.pattern.TypeFromArg && r.pattern.TypeArgIndex >= 1 && len(edge.Args) > r.pattern.TypeArgIndex {
+		if !r.decodeSourceTracesToRequest(node, edge.Args[r.pattern.TypeArgIndex-1]) {
+			return false
+		}
+	}
+	return true
+}
+
+// decodeSourceTracesToRequest reports whether a decode call's data-source
+// argument is, or derives from, the HTTP request — directly (r.Body, a
+// *http.Request value), or via a local assignment within the decode's own
+// function (e.g. b := io.ReadAll(r.Body); json.Unmarshal(b, &v)). It rejects
+// decodes of unrelated data — e.g. a DB-column json.Unmarshal reachable deep in
+// the handler's call graph — that would otherwise be misinferred as the request
+// body (issue #52).
+func (r *RequestPatternMatcherImpl) decodeSourceTracesToRequest(node TrackerNodeInterface, src *metadata.CallArgument) bool {
+	if src == nil {
+		return true // nothing to validate
+	}
+	if argReferencesRequest(src) {
+		return true
+	}
+	// The source is a local/param ident: accept when it's assigned from the
+	// request body within the decode's own function.
+	if src.GetKind() != metadata.KindIdent || node == nil {
+		return false
+	}
+	edge := node.GetEdge()
+	if edge == nil {
+		return false
+	}
+	meta := metadataFromContextProvider(r.contextProvider)
+	if meta == nil {
+		return false
+	}
+	fn := findFunction(meta, meta.StringPool.GetString(edge.Caller.Pkg), meta.StringPool.GetString(edge.Caller.Name))
+	if fn == nil {
+		return false
+	}
+	assigns := fn.AssignmentMap[src.GetName()]
+	for i := range assigns {
+		if argReferencesRequest(&assigns[i].Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// argReferencesRequest walks a CallArgument expression tree looking for a
+// reference to the HTTP request or its body: a `.Body` selector (r.Body,
+// request.Body) or a value typed `*http.Request`/`http.Request`. Recurses
+// through call expressions so io.ReadAll(r.Body) and similar are recognised.
+func argReferencesRequest(arg *metadata.CallArgument) bool {
+	if arg == nil {
+		return false
+	}
+	if t := arg.GetType(); strings.Contains(t, "http.Request") {
+		return true
+	}
+	if arg.GetKind() == metadata.KindSelector && arg.Sel != nil && arg.Sel.GetName() == "Body" {
+		return true
+	}
+	if argReferencesRequest(arg.X) || argReferencesRequest(arg.Fun) || argReferencesRequest(arg.Sel) {
+		return true
+	}
+	for _, a := range arg.Args {
+		if argReferencesRequest(a) {
+			return true
+		}
+	}
+	return false
 }
 
 // refineBodyTypeThroughHelper resolves a decode that lives in an extracted

--- a/internal/spec/request_source_test.go
+++ b/internal/spec/request_source_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+// rsSelector builds `<x>.Body` as a KindSelector.
+func rsBodySelector(meta *metadata.Metadata, recv string) *metadata.CallArgument {
+	s := metadata.NewCallArgument(meta)
+	s.SetKind(metadata.KindSelector)
+	s.X = wsIdent(meta, recv, "", "")
+	s.Sel = wsIdent(meta, "Body", "", "")
+	return s
+}
+
+func TestArgReferencesRequest(t *testing.T) {
+	meta := pmcTestMeta()
+
+	assert.False(t, argReferencesRequest(nil), "nil")
+
+	// A value typed *http.Request.
+	req := wsIdent(meta, "r", "", "*http.Request")
+	assert.True(t, argReferencesRequest(req))
+
+	// r.Body selector.
+	assert.True(t, argReferencesRequest(rsBodySelector(meta, "r")))
+
+	// io.ReadAll(r.Body) — recurse through the call's args.
+	call := metadata.NewCallArgument(meta)
+	call.SetKind(metadata.KindCall)
+	call.Fun = wsIdent(meta, "ReadAll", "io", "")
+	call.Args = []*metadata.CallArgument{rsBodySelector(meta, "r")}
+	assert.True(t, argReferencesRequest(call))
+
+	// A bare []byte ident with no request reference.
+	assert.False(t, argReferencesRequest(wsIdent(meta, "raw", "", "[]byte")))
+
+	// A selector that isn't .Body.
+	other := metadata.NewCallArgument(meta)
+	other.SetKind(metadata.KindSelector)
+	other.X = wsIdent(meta, "row", "", "")
+	other.Sel = wsIdent(meta, "ContentMetadata", "", "")
+	assert.False(t, argReferencesRequest(other))
+
+	// The request reference sits in the call's Fun position, e.g. r.Body.Close().
+	funCall := metadata.NewCallArgument(meta)
+	funCall.SetKind(metadata.KindCall)
+	funCall.Fun = rsBodySelector(meta, "r")
+	assert.True(t, argReferencesRequest(funCall))
+}
+
+func TestDecodeReadsRequestBody(t *testing.T) {
+	meta := pmcTestMeta()
+	matcher := &RequestPatternMatcherImpl{
+		BasePatternMatcher: NewBasePatternMatcher(pmcTestCfg(), NewContextProvider(meta), nil),
+	}
+
+	// nil edge → nothing to filter.
+	assert.True(t, matcher.decodeReadsRequestBody(buildTrackerNode(nil), nil))
+
+	// Chained json.NewDecoder(r.Body).Decode — decoder source is the body → accept.
+	bodyEdge := buildCallGraphEdge(meta, "h", "app", "Decode", "json", nil)
+	bodyEdge.ChainParent = buildCallGraphEdge(meta, "h", "app", "NewDecoder", "json",
+		[]*metadata.CallArgument{rsBodySelector(meta, "r")})
+	assert.True(t, matcher.decodeReadsRequestBody(buildTrackerNode(bodyEdge), bodyEdge))
+
+	// Chained json.NewDecoder(buf).Decode — decoder source isn't the body → reject.
+	bufEdge := buildCallGraphEdge(meta, "h", "app", "Decode", "json", nil)
+	bufEdge.ChainParent = buildCallGraphEdge(meta, "h", "app", "NewDecoder", "json",
+		[]*metadata.CallArgument{wsIdent(meta, "buf", "", "*bytes.Buffer")})
+	assert.False(t, matcher.decodeReadsRequestBody(buildTrackerNode(bufEdge), bufEdge))
+
+	// Arg-sourced json.Unmarshal(r.Body, &v) → accept; Unmarshal(<literal>, &v) → reject (#52).
+	matcher.pattern = RequestBodyPattern{TypeFromArg: true, TypeArgIndex: 1}
+	okEdge := buildCallGraphEdge(meta, "h", "app", "Unmarshal", "json",
+		[]*metadata.CallArgument{rsBodySelector(meta, "r"), wsIdent(meta, "v", "", "*T")})
+	assert.True(t, matcher.decodeReadsRequestBody(buildTrackerNode(okEdge), okEdge))
+
+	badEdge := buildCallGraphEdge(meta, "h", "app", "Unmarshal", "json",
+		[]*metadata.CallArgument{buildLiteralArg(meta, "x"), wsIdent(meta, "v", "", "*T")})
+	assert.False(t, matcher.decodeReadsRequestBody(buildTrackerNode(badEdge), badEdge))
+}
+
+func TestDecodeSourceTracesToRequest(t *testing.T) {
+	meta := pmcTestMeta()
+	sp := meta.StringPool
+	matcher := &RequestPatternMatcherImpl{
+		BasePatternMatcher: NewBasePatternMatcher(pmcTestCfg(), NewContextProvider(meta), nil),
+	}
+
+	// A handler function whose `body` local is assigned io.ReadAll(r.Body),
+	// while `raw` is assigned from a non-request source.
+	readAll := metadata.NewCallArgument(meta)
+	readAll.SetKind(metadata.KindCall)
+	readAll.Fun = wsIdent(meta, "ReadAll", "io", "")
+	readAll.Args = []*metadata.CallArgument{rsBodySelector(meta, "r")}
+
+	dbCall := metadata.NewCallArgument(meta)
+	dbCall.SetKind(metadata.KindCall)
+	dbCall.Fun = wsIdent(meta, "readMetadataColumn", "app", "")
+
+	meta.Packages["app"] = &metadata.Package{
+		Files: map[string]*metadata.File{
+			"h.go": {Functions: map[string]*metadata.Function{
+				"handler": {
+					Name: sp.Get("handler"),
+					Pkg:  sp.Get("app"),
+					AssignmentMap: map[string][]metadata.Assignment{
+						"body": {{Value: *readAll}},
+						"raw":  {{Value: *dbCall}},
+					},
+				},
+			}},
+		},
+	}
+	node := buildTrackerNode(buildCallGraphEdge(meta, "handler", "app", "Unmarshal", "encoding/json", nil))
+
+	// nil source → nothing to validate.
+	assert.True(t, matcher.decodeSourceTracesToRequest(node, nil))
+
+	// Direct request reference.
+	assert.True(t, matcher.decodeSourceTracesToRequest(node, rsBodySelector(meta, "r")))
+	assert.True(t, matcher.decodeSourceTracesToRequest(node, wsIdent(meta, "r", "", "*http.Request")))
+
+	// Ident assigned from io.ReadAll(r.Body).
+	assert.True(t, matcher.decodeSourceTracesToRequest(node, wsIdent(meta, "body", "", "[]byte")))
+
+	// Ident assigned from a non-request (DB) source → rejected (issue #52).
+	assert.False(t, matcher.decodeSourceTracesToRequest(node, wsIdent(meta, "raw", "", "[]byte")))
+
+	// Ident with no assignment at all → rejected.
+	assert.False(t, matcher.decodeSourceTracesToRequest(node, wsIdent(meta, "unknown", "", "[]byte")))
+
+	// Node without an edge → cannot trace assignments → rejected.
+	assert.False(t, matcher.decodeSourceTracesToRequest(buildTrackerNode(nil), wsIdent(meta, "body", "", "[]byte")))
+
+	// Caller function cannot be resolved in the metadata → rejected.
+	ghost := buildTrackerNode(buildCallGraphEdge(meta, "ghost", "ghostpkg", "Unmarshal", "encoding/json", nil))
+	assert.False(t, matcher.decodeSourceTracesToRequest(ghost, wsIdent(meta, "body", "", "[]byte")))
+
+	// Non-ident, non-request literal → rejected.
+	assert.False(t, matcher.decodeSourceTracesToRequest(node, buildLiteralArg(meta, "x")))
+}

--- a/testdata/multipart_overreach/expected_openapi.json
+++ b/testdata/multipart_overreach/expected_openapi.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    }
+  },
+  "paths": {
+    "/internal/file": {
+      "post": {
+        "summary": "Create is a multipart streaming upload — no JSON body, returns 201.",
+        "operationId": "Handler.Create",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "form",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/multipart_overreach/expected_openapi_legacy.json
+++ b/testdata/multipart_overreach/expected_openapi_legacy.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    }
+  },
+  "paths": {
+    "/internal/file": {
+      "post": {
+        "summary": "Create is a multipart streaming upload — no JSON body, returns 201.",
+        "operationId": "github.com/antst/go-apispec/testdata/multipart_overreach.Handler.Create",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "form",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/multipart_overreach/go.mod
+++ b/testdata/multipart_overreach/go.mod
@@ -1,0 +1,5 @@
+module github.com/antst/go-apispec/testdata/multipart_overreach
+
+go 1.24.3
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testdata/multipart_overreach/go.sum
+++ b/testdata/multipart_overreach/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testdata/multipart_overreach/main.go
+++ b/testdata/multipart_overreach/main.go
@@ -1,0 +1,68 @@
+// Package main reproduces issue #52: a multipart streaming-upload handler with
+// NO JSON request body must not have one inferred from an unrelated, deep
+// json.Unmarshal reachable through its call graph (here a DB-column parse). The
+// Unmarshal's source ([]byte from a DB column) does not trace to r.Body, so the
+// request-body inference must not attribute it to the handler.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handler holds the upload endpoint.
+type Handler struct{}
+
+// ContentMeta is the typed view of a DB metadata column.
+type ContentMeta struct {
+	ImageWidth  *int `json:"imageWidth,omitempty"`
+	ImageHeight *int `json:"imageHeight,omitempty"`
+}
+
+// Create is a multipart streaming upload — no JSON body, returns 201.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	h.persist(file)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// persist stores the upload, then reads its metadata back from the DB.
+func (h *Handler) persist(rd io.Reader) {
+	_, _ = io.Copy(io.Discard, rd)
+	raw := h.readMetadataColumn()
+	_ = parseContentMetadata(raw)
+}
+
+// readMetadataColumn returns a []byte from a database column (NOT the request).
+func (h *Handler) readMetadataColumn() []byte { return []byte("{}") }
+
+// parseContentMetadata json-unmarshals a DB column into an internal anonymous
+// struct — not the HTTP request body.
+func parseContentMetadata(raw []byte) ContentMeta {
+	var v struct {
+		ImageWidth   *int `json:"imageWidth,omitempty"`
+		ImageHeight  *int `json:"imageHeight,omitempty"`
+		DecodeFailed bool `json:"_decodeFailed,omitempty"`
+	}
+	_ = json.Unmarshal(raw, &v)
+	return ContentMeta{ImageWidth: v.ImageWidth, ImageHeight: v.ImageHeight}
+}
+
+func main() {
+	r := chi.NewRouter()
+	h := &Handler{}
+	r.Post("/internal/file", h.Create)
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
## Summary

Fixes #52 — a multipart upload handler was getting a spurious `requestBody` inferred (non-deterministically) from an **unrelated** `json.Unmarshal` deep in its call graph.

### Root cause

An arg-sourced decode (`json.Unmarshal(data, &v)`, `render.DecodeJSON(r, &v)`) was matched as the request body **without checking that `data` actually originates from the HTTP request**. `ExtractRequest` validated the decoder source only for chained `json.NewDecoder(x).Decode` calls — never for arg-sourced decodes.

So a handler that `ParseMultipartForm`s its input and, several frames down its call graph, `json.Unmarshal`s an unrelated payload (e.g. a DB metadata column) had that inner decode misattributed as the endpoint's request body. Because the misattribution is driven by call-graph **map iteration order**, the spurious `requestBody` flapped run-to-run, producing non-deterministic golden output.

### Fix

`decodeReadsRequestBody` (extracted from the two pre-existing decode-source guards) now also requires an arg-sourced data argument to trace to the request:
- directly — `r.Body` / a `*http.Request` value; or
- via a local assignment within the decode's own function — `b := io.ReadAll(r.Body); json.Unmarshal(b, &v)`.

Unrelated decodes are rejected, so the misinference (and the flap it caused) is gone.

## Tests

- **`testdata/multipart_overreach`** — regression fixture mirroring the real file-service `Create` handler (multipart upload + an inner DB-column `Unmarshal`). Golden now correctly carries **no `requestBody`**, only `201`/`400` responses.
- **`TestGolden_Deterministic`** — regenerates every fixture 5× in-process (Go randomises map iteration each range) and asserts byte-identical output, guarding the whole corpus against ordering-driven flap like this one.
- New helpers (`decodeReadsRequestBody`, `decodeSourceTracesToRequest`, `argReferencesRequest`) covered by `internal/spec/request_source_test.go` at 95–100%.

## Verification

- `go test ./...` — all pass
- coverage gate — every package ≥95%
- `golangci-lint run ./...` — 0 issues
- `TestGolden_Deterministic` — all fixtures byte-identical across runs

## Scope

The golden-corpus expansion (router-diversity fixtures) is intentionally **not** in this PR — it ships separately as a test-only change. This PR is the focused fix that unblocks file-service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-body detection and traceability to avoid incorrectly treating unrelated decode/unmarshal operations as reading from the HTTP request body, reducing false JSON request-body inference (including multipart scenarios).
* **Tests**
  * Added regression coverage for multipart handlers where JSON parsing originates from non-request sources.
  * Added deterministic golden-file checks to ensure OpenAPI JSON output is byte-identical across repeated runs (default and legacy modes).
* **Chores**
  * Updated ignore rules to exclude the multipart overreach test fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->