### PR TITLE
fix: require free-function write destination to be the response writer (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ testdata/error_switch_minimal/error_switch_minimal
 testdata/error_switch_file_service/error_switch_file_service
 testdata/bodyless_status/bodyless_status
 testdata/multipart_overreach/multipart_overreach
+testdata/binary_response_overreach/binary_response_overreach

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -68,6 +68,9 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		// Regression for #52: a multipart handler must not get a request body
 		// inferred from an unrelated json.Unmarshal deep in its call graph.
 		{name: "multipart_overreach", inputDir: "../../testdata/multipart_overreach", configFn: spec.DefaultChiConfig},
+		// Regression for #52 (response side): io.Copy to the response writer is a
+		// binary 200, but io.Copy to a file reachable in the call graph is not.
+		{name: "binary_response_overreach", inputDir: "../../testdata/binary_response_overreach", configFn: spec.DefaultHTTPConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {

--- a/internal/spec/config.go
+++ b/internal/spec/config.go
@@ -122,6 +122,16 @@ type ResponsePattern struct {
 	// response but has no type argument to extract (e.g., fmt.Fprintf → "string",
 	// io.Copy → "[]byte"). Used only when TypeFromArg is false.
 	DefaultBodyType string `yaml:"defaultBodyType,omitempty"`
+	// ValidateWriterDest gates patterns whose write target is the FIRST argument
+	// rather than the receiver — the stdlib free functions io.Copy(dst, src),
+	// io.WriteString(dst, s) and fmt.Fprintf(dst, …). Receiver-based response
+	// writes (w.Write, c.JSON, json.NewEncoder(w).Encode) are already constrained
+	// to a response type by RecvTypeRegex; these free functions are not, so any
+	// io.Copy to a file/buffer reachable in a handler's call graph would otherwise
+	// be misinferred as a (binary) response body. When set, the destination arg
+	// must trace to an http.ResponseWriter or the pattern produces no response
+	// (issue #52, response-side counterpart of the request decode-source check).
+	ValidateWriterDest bool `yaml:"validateWriterDest,omitempty"`
 }
 
 // ParamPattern defines how to extract parameter information
@@ -574,13 +584,13 @@ func DefaultChiConfig() *APISpecConfig {
 				},
 				// stdlib write functions that target io.Writer (often ResponseWriter)
 				{BasePattern: BasePattern{CallRegex: `^Fprintf$|^Fprint$|^Fprintln$`,
-					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^Copy$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^WriteString$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 			},
 			ParamPatterns: []ParamPattern{
@@ -747,13 +757,13 @@ func DefaultEchoConfig() *APISpecConfig {
 				},
 				// stdlib write functions that target io.Writer (often ResponseWriter)
 				{BasePattern: BasePattern{CallRegex: `^Fprintf$|^Fprint$|^Fprintln$`,
-					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^Copy$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^WriteString$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 			},
 			ParamPatterns: []ParamPattern{
@@ -913,13 +923,13 @@ func DefaultFiberConfig() *APISpecConfig {
 				},
 				// stdlib write functions that target io.Writer (often ResponseWriter)
 				{BasePattern: BasePattern{CallRegex: `^Fprintf$|^Fprint$|^Fprintln$`,
-					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^Copy$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^WriteString$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 			},
 			ParamPatterns: []ParamPattern{
@@ -1079,13 +1089,13 @@ func DefaultGinConfig() *APISpecConfig {
 				},
 				// stdlib write functions that target io.Writer (often ResponseWriter)
 				{BasePattern: BasePattern{CallRegex: `^Fprintf$|^Fprint$|^Fprintln$`,
-					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^Copy$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^WriteString$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 			},
 			ParamPatterns: []ParamPattern{
@@ -1273,13 +1283,13 @@ func DefaultMuxConfig() *APISpecConfig {
 				},
 				// stdlib write functions that target io.Writer (often ResponseWriter)
 				{BasePattern: BasePattern{CallRegex: `^Fprintf$|^Fprint$|^Fprintln$`,
-					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^Copy$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^WriteString$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 			},
 			ParamPatterns: []ParamPattern{
@@ -1411,13 +1421,13 @@ func DefaultHTTPConfig() *APISpecConfig {
 				},
 				// stdlib write functions that target io.Writer (often ResponseWriter)
 				{BasePattern: BasePattern{CallRegex: `^Fprintf$|^Fprint$|^Fprintln$`,
-					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^fmt$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^Copy$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "[]byte", ValidateWriterDest: true,
 				},
 				{BasePattern: BasePattern{CallRegex: `^WriteString$`,
-					RecvTypeRegex: `^io$`}, DefaultBodyType: "string",
+					RecvTypeRegex: `^io$`}, DefaultBodyType: "string", ValidateWriterDest: true,
 				},
 			},
 			ParamPatterns: []ParamPattern{

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -759,6 +759,64 @@ func (r *ResponsePatternMatcherImpl) resolveParamArgType(node TrackerNodeInterfa
 	return ""
 }
 
+// writeDestTracesToResponseWriter reports whether a free-function write's
+// destination argument is, or derives from, an http.ResponseWriter — directly
+// (its type names http.ResponseWriter), through a local assignment in the
+// write's own function (dst := …), or through the parameter the caller bound it
+// to. It rejects writes to files, buffers and other non-response writers that
+// merely happen to be reachable from a route handler — e.g. file-service's
+// storage adapter io.Copy(dst, src) copying an upload to an *os.File (issue
+// #52). The bias is toward precision: an unresolved destination is rejected, so
+// a phantom binary response is never emitted (and can never flap on map order).
+func (r *ResponsePatternMatcherImpl) writeDestTracesToResponseWriter(node TrackerNodeInterface, dst *metadata.CallArgument) bool {
+	if dst == nil {
+		return false
+	}
+	if argReferencesResponseWriter(dst) {
+		return true
+	}
+	if dst.GetKind() != metadata.KindIdent {
+		return false
+	}
+	// Local assignment within the writing function (dst := <expr>).
+	if edge := node.GetEdge(); edge != nil {
+		if assigns, ok := edge.AssignmentMap[dst.GetName()]; ok {
+			for i := range assigns {
+				if argReferencesResponseWriter(&assigns[i].Value) {
+					return true
+				}
+			}
+		}
+	}
+	// Parameter the caller bound to a response writer (helper(w io.Writer)
+	// invoked with the handler's http.ResponseWriter).
+	if t := r.resolveParamArgType(node, dst.GetName()); strings.Contains(t, "http.ResponseWriter") {
+		return true
+	}
+	return false
+}
+
+// argReferencesResponseWriter walks a CallArgument expression tree looking for a
+// value typed http.ResponseWriter (or *http.ResponseWriter). Recurses through
+// selector/call expressions so c.Response().Writer and similar are recognised.
+func argReferencesResponseWriter(arg *metadata.CallArgument) bool {
+	if arg == nil {
+		return false
+	}
+	if strings.Contains(arg.GetType(), "http.ResponseWriter") {
+		return true
+	}
+	if argReferencesResponseWriter(arg.X) || argReferencesResponseWriter(arg.Fun) || argReferencesResponseWriter(arg.Sel) {
+		return true
+	}
+	for _, a := range arg.Args {
+		if argReferencesResponseWriter(a) {
+			return true
+		}
+	}
+	return false
+}
+
 // isInterfaceHandler checks if the route handler's receiver type is an interface.
 func (e *Extractor) isInterfaceHandler(route *RouteInfo) bool {
 	meta := e.tree.GetMetadata()
@@ -1602,6 +1660,20 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	}
 
 	edge := node.GetEdge()
+
+	// For free-function writes whose destination is the first argument
+	// (io.Copy(dst, src), io.WriteString(dst, s), fmt.Fprintf(dst, …)), the
+	// destination must be the HTTP response. Otherwise an io.Copy to a file or
+	// buffer reachable deep in the handler's call graph (e.g. file-service's
+	// storage adapter copying an upload to disk) is misinferred as a binary
+	// response body, and — depending on call-graph map ordering — flaps run to
+	// run (issue #52, response-side counterpart of decodeReadsRequestBody).
+	if r.pattern.ValidateWriterDest && edge != nil {
+		if len(edge.Args) == 0 || !r.writeDestTracesToResponseWriter(node, edge.Args[0]) {
+			return nil
+		}
+	}
+
 	if r.pattern.StatusFromArg && len(edge.Args) > r.pattern.StatusArgIndex {
 		arg := edge.Args[r.pattern.StatusArgIndex]
 		statusStr := r.contextProvider.GetArgumentInfo(arg)

--- a/internal/spec/response_dest_test.go
+++ b/internal/spec/response_dest_test.go
@@ -1,0 +1,164 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/antst/go-apispec/internal/metadata"
+)
+
+func rdMatcher(meta *metadata.Metadata) *ResponsePatternMatcherImpl {
+	cfg := &APISpecConfig{Defaults: Defaults{ResponseContentType: "application/json"}}
+	return &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			contextProvider: NewContextProvider(meta),
+			cfg:             cfg,
+			schemaMapper:    NewSchemaMapper(cfg),
+		},
+		pattern: ResponsePattern{},
+	}
+}
+
+func TestArgReferencesResponseWriter(t *testing.T) {
+	meta := newTestMeta()
+
+	assert.False(t, argReferencesResponseWriter(nil))
+
+	// A value typed http.ResponseWriter.
+	assert.True(t, argReferencesResponseWriter(makeIdentArg(meta, "w", "net/http.ResponseWriter")))
+
+	// A file destination — not a response writer.
+	assert.False(t, argReferencesResponseWriter(makeIdentArg(meta, "dst", "*os.File")))
+
+	// io.Copy(w, f) — recurse through the call's args.
+	call := makeCallArg(meta)
+	call.SetKind(metadata.KindCall)
+	call.Fun = makeIdentArg(meta, "Copy", "")
+	call.Args = []*metadata.CallArgument{
+		makeIdentArg(meta, "w", "net/http.ResponseWriter"),
+		makeIdentArg(meta, "f", "*os.File"),
+	}
+	assert.True(t, argReferencesResponseWriter(call))
+
+	// c.Response().Writer style — the receiver carries the type.
+	sel := makeCallArg(meta)
+	sel.SetKind(metadata.KindSelector)
+	sel.X = makeIdentArg(meta, "rw", "http.ResponseWriter")
+	sel.Sel = makeIdentArg(meta, "Writer", "")
+	assert.True(t, argReferencesResponseWriter(sel))
+}
+
+func TestWriteDestTracesToResponseWriter(t *testing.T) {
+	meta := newTestMeta()
+	m := rdMatcher(meta)
+
+	base := makeEdge(meta, "h", "app", "Copy", "io", nil)
+	baseNode := makeTrackerNode(&base)
+
+	// nil destination → rejected.
+	assert.False(t, m.writeDestTracesToResponseWriter(baseNode, nil))
+
+	// Direct http.ResponseWriter destination — io.Copy(w, f).
+	e1 := makeEdge(meta, "Download", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "w", "net/http.ResponseWriter"),
+		makeIdentArg(meta, "f", "*os.File"),
+	})
+	assert.True(t, m.writeDestTracesToResponseWriter(makeTrackerNode(&e1), e1.Args[0]))
+
+	// io.Copy(dst, src) where dst is a bare *os.File ident — rejected (issue #52).
+	e2 := makeEdge(meta, "store", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "dst", "*os.File"),
+		makeIdentArg(meta, "src", "io.Reader"),
+	})
+	assert.False(t, m.writeDestTracesToResponseWriter(makeTrackerNode(&e2), e2.Args[0]))
+
+	// Destination ident assigned from a response writer (rw := w) — accepted.
+	e3 := makeEdge(meta, "h", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "rw", ""),
+		makeIdentArg(meta, "src", ""),
+	})
+	e3.AssignmentMap = map[string][]metadata.Assignment{
+		"rw": {{Value: *makeIdentArg(meta, "w", "net/http.ResponseWriter")}},
+	}
+	assert.True(t, m.writeDestTracesToResponseWriter(makeTrackerNode(&e3), e3.Args[0]))
+
+	// Destination ident assigned from a file — rejected.
+	e4 := makeEdge(meta, "h", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "f", ""),
+		makeIdentArg(meta, "src", ""),
+	})
+	e4.AssignmentMap = map[string][]metadata.Assignment{
+		"f": {{Value: *makeIdentArg(meta, "tmp", "*os.File")}},
+	}
+	assert.False(t, m.writeDestTracesToResponseWriter(makeTrackerNode(&e4), e4.Args[0]))
+
+	// Destination is a parameter the caller bound to a response writer:
+	// stream(out io.Writer) called as stream(w) where w is http.ResponseWriter.
+	parent := makeEdge(meta, "Download", "app", "stream", "app", nil)
+	parent.ParamArgMap = map[string]metadata.CallArgument{
+		"out": *makeIdentArg(meta, "w", "net/http.ResponseWriter"),
+	}
+	parentNode := makeTrackerNode(&parent)
+	e5 := makeEdge(meta, "stream", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "out", "io.Writer"),
+		makeIdentArg(meta, "src", "io.Reader"),
+	})
+	child := makeTrackerNode(&e5)
+	child.Parent = parentNode
+	assert.True(t, m.writeDestTracesToResponseWriter(child, e5.Args[0]))
+
+	// A non-ident destination that isn't a response writer — rejected.
+	assert.False(t, m.writeDestTracesToResponseWriter(baseNode, makeLiteralArg(meta, "x")))
+}
+
+func TestExtractResponse_ValidateWriterDestGate(t *testing.T) {
+	meta := newTestMeta()
+	cfg := &APISpecConfig{Defaults: Defaults{ResponseContentType: "application/json"}}
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{
+			contextProvider: NewContextProvider(meta),
+			cfg:             cfg,
+			schemaMapper:    NewSchemaMapper(cfg),
+		},
+		pattern: ResponsePattern{DefaultBodyType: "[]byte", ValidateWriterDest: true},
+	}
+	route := NewRouteInfo()
+	route.Metadata = meta
+
+	// io.Copy(dst, src) where dst is a file → gate rejects → no response.
+	fileEdge := makeEdge(meta, "store", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "dst", "*os.File"),
+		makeIdentArg(meta, "src", "io.Reader"),
+	})
+	assert.Empty(t, matcher.ExtractResponse(makeTrackerNode(&fileEdge), route))
+
+	// io.Copy(w, f) where w is the response writer → gate passes → binary response.
+	wEdge := makeEdge(meta, "Download", "app", "Copy", "io", []*metadata.CallArgument{
+		makeIdentArg(meta, "w", "net/http.ResponseWriter"),
+		makeIdentArg(meta, "f", "*os.File"),
+	})
+	resp := firstResponse(matcher.ExtractResponse(makeTrackerNode(&wEdge), route))
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Schema)
+	assert.Equal(t, "binary", resp.Schema.Format)
+
+	// A pattern that writes to arg0 but the call carries no args → gate rejects.
+	noArgs := makeEdge(meta, "h", "app", "Copy", "io", nil)
+	assert.Empty(t, matcher.ExtractResponse(makeTrackerNode(&noArgs), route))
+}

