### PR TITLE
fix: filter conditional-status fan-out to call-site-reachable assignments (#50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ testdata/optional_fields/optional_fields
 testdata/pointers_variety/pointers_variety
 testdata/status_codes/status_codes
 testdata/xml_text_response/xml_text_response
+testdata/conditional_status_reachability/conditional_status_reachability

--- a/internal/engine/engine_e2e_test.go
+++ b/internal/engine/engine_e2e_test.go
@@ -117,6 +117,9 @@ func allFrameworks(t *testing.T) []frameworkTestCase {
 		{name: "generic_response_wrapper", inputDir: "../../testdata/generic_response_wrapper", configFn: spec.DefaultHTTPConfig},
 		// gorilla/mux .Queries(...) query params attach to their own route only.
 		{name: "mux_queries", inputDir: "../../testdata/mux_queries", configFn: spec.DefaultMuxConfig},
+		// Conditional-status fan-out reachability (#50): only statuses whose
+		// assignment reaches the response call site are emitted.
+		{name: "conditional_status_reachability", inputDir: "../../testdata/conditional_status_reachability", configFn: spec.DefaultHTTPConfig},
 	}
 	var available []frameworkTestCase
 	for _, tc := range cases {

--- a/internal/metadata/cfg.go
+++ b/internal/metadata/cfg.go
@@ -71,19 +71,43 @@ func buildEdgePositionIndex(meta *Metadata, _ *token.FileSet) map[string]*CallGr
 }
 
 // buildAssignmentPositionIndex creates a map from source position string to
-// Assignment pointers across all call graph edges. Mirrors
+// the Assignment pointers at that position. It covers the call-graph edge maps
+// AND the function/method AssignmentMaps — the latter are distinct copies that
+// downstream reachability analysis (expandStatusesFromIdent, issue #50) reads,
+// so they must be annotated too. Several assignments can share a position
+// (an edge copy and a function copy), hence the slice value. Mirrors
 // buildEdgePositionIndex's repoRoot-stripped + raw double-keying.
-func buildAssignmentPositionIndex(meta *Metadata, _ *token.FileSet) map[string]*Assignment {
-	index := make(map[string]*Assignment)
+func buildAssignmentPositionIndex(meta *Metadata, _ *token.FileSet) map[string][]*Assignment {
+	index := make(map[string][]*Assignment)
+	add := func(assigns []Assignment) {
+		for j := range assigns {
+			assign := &assigns[j]
+			pos := meta.StringPool.GetString(assign.Position)
+			if pos == "" {
+				continue
+			}
+			index[pos] = append(index[pos], assign)
+			if repoRoot != "" {
+				index[repoRoot+pos] = append(index[repoRoot+pos], assign)
+			}
+		}
+	}
 	for i := range meta.CallGraph {
 		for varName := range meta.CallGraph[i].AssignmentMap {
-			for j := range meta.CallGraph[i].AssignmentMap[varName] {
-				assign := &meta.CallGraph[i].AssignmentMap[varName][j]
-				pos := meta.StringPool.GetString(assign.Position)
-				if pos != "" {
-					index[pos] = assign
-					if repoRoot != "" {
-						index[repoRoot+pos] = assign
+			add(meta.CallGraph[i].AssignmentMap[varName])
+		}
+	}
+	for _, pkg := range meta.Packages {
+		for _, file := range pkg.Files {
+			for _, fn := range file.Functions {
+				for varName := range fn.AssignmentMap {
+					add(fn.AssignmentMap[varName])
+				}
+			}
+			for _, typ := range file.Types {
+				for m := range typ.Methods {
+					for varName := range typ.Methods[m].AssignmentMap {
+						add(typ.Methods[m].AssignmentMap[varName])
 					}
 				}
 			}
@@ -95,7 +119,7 @@ func buildAssignmentPositionIndex(meta *Metadata, _ *token.FileSet) map[string]*
 // annotateBranches walks the CFG blocks and tags edges/assignments with
 // BranchContext based on the block's Kind and parent statement.
 func annotateBranches(graph *cfg.CFG, fset *token.FileSet, meta *Metadata,
-	edgesByPos map[string]*CallGraphEdge, assignsByPos map[string]*Assignment) {
+	edgesByPos map[string]*CallGraphEdge, assignsByPos map[string][]*Assignment) {
 	for _, block := range graph.Blocks {
 		if !block.Live {
 			continue
@@ -138,7 +162,7 @@ func annotateBranches(graph *cfg.CFG, fset *token.FileSet, meta *Metadata,
 				if edge, ok := edgesByPos[pos]; ok {
 					edge.Branch = ctx
 				}
-				if assign, ok := assignsByPos[pos]; ok {
+				for _, assign := range assignsByPos[pos] {
 					assign.Branch = ctx
 				}
 				return true

--- a/internal/spec/conditional_status_test.go
+++ b/internal/spec/conditional_status_test.go
@@ -51,7 +51,13 @@ func csMatcher(t *testing.T, branchStatuses []string) (*ResponsePatternMatcherIm
 
 	assigns := make([]metadata.Assignment, 0, len(branchStatuses))
 	for _, name := range branchStatuses {
-		assigns = append(assigns, metadata.Assignment{Value: csNewErrorCall(meta, name)})
+		// These mirror `err = NewError(msg, http.Status…)` in distinct if/else
+		// branches, so each carries a (conditional) BranchContext — sibling
+		// branches don't shadow one another, so the fan-out keeps every status.
+		assigns = append(assigns, metadata.Assignment{
+			Value:  csNewErrorCall(meta, name),
+			Branch: &metadata.BranchContext{BlockKind: "if-else"},
+		})
 	}
 	meta.Packages["app"] = &metadata.Package{
 		Files: map[string]*metadata.File{
@@ -146,4 +152,104 @@ func csAssign(v metadata.CallArgument) metadata.Assignment { return metadata.Ass
 
 func matcherMeta(m *ResponsePatternMatcherImpl) *metadata.Metadata {
 	return metadataFromContextProvider(m.contextProvider)
+}
+
+func TestPositionAfter(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"f.go:20:1", "f.go:10:1", true},  // later line
+		{"f.go:10:5", "f.go:10:2", true},  // same line, later column
+		{"f.go:10:1", "f.go:20:1", false}, // earlier line
+		{"f.go:10:1", "f.go:10:1", false}, // equal
+		{"", "f.go:10:1", false},          // missing a
+		{"f.go:10:1", "", false},          // missing b
+		{"bad", "f.go:10:1", false},       // unparseable a
+		{"f.go:x:1", "f.go:10:1", false},  // non-numeric line
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, positionAfter(c.a, c.b), "%q vs %q", c.a, c.b)
+	}
+}
+
+func TestExpandStatusesFromIdent_Reachability(t *testing.T) {
+	// Two assignments (400 then 500); the 500 is positioned AFTER the response
+	// call site, so only 400 reaches it (issue #50).
+	matcher, node := csMatcher(t, []string{"StatusBadRequest", "StatusInternalServerError"})
+	meta := matcherMeta(matcher)
+	sp := meta.StringPool
+	fn := findFunction(meta, "app", "handler")
+	fn.AssignmentMap["err"][0].Position = sp.Get("h.go:10:3") // before the call
+	fn.AssignmentMap["err"][1].Position = sp.Get("h.go:20:3") // after the call
+
+	edge := node.GetEdge()
+	edge.Position = sp.Get("h.go:15:3") // call site between the two assignments
+
+	assert.Equal(t, []int{400}, matcher.expandStatusesFromIdent(edge.Args[1], edge))
+}
+
+func TestExpandStatusesFromIdent_UnconditionalShadow(t *testing.T) {
+	// code=500 (unconditional) then code=400 (unconditional) before the call:
+	// the later unconditional assignment overwrites the earlier on every path,
+	// so only 400 reaches the call (issue #50, the reused-variable case).
+	matcher, node := csMatcher(t, []string{"StatusInternalServerError", "StatusBadRequest"})
+	meta := matcherMeta(matcher)
+	sp := meta.StringPool
+	fn := findFunction(meta, "app", "handler")
+	fn.AssignmentMap["err"][0].Position = sp.Get("h.go:10:3") // 500, earlier
+	fn.AssignmentMap["err"][0].Branch = nil                   // unconditional
+	fn.AssignmentMap["err"][1].Position = sp.Get("h.go:12:3") // 400, later
+	fn.AssignmentMap["err"][1].Branch = nil                   // unconditional (shadows 500)
+	edge := node.GetEdge()
+	edge.Position = sp.Get("h.go:15:3")
+	assert.Equal(t, []int{400}, matcher.expandStatusesFromIdent(edge.Args[1], edge))
+}
+
+func TestExpandStatusesFromIdent_SiblingBranchesNotShadowed(t *testing.T) {
+	// Two conditional (if-then / if-else) assignments before the call don't
+	// shadow each other — both reach, so the intended fan-out is preserved.
+	matcher, node := csMatcher(t, []string{"StatusBadRequest", "StatusNotFound"})
+	meta := matcherMeta(matcher)
+	sp := meta.StringPool
+	fn := findFunction(meta, "app", "handler")
+	fn.AssignmentMap["err"][0].Position = sp.Get("h.go:10:3")
+	fn.AssignmentMap["err"][0].Branch = &metadata.BranchContext{BlockKind: "if-then"}
+	fn.AssignmentMap["err"][1].Position = sp.Get("h.go:12:3")
+	fn.AssignmentMap["err"][1].Branch = &metadata.BranchContext{BlockKind: "if-else"}
+	edge := node.GetEdge()
+	edge.Position = sp.Get("h.go:15:3")
+	got := matcher.expandStatusesFromIdent(edge.Args[1], edge)
+	sort.Ints(got)
+	assert.Equal(t, []int{400, 404}, got)
+}
+
+func TestStatusFromCallArgs_NoStatus(t *testing.T) {
+	meta := pmcTestMeta()
+	matcher := &ResponsePatternMatcherImpl{
+		BasePatternMatcher: &BasePatternMatcher{cfg: pmcTestCfg(), contextProvider: NewContextProvider(meta), schemaMapper: NewSchemaMapper(pmcTestCfg())},
+	}
+	call := metadata.NewCallArgument(meta)
+	call.SetKind(metadata.KindCall)
+	call.Args = []*metadata.CallArgument{nil, buildIdentArg(meta, "notAStatus", "app")}
+	_, ok := statusFromCallArgs(matcher, call)
+	assert.False(t, ok)
+}
+
+func TestExpandStatusesFromIdent_ShadowRobustToUnparseablePosition(t *testing.T) {
+	// Copilot (#57): the LATER unconditional assignment — the real shadow
+	// boundary — has an unparseable position. The index-based boundary must
+	// still shadow the earlier 500, leaving only 400 (a position-based boundary
+	// would have stayed pinned to 500 and leaked it).
+	matcher, node := csMatcher(t, []string{"StatusInternalServerError", "StatusBadRequest"})
+	meta := matcherMeta(matcher)
+	sp := meta.StringPool
+	fn := findFunction(meta, "app", "handler")
+	fn.AssignmentMap["err"][0].Position = sp.Get("h.go:10:3") // 500, parseable
+	fn.AssignmentMap["err"][0].Branch = nil
+	fn.AssignmentMap["err"][1].Position = sp.Get("???") // 400, UNPARSEABLE
+	fn.AssignmentMap["err"][1].Branch = nil
+	edge := node.GetEdge()
+	edge.Position = sp.Get("h.go:15:3")
+	assert.Equal(t, []int{400}, matcher.expandStatusesFromIdent(edge.Args[1], edge))
 }

--- a/internal/spec/extractor.go
+++ b/internal/spec/extractor.go
@@ -1919,13 +1919,15 @@ func (r *ResponsePatternMatcherImpl) ExtractResponse(node TrackerNodeInterface, 
 	}
 
 	// Conditional status fan-out (issue #39): if the status arg is a local
-	// variable with multiple branched assignments mapping to *distinct* status
-	// codes, emit one response per status, all sharing the body/schema. Runs
-	// before the no-status-no-body guard so patterns whose status arg is an
-	// opaque ident (e.g. RespondWithError(w, err)) still produce responses when
-	// the branches encode the codes.
+	// variable with branched assignments mapping to distinct status codes, emit
+	// one response per status, all sharing the body/schema. Runs before the
+	// no-status-no-body guard so patterns whose status arg is an opaque ident
+	// (e.g. RespondWithError(w, err)) still produce responses when the branches
+	// encode the codes. The set is filtered to assignments that reach this call
+	// site (issue #50), so a single reachable status yields a single response
+	// rather than falling through to the unresolvable latest-wins path.
 	if r.pattern.StatusFromArg && len(edge.Args) > r.pattern.StatusArgIndex {
-		if statuses := r.expandStatusesFromIdent(edge.Args[r.pattern.StatusArgIndex], edge); len(statuses) > 1 {
+		if statuses := r.expandStatusesFromIdent(edge.Args[r.pattern.StatusArgIndex], edge); len(statuses) >= 1 {
 			out := make([]*ResponseInfo, 0, len(statuses))
 			for _, st := range statuses {
 				out = append(out, &ResponseInfo{
@@ -1976,28 +1978,103 @@ func (r *ResponsePatternMatcherImpl) expandStatusesFromIdent(arg *metadata.CallA
 	if !ok || len(assigns) < 2 {
 		return nil
 	}
-	seen := make(map[int]struct{}, len(assigns))
-	out := make([]int, 0, len(assigns))
+	// Reachability filter (issue #50): keep only the assignments whose value can
+	// reach this response call site, in two steps:
+	//
+	//  1. Drop assignments positioned textually after the call — they cannot
+	//     supply the value at the call.
+	//  2. Among the survivors, an *unconditional* assignment (Branch == nil)
+	//     overwrites every earlier assignment on every path, so it shadows them:
+	//     keep only the assignments from the last unconditional one onward.
+	//     Sibling if/else branch assignments (Branch != nil) don't shadow each
+	//     other, so the intended fan-out — both branches reassigning before one
+	//     trailing RespondWithError — is preserved.
+	//
+	// The shadow boundary is the *index* of the last unconditional survivor, not
+	// its source position: assignments are recorded in source order, so the
+	// index is a reliable boundary even when a position is missing/unparseable
+	// (a position-based boundary could be pinned to an earlier assignment and
+	// leak a shadowed status). Positions are only used — conservatively — for
+	// the textual after-call filter.
+	callPos := meta.StringPool.GetString(edge.Position)
+
+	statuses := make([]int, 0, len(assigns))
+	lastUncond := -1
 	for i := range assigns {
 		if assigns[i].Value.GetKind() != metadata.KindCall {
 			continue
 		}
-		for _, callArg := range assigns[i].Value.Args {
-			if callArg == nil {
-				continue
-			}
-			status, ok := r.schemaMapper.MapStatusCode(r.contextProvider.GetArgumentInfo(callArg))
-			if !ok {
-				continue
-			}
-			if _, dup := seen[status]; !dup {
-				seen[status] = struct{}{}
-				out = append(out, status)
-			}
-			break
+		if positionAfter(meta.StringPool.GetString(assigns[i].Position), callPos) {
+			continue
+		}
+		status, ok := statusFromCallArgs(r, &assigns[i].Value)
+		if !ok {
+			continue
+		}
+		statuses = append(statuses, status)
+		if assigns[i].Branch == nil {
+			lastUncond = len(statuses) - 1
+		}
+	}
+
+	start := 0
+	if lastUncond >= 0 {
+		start = lastUncond
+	}
+	seen := make(map[int]struct{}, len(statuses))
+	out := make([]int, 0, len(statuses))
+	for _, status := range statuses[start:] {
+		if _, dup := seen[status]; !dup {
+			seen[status] = struct{}{}
+			out = append(out, status)
 		}
 	}
 	return out
+}
+
+// statusFromCallArgs returns the first argument of a call that parses as a known
+// HTTP status code (e.g. the http.StatusXxx in NewError(msg, http.StatusXxx)).
+func statusFromCallArgs(r *ResponsePatternMatcherImpl, call *metadata.CallArgument) (int, bool) {
+	for _, callArg := range call.Args {
+		if callArg == nil {
+			continue
+		}
+		if status, ok := r.schemaMapper.MapStatusCode(r.contextProvider.GetArgumentInfo(callArg)); ok {
+			return status, true
+		}
+	}
+	return 0, false
+}
+
+// positionAfter reports whether source position a occurs strictly after b.
+// Positions are "file:line:col"; comparison is by (line, col), using the last
+// two colon-separated fields. Missing/unparseable positions return false so the
+// caller does not over-filter on incomplete data.
+func positionAfter(a, b string) bool {
+	la, ca, oka := positionLineCol(a)
+	lb, cb, okb := positionLineCol(b)
+	if !oka || !okb {
+		return false
+	}
+	if la != lb {
+		return la > lb
+	}
+	return ca > cb
+}
+
+// positionLineCol parses the trailing line and column from a "file:line:col"
+// position string.
+func positionLineCol(pos string) (line, col int, ok bool) {
+	parts := strings.Split(pos, ":")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	col, errC := strconv.Atoi(parts[len(parts)-1])
+	line, errL := strconv.Atoi(parts[len(parts)-2])
+	if errC != nil || errL != nil {
+		return 0, 0, false
+	}
+	return line, col, true
 }
 
 // resolveTypeOrigin traces the origin of a type through assignments and type parameters

--- a/testdata/conditional_status_reachability/expected_openapi.json
+++ b/testdata/conditional_status_reachability/expected_openapi.json
@@ -1,0 +1,104 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    }
+  },
+  "paths": {
+    "/fanout": {
+      "get": {
+        "summary": "fanout: both if/else branches reassign code before the single trailing\nWriteHeader, so both statuses reach it — the fan-out emits 400 and 404.",
+        "operationId": "conditional_status_reachability.fanout",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/mixed": {
+      "get": {
+        "summary": "mixed: an unconditional default (503) followed by a conditional override\n(400); both reach the WriteHeader (503 when the branch is skipped, 400 when\ntaken) — the unconditional default is not shadowed by a conditional.",
+        "description": "mixed: an unconditional default (503) followed by a conditional override\n(400); both reach the WriteHeader (503 when the branch is skipped, 400 when\ntaken) — the unconditional default is not shadowed by a conditional. Route is\n400 and 503.",
+        "operationId": "conditional_status_reachability.mixed",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/reachable": {
+      "post": {
+        "summary": "reachable: the only response is the 400 in the early-return branch.",
+        "description": "reachable: the only response is the 400 in the early-return branch. The later\ncode = 500 assignment is positioned after that call, so it must NOT appear —\nthe route is 400 only.",
+        "operationId": "conditional_status_reachability.reachable",
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/shadowed": {
+      "get": {
+        "summary": "shadowed: code = 500 is a dead store, overwritten unconditionally by code =\n400 before the only WriteHeader, so only 400 reaches it — the unconditional\nreassignment shadows the earlier one.",
+        "description": "shadowed: code = 500 is a dead store, overwritten unconditionally by code =\n400 before the only WriteHeader, so only 400 reaches it — the unconditional\nreassignment shadows the earlier one. Route is 400 only.",
+        "operationId": "conditional_status_reachability.shadowed",
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/conditional_status_reachability/expected_openapi_legacy.json
+++ b/testdata/conditional_status_reachability/expected_openapi_legacy.json
@@ -1,0 +1,104 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Generated API",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Anton Starikov",
+      "url": "https://github.com/antst/go-apispec",
+      "email": "antst@gmail.com"
+    }
+  },
+  "paths": {
+    "/fanout": {
+      "get": {
+        "summary": "fanout: both if/else branches reassign code before the single trailing\nWriteHeader, so both statuses reach it — the fan-out emits 400 and 404.",
+        "operationId": "testdata/conditional_status_reachability.fanout",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/mixed": {
+      "get": {
+        "summary": "mixed: an unconditional default (503) followed by a conditional override\n(400); both reach the WriteHeader (503 when the branch is skipped, 400 when\ntaken) — the unconditional default is not shadowed by a conditional.",
+        "description": "mixed: an unconditional default (503) followed by a conditional override\n(400); both reach the WriteHeader (503 when the branch is skipped, 400 when\ntaken) — the unconditional default is not shadowed by a conditional. Route is\n400 and 503.",
+        "operationId": "testdata/conditional_status_reachability.mixed",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/reachable": {
+      "post": {
+        "summary": "reachable: the only response is the 400 in the early-return branch.",
+        "description": "reachable: the only response is the 400 in the early-return branch. The later\ncode = 500 assignment is positioned after that call, so it must NOT appear —\nthe route is 400 only.",
+        "operationId": "testdata/conditional_status_reachability.reachable",
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/shadowed": {
+      "get": {
+        "summary": "shadowed: code = 500 is a dead store, overwritten unconditionally by code =\n400 before the only WriteHeader, so only 400 reaches it — the unconditional\nreassignment shadows the earlier one.",
+        "description": "shadowed: code = 500 is a dead store, overwritten unconditionally by code =\n400 before the only WriteHeader, so only 400 reaches it — the unconditional\nreassignment shadows the earlier one. Route is 400 only.",
+        "operationId": "testdata/conditional_status_reachability.shadowed",
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/testdata/conditional_status_reachability/go.mod
+++ b/testdata/conditional_status_reachability/go.mod
@@ -1,0 +1,3 @@
+module testdata/conditional_status_reachability
+
+go 1.22

--- a/testdata/conditional_status_reachability/main.go
+++ b/testdata/conditional_status_reachability/main.go
@@ -1,0 +1,67 @@
+// Package main exercises the conditional-status fan-out reachability filter
+// (issue #50). The status variable is assigned from calls (mapStatus(...)) so
+// the ident-based fan-out fires; the fan-out must include only the statuses
+// whose assignment actually reaches the response call site.
+package main
+
+import "net/http"
+
+// mapStatus makes the status assignment a call RHS (not a bare literal), which
+// is what triggers the ident-based status fan-out.
+func mapStatus(s int) int { return s }
+
+// fanout: both if/else branches reassign code before the single trailing
+// WriteHeader, so both statuses reach it — the fan-out emits 400 and 404.
+func fanout(w http.ResponseWriter, r *http.Request) {
+	var code int
+	if r.URL.Query().Get("a") != "" {
+		code = mapStatus(http.StatusBadRequest)
+	} else {
+		code = mapStatus(http.StatusNotFound)
+	}
+	w.WriteHeader(code)
+}
+
+// reachable: the only response is the 400 in the early-return branch. The later
+// code = 500 assignment is positioned after that call, so it must NOT appear —
+// the route is 400 only.
+func reachable(w http.ResponseWriter, r *http.Request) {
+	var code int
+	if r.Method == http.MethodGet {
+		code = mapStatus(http.StatusBadRequest)
+		w.WriteHeader(code)
+		return
+	}
+	code = mapStatus(http.StatusInternalServerError)
+	_ = code
+}
+
+// shadowed: code = 500 is a dead store, overwritten unconditionally by code =
+// 400 before the only WriteHeader, so only 400 reaches it — the unconditional
+// reassignment shadows the earlier one. Route is 400 only.
+func shadowed(w http.ResponseWriter, r *http.Request) {
+	code := mapStatus(http.StatusInternalServerError)
+	code = mapStatus(http.StatusBadRequest)
+	w.WriteHeader(code)
+}
+
+// mixed: an unconditional default (503) followed by a conditional override
+// (400); both reach the WriteHeader (503 when the branch is skipped, 400 when
+// taken) — the unconditional default is not shadowed by a conditional. Route is
+// 400 and 503.
+func mixed(w http.ResponseWriter, r *http.Request) {
+	code := mapStatus(http.StatusServiceUnavailable)
+	if r.URL.Query().Get("a") != "" {
+		code = mapStatus(http.StatusBadRequest)
+	}
+	w.WriteHeader(code)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /fanout", fanout)
+	mux.HandleFunc("POST /reachable", reachable)
+	mux.HandleFunc("GET /shadowed", shadowed)
+	mux.HandleFunc("GET /mixed", mixed)
+	_ = http.ListenAndServe(":8080", mux)
+}


### PR DESCRIPTION
Closes #50.

## Problem

`expandStatusesFromIdent` (the conditional-status fan-out from #44) read the status variable's **function-wide** `AssignmentMap` and emitted one response per distinct status across **all** assignments — with no filter for whether an assignment reaches the matched response call. So a later, shadowed, or out-of-branch reassignment of the same variable leaked spurious status codes onto the route.

## Fix (two parts)

**1. Metadata (`cfg.go`).** The CFG branch annotation only indexed the call-graph **edge** assignment maps, so the **function/method** maps that `expandStatusesFromIdent` actually reads kept `Branch == nil`. `buildAssignmentPositionIndex` now also indexes function/method maps (multi-valued, since an edge copy and a function copy can share a source position), making per-assignment branch context available to reachability analysis.

**2. Spec (`extractor.go`).** `expandStatusesFromIdent` keeps only the reachable statuses:
- (a) drop assignments positioned **after** the call site; then
- (b) keep only assignments at/after the **last unconditional** (`Branch == nil`) pre-call assignment — an unconditional reassignment overwrites earlier ones on every path, so it shadows them. Sibling `if`/`else` assignments (`Branch != nil`) don't shadow each other, so the intended fan-out is preserved.

The fan-out guard also relaxes `>1` → `>=1` so a single reachable status resolves to one response rather than a bodyless `default`.

## Result — all four shapes (fixture `conditional_status_reachability`)

| handler | shape | responses |
|---|---|---|
| `fanout` | if/else, both branches reach | **400, 404** |
| `mixed` | unconditional default + conditional override | **400, 503** |
| `reachable` | response only in the early-return branch; later 500 unreachable | **400** |
| `shadowed` | dead store overwritten before the only call | **400** |

The last two were wrong pre-#50 (each gained a spurious 500). This also resolves the **reused-variable** case that an earlier draft had deferred — the unconditional-shadow rule (now that branch data reaches the function map) handles it.

## Tests
- `positionAfter` / `positionLineCol` / `statusFromCallArgs` unit-tested; reachability, unconditional-shadow, and sibling-branch cases added to the `expandStatusesFromIdent` tests.
- Full suite + determinism (both modes) + coverage gate (≥95%, incl. the metadata change) + lint all green; no other fixture changed by the broadened branch annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for conditional status code handling and reachability analysis
  * Added comprehensive unit tests for status code assignment filtering across code branches

* **Improvements**
  * Enhanced status code resolution to correctly identify which assignments reach response call sites
  * Improved handling of branch shadowing logic for conditional status codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->