--- a/testdata/binary_response_overreach/expected_openapi.json
+++ b/testdata/binary_response_overreach/expected_openapi.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    }
+  },
+  "paths": {
+    "/file": {
+      "post": {
+        "summary": "Upload is a multipart upload returning 201; its body is never binary.",
+        "operationId": "Handler.Upload",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "form",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/file/{id}": {
+      "get": {
+        "summary": "Download streams raw bytes to the response writer — a real binary 200.",
+        "operationId": "Handler.Download",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/binary_response_overreach/expected_openapi_legacy.json
+++ b/testdata/binary_response_overreach/expected_openapi_legacy.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    }
+  },
+  "paths": {
+    "/file": {
+      "post": {
+        "summary": "Upload is a multipart upload returning 201; its body is never binary.",
+        "operationId": "binary_response_overreach.binary_response_overreach.Handler.Upload",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "form",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/file/{id}": {
+      "get": {
+        "summary": "Download streams raw bytes to the response writer — a real binary 200.",
+        "operationId": "binary_response_overreach.binary_response_overreach.Handler.Download",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/binary_response_overreach/go.mod
+++ b/testdata/binary_response_overreach/go.mod
@@ -1,0 +1,3 @@
+module binary_response_overreach
+
+go 1.25

--- a/testdata/binary_response_overreach/main.go
+++ b/testdata/binary_response_overreach/main.go
@@ -1,0 +1,67 @@
+// Package main guards the response-side destination check (issue #52): a
+// free-function write (io.Copy/io.WriteString/fmt.Fprintf) only yields a
+// response when its destination is the HTTP ResponseWriter.
+//
+//   - Download streams a file straight to w via io.Copy(w, f) — a legitimate
+//     binary 200 that MUST be preserved.
+//   - Upload's call graph reaches io.Copy(dst, src) where dst is an *os.File
+//     (store) — that copy must NOT be misinferred as Upload's response body.
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+// Handler holds both endpoints.
+type Handler struct{}
+
+// Download streams raw bytes to the response writer — a real binary 200.
+func (h *Handler) Download(w http.ResponseWriter, r *http.Request) {
+	f := h.open(r.PathValue("id"))
+	defer f.Close()
+	w.Header().Set("Content-Type", "application/octet-stream")
+	_, _ = io.Copy(w, f)
+}
+
+// open returns the blob file for an id.
+func (h *Handler) open(id string) *os.File {
+	f, _ := os.Open("/data/" + id)
+	return f
+}
+
+// Upload is a multipart upload returning 201; its body is never binary.
+func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseMultipartForm(1 << 20); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	h.store(file)
+	w.WriteHeader(http.StatusCreated)
+}
+
+// store copies the upload to a file on disk — io.Copy whose destination is an
+// *os.File, not the response writer.
+func (h *Handler) store(src io.Reader) {
+	dst, err := os.Create("/tmp/blob")
+	if err != nil {
+		return
+	}
+	defer dst.Close()
+	_, _ = io.Copy(dst, src)
+}
+
+func main() {
+	h := &Handler{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /file/{id}", h.Download)
+	mux.HandleFunc("POST /file", h.Upload)
+	_ = http.ListenAndServe(":8080", mux)
+}

--- a/testdata/multipart_overreach/expected_openapi.json
+++ b/testdata/multipart_overreach/expected_openapi.json
@@ -28,23 +28,13 @@
           "201": {
             "description": "Created",
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
+              "application/json": {}
             }
           },
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
+              "application/json": {}
             }
           }
         }

--- a/testdata/multipart_overreach/expected_openapi_legacy.json
+++ b/testdata/multipart_overreach/expected_openapi_legacy.json
@@ -28,23 +28,13 @@
           "201": {
             "description": "Created",
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
+              "application/json": {}
             }
           },
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
+              "application/json": {}
             }
           }
         }


### PR DESCRIPTION
## Summary

Second non-determinism source behind #52, surfaced once v0.4.24 fixed the request-body half. A multipart `Create` handler (returns 201) was getting a **phantom `200` response with `format: binary`** that flapped run-to-run.

### Root cause

The `io.Copy` / `io.WriteString` / `fmt.Fprintf` response patterns match the writer **argument** (their `RecvTypeRegex` is the `io`/`fmt` package). Unlike the receiver-based `w.Write` pattern — constrained by `RecvTypeRegex: net/http.ResponseWriter` — they **never validated that the destination is the HTTP response**.

So any `io.Copy` reachable in a handler's call graph whose destination is a file or buffer was misinferred as the handler's binary response body. In file-service that's the storage adapter's `io.Copy(dst, src)` (dst is an `*os.File`) and an image transcode sink, both reached via `Create → Service.StageUpload/CompleteUpload`. Because that node is collected through **map-ordered call-graph traversal**, the phantom flapped.

### Fix

A `ValidateWriterDest` flag on those three stdlib patterns gates them in `ExtractResponse`: the destination arg (arg 0) must trace to an `http.ResponseWriter` —
- directly (its type names `http.ResponseWriter`),
- through a local assignment in the writing function, or
- through the parameter the caller bound it to (`resolveParamArgType`).

The bias is toward **precision**: an unresolved destination yields no response, so a phantom can never be emitted (or flap). This is the response-side counterpart of v0.4.24's `decodeReadsRequestBody` source check.

## Verification

On `alkem-io/file-service@develop`: previously flapped between **600 and 607 lines** (phantom `200` on `POST /internal/file` in ~3/12 runs); now a **stable 600 lines every run** (16/16 identical), and the legitimate binary `200`s on the GET download routes are preserved.

## Tests

- **`testdata/binary_response_overreach`** — two-way regression fixture: `io.Copy(w, f)` to the response writer keeps its binary `200`; `io.Copy(file, src)` deep in an upload handler's call graph no longer leaks a phantom binary response.
- **`testdata/multipart_overreach`** golden — its `io.Copy(io.Discard, rd)` no longer fabricates a `format: binary` schema on the bodyless 201/400 (a leak the original #52 golden had baked in).
- New helpers `writeDestTracesToResponseWriter` / `argReferencesResponseWriter` at 100% (`internal/spec/response_dest_test.go`); the `ExtractResponse` gate branch covered directly.
- Full suite + coverage gate (≥95% every package) + `golangci-lint` (0 issues) + `TestGolden_Deterministic` (both default & legacy modes) all green.

Closes #52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect inference of binary responses written to files, ensuring only data written directly to the HTTP response writer is captured as response body content.

* **Tests**
  * Added regression test case for binary response handling to prevent similar issues in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->