### PR TITLE
refactor: typed type model built at the AST boundary (Phase 1)

### DIFF
--- a/internal/metadata/typeref.go
+++ b/internal/metadata/typeref.go
@@ -153,17 +153,23 @@ func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 	}
 }
 
-// namedWithArgs builds a generic instantiation: the base type carrying the
-// positional type arguments. A generic is always a named type, so the base is
-// forced to RefNamed even if its bare name would otherwise look primitive.
+// namedWithArgs builds a generic instantiation: the named base type carrying
+// its positional type arguments. A generic's base must be a named type, so a
+// non-named base (a primitive, composite, or type parameter — only reachable
+// from ill-typed source like int[T] or ([]int)[T]) yields no usable type, as
+// does any unrecognized argument; in both cases the result is nil rather than a
+// fabricated "[T]"-style identifier.
 func namedWithArgs(base ast.Expr, args []ast.Expr, info *types.Info) *TypeRef {
 	ref := TypeRefFromExpr(base, info)
-	if ref == nil {
+	if ref == nil || ref.Kind != RefNamed {
 		return nil
 	}
-	ref.Kind = RefNamed
 	for _, a := range args {
-		ref.Args = append(ref.Args, TypeRefFromExpr(a, info))
+		arg := TypeRefFromExpr(a, info)
+		if arg == nil {
+			return nil
+		}
+		ref.Args = append(ref.Args, arg)
 	}
 	return ref
 }

--- a/internal/metadata/typeref.go
+++ b/internal/metadata/typeref.go
@@ -1,0 +1,249 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"strconv"
+	"strings"
+)
+
+// TypeRef is a structured, recursive representation of a Go type, built once
+// from the syntax tree (and type info) at the point where the structure is
+// still intact, then carried as a tree rather than flattened to a string and
+// re-parsed downstream.
+//
+// It replaces getTypeName's string flattening, which is lossy and ambiguous:
+// getTypeName collapses every function to "func", every struct to "struct{}",
+// every array to a slice (the length is dropped), and has no case for
+// multi-parameter generics at all. A consumer that re-parses such a string
+// cannot recover what was thrown away, and a string parser that tries to is an
+// open-ended reimplementation of Go's type grammar. Building the tree from the
+// AST sidesteps all of it: *ast.FuncType, *ast.IndexListExpr, and
+// *ast.ArrayType.Len each answer the question directly and unambiguously.
+type TypeRef struct {
+	Kind RefKind
+	// Named: the package import path and type name. Basic: Name only (and Pkg
+	// for a qualified primitive such as time.Time, so String renders it whole).
+	Pkg  string
+	Name string
+	// Slice/Array/Pointer/Chan: the element type. Map: the value type.
+	Elem *TypeRef
+	// Map: the key type.
+	Key *TypeRef
+	// Named: generic instantiation arguments, e.g. the User in APIResponse[User]
+	// or the K, V in Pair[K, V] — positional, one per declared type parameter.
+	Args []*TypeRef
+	// Array: the length (>= 0; 0 when it could not be resolved as a constant).
+	Len int
+}
+
+// RefKind tags the shape of a TypeRef.
+type RefKind uint8
+
+const (
+	// RefBasic is a builtin/primitive scalar (int, string, bool, time.Time, …).
+	RefBasic RefKind = iota
+	// RefNamed is a package-qualified named type, a generic instantiation when
+	// Args is non-empty.
+	RefNamed
+	// RefSlice is []Elem.
+	RefSlice
+	// RefArray is [Len]Elem.
+	RefArray
+	// RefMap is map[Key]Elem.
+	RefMap
+	// RefPointer is *Elem.
+	RefPointer
+	// RefInterface is an interface type; schema-wise it is treated as any.
+	RefInterface
+	// RefFunc is a function type — opaque (no schema).
+	RefFunc
+	// RefStruct is an inline/anonymous struct type — opaque here; its fields
+	// are captured separately as a nested type.
+	RefStruct
+	// RefChan is a channel type — opaque (no schema).
+	RefChan
+)
+
+// TypeRefFromExpr builds a TypeRef from a type expression. info may be nil; it
+// is used only to resolve a selector's package path and to evaluate a constant
+// array length, both of which degrade gracefully when absent. Unrecognized
+// nodes return nil so callers can detect "no usable type" rather than a
+// fabricated one.
+func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
+	switch t := e.(type) {
+	case nil:
+		return nil
+	case *ast.ParenExpr:
+		return TypeRefFromExpr(t.X, info)
+	case *ast.Ident:
+		if IsPrimitiveType(t.Name) {
+			return &TypeRef{Kind: RefBasic, Name: t.Name}
+		}
+		return &TypeRef{Kind: RefNamed, Name: t.Name}
+	case *ast.SelectorExpr:
+		pkg, name := selectorParts(t, info)
+		full := name
+		if pkg != "" {
+			full = pkg + "." + name
+		}
+		if IsPrimitiveType(full) {
+			return &TypeRef{Kind: RefBasic, Pkg: pkg, Name: name}
+		}
+		return &TypeRef{Kind: RefNamed, Pkg: pkg, Name: name}
+	case *ast.StarExpr:
+		return &TypeRef{Kind: RefPointer, Elem: TypeRefFromExpr(t.X, info)}
+	case *ast.ArrayType:
+		if t.Len == nil {
+			return &TypeRef{Kind: RefSlice, Elem: TypeRefFromExpr(t.Elt, info)}
+		}
+		return &TypeRef{Kind: RefArray, Len: arrayLen(t.Len, info), Elem: TypeRefFromExpr(t.Elt, info)}
+	case *ast.MapType:
+		return &TypeRef{Kind: RefMap, Key: TypeRefFromExpr(t.Key, info), Elem: TypeRefFromExpr(t.Value, info)}
+	case *ast.InterfaceType:
+		return &TypeRef{Kind: RefInterface}
+	case *ast.StructType:
+		return &TypeRef{Kind: RefStruct}
+	case *ast.FuncType:
+		return &TypeRef{Kind: RefFunc}
+	case *ast.ChanType:
+		return &TypeRef{Kind: RefChan, Elem: TypeRefFromExpr(t.Value, info)}
+	case *ast.IndexExpr: // single-arg generic instantiation: Base[Arg]
+		return namedWithArgs(t.X, []ast.Expr{t.Index}, info)
+	case *ast.IndexListExpr: // multi-arg generic instantiation: Base[A, B]
+		return namedWithArgs(t.X, t.Indices, info)
+	default:
+		return nil
+	}
+}
+
+// namedWithArgs builds a generic instantiation: the base type carrying the
+// positional type arguments. A generic is always a named type, so the base is
+// forced to RefNamed even if its bare name would otherwise look primitive.
+func namedWithArgs(base ast.Expr, args []ast.Expr, info *types.Info) *TypeRef {
+	ref := TypeRefFromExpr(base, info)
+	if ref == nil {
+		return nil
+	}
+	ref.Kind = RefNamed
+	for _, a := range args {
+		ref.Args = append(ref.Args, TypeRefFromExpr(a, info))
+	}
+	return ref
+}
+
+// selectorParts resolves a qualified type "pkg.Name" to its import path and
+// name. With type info the package's full import path is used; without it the
+// source-level qualifier is the best available.
+func selectorParts(t *ast.SelectorExpr, info *types.Info) (pkg, name string) {
+	name = t.Sel.Name
+	x, ok := t.X.(*ast.Ident)
+	if !ok {
+		return "", name
+	}
+	if info != nil {
+		if p, ok := info.ObjectOf(x).(*types.PkgName); ok {
+			return p.Imported().Path(), name
+		}
+	}
+	return x.Name, name
+}
+
+// arrayLen evaluates a constant array length, preferring the type-checker's
+// constant value (which resolves named/const-expression lengths) and falling
+// back to a literal integer. Returns 0 when the length cannot be determined.
+func arrayLen(e ast.Expr, info *types.Info) int {
+	if info != nil {
+		if tv, ok := info.Types[e]; ok && tv.Value != nil {
+			if n, ok := constant.Int64Val(tv.Value); ok {
+				return int(n)
+			}
+		}
+	}
+	if lit, ok := e.(*ast.BasicLit); ok {
+		if n, err := strconv.Atoi(lit.Value); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// Qualify attaches pkg to every unqualified named node in the tree, turning a
+// bare field type like []Money into []pkg.Money. Already-qualified nodes,
+// primitives, and opaque kinds are left untouched.
+func (t *TypeRef) Qualify(pkg string) {
+	if t == nil || pkg == "" {
+		return
+	}
+	switch t.Kind {
+	case RefNamed:
+		if t.Pkg == "" {
+			t.Pkg = pkg
+		}
+		for _, a := range t.Args {
+			a.Qualify(pkg)
+		}
+	case RefSlice, RefArray, RefPointer, RefChan:
+		t.Elem.Qualify(pkg)
+	case RefMap:
+		t.Key.Qualify(pkg)
+		t.Elem.Qualify(pkg)
+	}
+}
+
+// String renders the TypeRef in canonical Go form. Opaque kinds render to their
+// bare keyword form (func, struct{}, interface{}, chan Elem).
+func (t *TypeRef) String() string {
+	if t == nil {
+		return ""
+	}
+	switch t.Kind {
+	case RefPointer:
+		return "*" + t.Elem.String()
+	case RefSlice:
+		return "[]" + t.Elem.String()
+	case RefArray:
+		return "[" + strconv.Itoa(t.Len) + "]" + t.Elem.String()
+	case RefMap:
+		return "map[" + t.Key.String() + "]" + t.Elem.String()
+	case RefInterface:
+		return "interface{}"
+	case RefStruct:
+		return "struct{}"
+	case RefFunc:
+		return "func"
+	case RefChan:
+		if t.Elem == nil {
+			return "chan"
+		}
+		return "chan " + t.Elem.String()
+	default: // RefNamed, RefBasic
+		name := t.Name
+		if t.Pkg != "" {
+			name = t.Pkg + "." + t.Name
+		}
+		if len(t.Args) == 0 {
+			return name
+		}
+		args := make([]string, len(t.Args))
+		for i, a := range t.Args {
+			args[i] = a.String()
+		}
+		return name + "[" + strings.Join(args, ",") + "]"
+	}
+}

--- a/internal/metadata/typeref.go
+++ b/internal/metadata/typeref.go
@@ -86,10 +86,11 @@ const (
 )
 
 // TypeRefFromExpr builds a TypeRef from a type expression. info may be nil; it
-// is used only to resolve a selector's package path and to evaluate a constant
-// array length, both of which degrade gracefully when absent. Unrecognized
-// nodes return nil so callers can detect "no usable type" rather than a
-// fabricated one.
+// is used to resolve a selector's package path, evaluate a constant array
+// length, and distinguish a generic type parameter from a package-local type —
+// all of which degrade gracefully when absent (without info a bare identifier
+// is treated as a named type, never a type parameter). Unrecognized nodes
+// return nil so callers can detect "no usable type" rather than a fabricated one.
 //
 //nolint:gocyclo // flat type switch over many AST node kinds — low real complexity
 func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
@@ -153,15 +154,15 @@ func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 	}
 }
 
-// namedWithArgs builds a generic instantiation: the named base type carrying
-// its positional type arguments. A generic's base must be a named type, so a
-// non-named base (a primitive, composite, or type parameter — only reachable
-// from ill-typed source like int[T] or ([]int)[T]) yields no usable type, as
-// does any unrecognized argument; in both cases the result is nil rather than a
-// fabricated "[T]"-style identifier.
+// namedWithArgs builds a generic instantiation: an un-instantiated named base
+// type carrying its positional type arguments. Anything else is reachable only
+// from ill-typed source and yields nil (never a fabricated identifier): a
+// non-named base (int[T], ([]int)[T]), a base that is already instantiated (the
+// nested Foo[A][B], which must not collapse to Foo[A,B]), or an unrecognized
+// argument.
 func namedWithArgs(base ast.Expr, args []ast.Expr, info *types.Info) *TypeRef {
 	ref := TypeRefFromExpr(base, info)
-	if ref == nil || ref.Kind != RefNamed {
+	if ref == nil || ref.Kind != RefNamed || len(ref.Args) > 0 {
 		return nil
 	}
 	for _, a := range args {

--- a/internal/metadata/typeref.go
+++ b/internal/metadata/typeref.go
@@ -48,9 +48,9 @@ type TypeRef struct {
 	// Named: generic instantiation arguments, e.g. the User in APIResponse[User]
 	// or the K, V in Pair[K, V] — positional, one per declared type parameter.
 	Args []*TypeRef
-	// Array: the length (>= 0). 0 means either a genuine [0]T or — only when
-	// built without type info — an unresolved length; production always supplies
-	// type info, so the length is accurate there.
+	// Array: the length. >= 0 is a known constant length; -1 means inferred or
+	// not statically resolved — [...]T, or a const-expression length built
+	// without type info — and renders as [...]. A genuine [0]T keeps Len 0.
 	Len int
 }
 
@@ -219,7 +219,8 @@ func selectorParts(t *ast.SelectorExpr, info *types.Info) (pkg, name string) {
 
 // arrayLen evaluates a constant array length, preferring the type-checker's
 // constant value (which resolves named/const-expression lengths) and falling
-// back to a literal integer. Returns 0 when the length cannot be determined.
+// back to a literal integer. Returns -1 when the length is inferred ([...]) or
+// cannot be statically determined.
 func arrayLen(e ast.Expr, info *types.Info) int {
 	if info != nil {
 		if tv, ok := info.Types[e]; ok && tv.Value != nil {
@@ -235,7 +236,7 @@ func arrayLen(e ast.Expr, info *types.Info) int {
 			return int(n)
 		}
 	}
-	return 0
+	return -1 // inferred ([...]T) or not statically resolvable
 }
 
 // fitsLen reports whether a 64-bit array length is a non-negative value that
@@ -281,6 +282,9 @@ func (t *TypeRef) String() string {
 	case RefSlice:
 		return "[]" + t.Elem.String()
 	case RefArray:
+		if t.Len < 0 {
+			return "[...]" + t.Elem.String()
+		}
 		return "[" + strconv.Itoa(t.Len) + "]" + t.Elem.String()
 	case RefMap:
 		return "map[" + t.Key.String() + "]" + t.Elem.String()

--- a/internal/metadata/typeref.go
+++ b/internal/metadata/typeref.go
@@ -41,7 +41,7 @@ type TypeRef struct {
 	// for a qualified primitive such as time.Time, so String renders it whole).
 	Pkg  string
 	Name string
-	// Slice/Array/Pointer/Chan: the element type. Map: the value type.
+	// Slice/Array/Pointer: the element type. Map: the value type.
 	Elem *TypeRef
 	// Map: the key type.
 	Key *TypeRef
@@ -121,8 +121,10 @@ func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 		return &TypeRef{Kind: RefStruct}
 	case *ast.FuncType:
 		return &TypeRef{Kind: RefFunc}
-	case *ast.ChanType:
-		return &TypeRef{Kind: RefChan, Elem: TypeRefFromExpr(t.Value, info)}
+	case *ast.ChanType: // opaque (no schema); direction and element carry no schema meaning
+		return &TypeRef{Kind: RefChan}
+	case *ast.Ellipsis: // variadic ...T is a []T (go/types lowers it the same way)
+		return &TypeRef{Kind: RefSlice, Elem: TypeRefFromExpr(t.Elt, info)}
 	case *ast.IndexExpr: // single-arg generic instantiation: Base[Arg]
 		return namedWithArgs(t.X, []ast.Expr{t.Index}, info)
 	case *ast.IndexListExpr: // multi-arg generic instantiation: Base[A, B]
@@ -170,17 +172,25 @@ func selectorParts(t *ast.SelectorExpr, info *types.Info) (pkg, name string) {
 func arrayLen(e ast.Expr, info *types.Info) int {
 	if info != nil {
 		if tv, ok := info.Types[e]; ok && tv.Value != nil {
-			if n, ok := constant.Int64Val(tv.Value); ok {
+			if n, ok := constant.Int64Val(tv.Value); ok && fitsLen(n) {
 				return int(n)
 			}
 		}
 	}
+	// Fallback without type info: ParseInt(base 0) honors Go's 0x/0o/0b/_ literal
+	// forms, which strconv.Atoi would reject or misread (e.g. "010" as 10).
 	if lit, ok := e.(*ast.BasicLit); ok {
-		if n, err := strconv.Atoi(lit.Value); err == nil {
-			return n
+		if n, err := strconv.ParseInt(lit.Value, 0, 64); err == nil && fitsLen(n) {
+			return int(n)
 		}
 	}
 	return 0
+}
+
+// fitsLen reports whether a 64-bit array length is a non-negative value that
+// survives the int conversion without truncation (relevant on 32-bit builds).
+func fitsLen(n int64) bool {
+	return n >= 0 && int64(int(n)) == n
 }
 
 // Qualify attaches pkg to every unqualified named node in the tree, turning a
@@ -198,7 +208,7 @@ func (t *TypeRef) Qualify(pkg string) {
 		for _, a := range t.Args {
 			a.Qualify(pkg)
 		}
-	case RefSlice, RefArray, RefPointer, RefChan:
+	case RefSlice, RefArray, RefPointer:
 		t.Elem.Qualify(pkg)
 	case RefMap:
 		t.Key.Qualify(pkg)
@@ -228,10 +238,7 @@ func (t *TypeRef) String() string {
 	case RefFunc:
 		return "func"
 	case RefChan:
-		if t.Elem == nil {
-			return "chan"
-		}
-		return "chan " + t.Elem.String()
+		return "chan"
 	default: // RefNamed, RefBasic
 		name := t.Name
 		if t.Pkg != "" {

--- a/internal/metadata/typeref.go
+++ b/internal/metadata/typeref.go
@@ -48,7 +48,9 @@ type TypeRef struct {
 	// Named: generic instantiation arguments, e.g. the User in APIResponse[User]
 	// or the K, V in Pair[K, V] — positional, one per declared type parameter.
 	Args []*TypeRef
-	// Array: the length (>= 0; 0 when it could not be resolved as a constant).
+	// Array: the length (>= 0). 0 means either a genuine [0]T or — only when
+	// built without type info — an unresolved length; production always supplies
+	// type info, so the length is accurate there.
 	Len int
 }
 
@@ -78,6 +80,9 @@ const (
 	RefStruct
 	// RefChan is a channel type — opaque (no schema).
 	RefChan
+	// RefParam is a generic type-parameter reference (the T in Box[T]). It is not
+	// a package type, so Qualify must leave it alone; detected only with type info.
+	RefParam
 )
 
 // TypeRefFromExpr builds a TypeRef from a type expression. info may be nil; it
@@ -85,6 +90,8 @@ const (
 // array length, both of which degrade gracefully when absent. Unrecognized
 // nodes return nil so callers can detect "no usable type" rather than a
 // fabricated one.
+//
+//nolint:gocyclo // flat type switch over many AST node kinds — low real complexity
 func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 	switch t := e.(type) {
 	case nil:
@@ -92,10 +99,14 @@ func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 	case *ast.ParenExpr:
 		return TypeRefFromExpr(t.X, info)
 	case *ast.Ident:
-		if IsPrimitiveType(t.Name) {
+		switch {
+		case IsPrimitiveType(t.Name):
 			return &TypeRef{Kind: RefBasic, Name: t.Name}
+		case isTypeParam(t, info):
+			return &TypeRef{Kind: RefParam, Name: t.Name}
+		default:
+			return &TypeRef{Kind: RefNamed, Name: t.Name}
 		}
-		return &TypeRef{Kind: RefNamed, Name: t.Name}
 	case *ast.SelectorExpr:
 		pkg, name := selectorParts(t, info)
 		full := name
@@ -107,14 +118,22 @@ func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 		}
 		return &TypeRef{Kind: RefNamed, Pkg: pkg, Name: name}
 	case *ast.StarExpr:
-		return &TypeRef{Kind: RefPointer, Elem: TypeRefFromExpr(t.X, info)}
+		return wrap(RefPointer, TypeRefFromExpr(t.X, info))
 	case *ast.ArrayType:
-		if t.Len == nil {
-			return &TypeRef{Kind: RefSlice, Elem: TypeRefFromExpr(t.Elt, info)}
+		elem := TypeRefFromExpr(t.Elt, info)
+		if elem == nil {
+			return nil
 		}
-		return &TypeRef{Kind: RefArray, Len: arrayLen(t.Len, info), Elem: TypeRefFromExpr(t.Elt, info)}
+		if t.Len == nil {
+			return &TypeRef{Kind: RefSlice, Elem: elem}
+		}
+		return &TypeRef{Kind: RefArray, Len: arrayLen(t.Len, info), Elem: elem}
 	case *ast.MapType:
-		return &TypeRef{Kind: RefMap, Key: TypeRefFromExpr(t.Key, info), Elem: TypeRefFromExpr(t.Value, info)}
+		key, val := TypeRefFromExpr(t.Key, info), TypeRefFromExpr(t.Value, info)
+		if key == nil || val == nil {
+			return nil
+		}
+		return &TypeRef{Kind: RefMap, Key: key, Elem: val}
 	case *ast.InterfaceType:
 		return &TypeRef{Kind: RefInterface}
 	case *ast.StructType:
@@ -124,7 +143,7 @@ func TypeRefFromExpr(e ast.Expr, info *types.Info) *TypeRef {
 	case *ast.ChanType: // opaque (no schema); direction and element carry no schema meaning
 		return &TypeRef{Kind: RefChan}
 	case *ast.Ellipsis: // variadic ...T is a []T (go/types lowers it the same way)
-		return &TypeRef{Kind: RefSlice, Elem: TypeRefFromExpr(t.Elt, info)}
+		return wrap(RefSlice, TypeRefFromExpr(t.Elt, info))
 	case *ast.IndexExpr: // single-arg generic instantiation: Base[Arg]
 		return namedWithArgs(t.X, []ast.Expr{t.Index}, info)
 	case *ast.IndexListExpr: // multi-arg generic instantiation: Base[A, B]
@@ -147,6 +166,31 @@ func namedWithArgs(base ast.Expr, args []ast.Expr, info *types.Info) *TypeRef {
 		ref.Args = append(ref.Args, TypeRefFromExpr(a, info))
 	}
 	return ref
+}
+
+// wrap builds a single-element composite (pointer/slice), propagating a nil
+// element as nil so an unrecognized inner type yields no usable type rather
+// than a fabricated "*"/"[]" shell.
+func wrap(kind RefKind, elem *TypeRef) *TypeRef {
+	if elem == nil {
+		return nil
+	}
+	return &TypeRef{Kind: kind, Elem: elem}
+}
+
+// isTypeParam reports whether id refers to a generic type parameter, which must
+// not be qualified or treated as a package type. Requires type info; without it
+// a bare identifier is indistinguishable from a package-local type.
+func isTypeParam(id *ast.Ident, info *types.Info) bool {
+	if info == nil {
+		return false
+	}
+	obj := info.ObjectOf(id)
+	if obj == nil {
+		return false
+	}
+	_, ok := obj.Type().(*types.TypeParam)
+	return ok
 }
 
 // selectorParts resolves a qualified type "pkg.Name" to its import path and
@@ -216,8 +260,10 @@ func (t *TypeRef) Qualify(pkg string) {
 	}
 }
 
-// String renders the TypeRef in canonical Go form. Opaque kinds render to their
-// bare keyword form (func, struct{}, interface{}, chan Elem).
+// String renders the TypeRef as the project's canonical metadata identifier:
+// dot-separated using the package's full import path, so a qualified type reads
+// "net/http.Header" (an import-path form, not literal Go source). Opaque kinds
+// render to their bare keyword (func, struct{}, interface{}, chan).
 func (t *TypeRef) String() string {
 	if t == nil {
 		return ""

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -1,0 +1,238 @@
+// Copyright 2025 Ehab Terra, 2025-2026 Anton Starikov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fieldExprs parses src and returns each struct field's type expression keyed
+// by field name. When check is true it also type-checks (importing real
+// packages) and returns the types.Info, so selector package paths and constant
+// array lengths resolve.
+func fieldExprs(t *testing.T, src string, check bool) (map[string]ast.Expr, *types.Info) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, 0)
+	require.NoError(t, err)
+
+	var info *types.Info
+	if check {
+		info = &types.Info{Types: map[ast.Expr]types.TypeAndValue{}, Defs: map[*ast.Ident]types.Object{}, Uses: map[*ast.Ident]types.Object{}}
+		conf := types.Config{Importer: importer.Default(), Error: func(error) {}}
+		_, _ = conf.Check("x", fset, []*ast.File{f}, info) // tolerate undefined types
+	}
+
+	// Collect only the fields of the top-level struct declarations — not nested
+	// function params/results or interface methods, whose names could otherwise
+	// overwrite a struct field's entry and make a test assert the wrong type.
+	exprs := map[string]ast.Expr{}
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				continue
+			}
+			for _, field := range st.Fields.List {
+				for _, name := range field.Names {
+					exprs[name.Name] = field.Type
+				}
+			}
+		}
+	}
+	return exprs, info
+}
+
+func TestTypeRefFromExpr_Kinds(t *testing.T) {
+	src := `package x
+type S struct {
+	A int
+	B *User
+	C []User
+	D [16]byte
+	E map[string]int
+	F interface{}
+	G interface{ Read() error }
+	H struct{ X int }
+	I func(a, b int) (string, error)
+	J chan int
+	K Box[User]
+	L Pair[K, V]
+	M [][]int
+	N **User
+	O map[string][]*User
+	P qual.Type
+}`
+	exprs, _ := fieldExprs(t, src, false)
+
+	cases := []struct {
+		field string
+		kind  RefKind
+		str   string
+	}{
+		{"A", RefBasic, "int"},
+		{"B", RefPointer, "*User"},
+		{"C", RefSlice, "[]User"},
+		{"D", RefArray, "[16]byte"}, // length preserved (getTypeName dropped it)
+		{"E", RefMap, "map[string]int"},
+		{"F", RefInterface, "interface{}"},
+		{"G", RefInterface, "interface{}"}, // non-empty interface still opaque any
+		{"H", RefStruct, "struct{}"},
+		{"I", RefFunc, "func"}, // never a string, so never mis-split on its commas
+		{"J", RefChan, "chan int"},
+		{"K", RefNamed, "Box[User]"},
+		{"L", RefNamed, "Pair[K,V]"}, // IndexListExpr — getTypeName produced ""
+		{"M", RefSlice, "[][]int"},
+		{"N", RefPointer, "**User"},
+		{"O", RefMap, "map[string][]*User"},
+		{"P", RefNamed, "qual.Type"}, // selector, no type info → source qualifier
+	}
+	for _, c := range cases {
+		ref := TypeRefFromExpr(exprs[c.field], nil)
+		require.NotNil(t, ref, c.field)
+		assert.Equal(t, c.kind, ref.Kind, "field %s kind", c.field)
+		assert.Equal(t, c.str, ref.String(), "field %s string", c.field)
+	}
+
+	// Structural spot-checks the round-trip string can't fully convey.
+	require.Len(t, TypeRefFromExpr(exprs["D"], nil).Args, 0)
+	assert.Equal(t, 16, TypeRefFromExpr(exprs["D"], nil).Len)
+	l := TypeRefFromExpr(exprs["L"], nil)
+	require.Len(t, l.Args, 2)
+	assert.Equal(t, "K", l.Args[0].Name)
+	assert.Equal(t, "V", l.Args[1].Name)
+	p := TypeRefFromExpr(exprs["P"], nil)
+	assert.Equal(t, "qual", p.Pkg)
+	assert.Equal(t, "Type", p.Name)
+}
+
+func TestTypeRefFromExpr_WithInfo(t *testing.T) {
+	src := `package x
+import "time"
+const N = 8
+type S struct {
+	A time.Time
+	B time.Duration
+	C [N]byte
+	D [4]int
+	E []time.Time
+}`
+	exprs, info := fieldExprs(t, src, true)
+	require.NotNil(t, info)
+
+	// time.Time is a recognized primitive; its package path is resolved.
+	a := TypeRefFromExpr(exprs["A"], info)
+	assert.Equal(t, RefBasic, a.Kind)
+	assert.Equal(t, "time", a.Pkg)
+	assert.Equal(t, "time.Time", a.String())
+
+	// time.Duration is a named type, not a primitive — keeps its $ref.
+	b := TypeRefFromExpr(exprs["B"], info)
+	assert.Equal(t, RefNamed, b.Kind)
+	assert.Equal(t, "time.Duration", b.String())
+
+	// Constant array length resolved through the type-checker, and a literal.
+	assert.Equal(t, 8, TypeRefFromExpr(exprs["C"], info).Len)
+	assert.Equal(t, 4, TypeRefFromExpr(exprs["D"], info).Len)
+	assert.Equal(t, "[]time.Time", TypeRefFromExpr(exprs["E"], info).String())
+}
+
+func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
+	assert.Nil(t, TypeRefFromExpr(nil, nil))
+	assert.Nil(t, TypeRefFromExpr(&ast.BasicLit{Kind: token.INT, Value: "1"}, nil)) // not a type expr
+
+	// A parenthesized type unwraps to its inner type.
+	paren := TypeRefFromExpr(&ast.ParenExpr{X: &ast.Ident{Name: "int"}}, nil)
+	require.NotNil(t, paren)
+	assert.Equal(t, "int", paren.String())
+
+	// A generic whose base is not a type (here a literal) yields no usable type.
+	assert.Nil(t, TypeRefFromExpr(&ast.IndexExpr{X: &ast.BasicLit{Kind: token.INT, Value: "1"}, Index: &ast.Ident{Name: "T"}}, nil))
+
+	// An array whose length is a non-constant, non-literal expression and no
+	// type info to resolve it falls back to length 0 (still an array).
+	arr := TypeRefFromExpr(&ast.ArrayType{Len: &ast.Ident{Name: "N"}, Elt: &ast.Ident{Name: "byte"}}, nil)
+	require.Equal(t, RefArray, arr.Kind)
+	assert.Equal(t, 0, arr.Len)
+
+	// A selector whose base is not a plain package ident (a.b.C) has no simple
+	// qualifier; it degrades to the trailing name with no package.
+	nested := &ast.SelectorExpr{
+		X:   &ast.SelectorExpr{X: &ast.Ident{Name: "a"}, Sel: &ast.Ident{Name: "b"}},
+		Sel: &ast.Ident{Name: "C"},
+	}
+	y := TypeRefFromExpr(nested, nil)
+	require.Equal(t, RefNamed, y.Kind)
+	assert.Equal(t, "C", y.Name)
+	assert.Empty(t, y.Pkg)
+}
+
+func TestTypeRef_Qualify(t *testing.T) {
+	exprs, _ := fieldExprs(t, `package x
+type S struct {
+	A map[string][]Money
+	B []other.Thing
+	C [][]int
+	D Box[Item]
+	E chan Event
+}`, false)
+
+	a := TypeRefFromExpr(exprs["A"], nil)
+	a.Qualify("pkg")
+	assert.Equal(t, "map[string][]pkg.Money", a.String())
+
+	b := TypeRefFromExpr(exprs["B"], nil)
+	b.Qualify("pkg")
+	assert.Equal(t, "[]other.Thing", b.String()) // already qualified — untouched
+
+	c := TypeRefFromExpr(exprs["C"], nil)
+	c.Qualify("pkg")
+	assert.Equal(t, "[][]int", c.String()) // primitives — untouched
+
+	d := TypeRefFromExpr(exprs["D"], nil)
+	d.Qualify("pkg")
+	assert.Equal(t, "pkg.Box[pkg.Item]", d.String()) // base and args both qualified
+
+	e := TypeRefFromExpr(exprs["E"], nil)
+	e.Qualify("pkg")
+	assert.Equal(t, "chan pkg.Event", e.String())
+
+	var nilRef *TypeRef
+	nilRef.Qualify("pkg") // no panic
+	d.Qualify("")         // empty pkg — no-op
+}
+
+func TestTypeRef_StringNil(t *testing.T) {
+	var t0 *TypeRef
+	assert.Equal(t, "", t0.String())
+	// A bare channel with no element renders without a trailing space.
+	assert.Equal(t, "chan", (&TypeRef{Kind: RefChan}).String())
+}

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -241,6 +241,10 @@ func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
 	assert.Nil(t, TypeRefFromExpr(&ast.IndexListExpr{X: &ast.StarExpr{X: &ast.Ident{Name: "Foo"}}, Indices: []ast.Expr{tp}}, nil)) // (*Foo)[T]
 	// A named base with an unrecognized argument also yields nil, not an empty arg.
 	assert.Nil(t, TypeRefFromExpr(&ast.IndexExpr{X: &ast.Ident{Name: "Foo"}, Index: &ast.BasicLit{Kind: token.INT, Value: "1"}}, nil))
+	// An already-instantiated base (the ill-typed nested Foo[A][B]) is nil, not a
+	// collapsed Foo[A,B].
+	fooAB := &ast.IndexExpr{X: &ast.IndexExpr{X: &ast.Ident{Name: "Foo"}, Index: &ast.Ident{Name: "A"}}, Index: &ast.Ident{Name: "B"}}
+	assert.Nil(t, TypeRefFromExpr(fooAB, nil))
 
 	// An array whose length is a non-constant, non-literal expression and no
 	// type info to resolve it falls back to length 0 (still an array).

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -84,6 +84,8 @@ type S struct {
 	H struct{ X int }
 	I func(a, b int) (string, error)
 	J chan int
+	Q <-chan int
+	R chan<- Event
 	K Box[User]
 	L Pair[K, V]
 	M [][]int
@@ -107,7 +109,9 @@ type S struct {
 		{"G", RefInterface, "interface{}"}, // non-empty interface still opaque any
 		{"H", RefStruct, "struct{}"},
 		{"I", RefFunc, "func"}, // never a string, so never mis-split on its commas
-		{"J", RefChan, "chan int"},
+		{"J", RefChan, "chan"}, // chan is opaque — direction and element dropped
+		{"Q", RefChan, "chan"}, // <-chan int
+		{"R", RefChan, "chan"}, // chan<- Event
 		{"K", RefNamed, "Box[User]"},
 		{"L", RefNamed, "Pair[K,V]"}, // IndexListExpr — getTypeName produced ""
 		{"M", RefSlice, "[][]int"},
@@ -132,11 +136,20 @@ type S struct {
 	p := TypeRefFromExpr(exprs["P"], nil)
 	assert.Equal(t, "qual", p.Pkg)
 	assert.Equal(t, "Type", p.Name)
+
+	// Variadic ...T (valid only in signatures, so constructed directly) is a
+	// slice, matching how go/types lowers it.
+	va := TypeRefFromExpr(&ast.Ellipsis{Elt: &ast.Ident{Name: "Order"}}, nil)
+	require.Equal(t, RefSlice, va.Kind)
+	assert.Equal(t, "[]Order", va.String())
 }
 
 func TestTypeRefFromExpr_WithInfo(t *testing.T) {
 	src := `package x
-import "time"
+import (
+	"time"
+	"net/http"
+)
 const N = 8
 type S struct {
 	A time.Time
@@ -144,6 +157,7 @@ type S struct {
 	C [N]byte
 	D [4]int
 	E []time.Time
+	F http.Header
 }`
 	exprs, info := fieldExprs(t, src, true)
 	require.NotNil(t, info)
@@ -163,6 +177,13 @@ type S struct {
 	assert.Equal(t, 8, TypeRefFromExpr(exprs["C"], info).Len)
 	assert.Equal(t, 4, TypeRefFromExpr(exprs["D"], info).Len)
 	assert.Equal(t, "[]time.Time", TypeRefFromExpr(exprs["E"], info).String())
+
+	// A multi-segment import path (ident "http" ≠ path "net/http") proves the
+	// package comes from type info, not the source-level qualifier.
+	f := TypeRefFromExpr(exprs["F"], info)
+	assert.Equal(t, RefNamed, f.Kind)
+	assert.Equal(t, "net/http", f.Pkg)
+	assert.Equal(t, "net/http.Header", f.String())
 }
 
 func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
@@ -223,16 +244,18 @@ type S struct {
 
 	e := TypeRefFromExpr(exprs["E"], nil)
 	e.Qualify("pkg")
-	assert.Equal(t, "chan pkg.Event", e.String())
+	assert.Equal(t, "chan", e.String()) // chan is opaque — not descended into
 
 	var nilRef *TypeRef
 	nilRef.Qualify("pkg") // no panic
-	d.Qualify("")         // empty pkg — no-op
+	before := d.String()
+	d.Qualify("") // empty pkg — no-op
+	assert.Equal(t, before, d.String())
 }
 
 func TestTypeRef_StringNil(t *testing.T) {
 	var t0 *TypeRef
 	assert.Equal(t, "", t0.String())
-	// A bare channel with no element renders without a trailing space.
+	// chan is opaque — it always renders as the bare keyword.
 	assert.Equal(t, "chan", (&TypeRef{Kind: RefChan}).String())
 }

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -246,11 +246,19 @@ func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
 	fooAB := &ast.IndexExpr{X: &ast.IndexExpr{X: &ast.Ident{Name: "Foo"}, Index: &ast.Ident{Name: "A"}}, Index: &ast.Ident{Name: "B"}}
 	assert.Nil(t, TypeRefFromExpr(fooAB, nil))
 
-	// An array whose length is a non-constant, non-literal expression and no
-	// type info to resolve it falls back to length 0 (still an array).
+	// An array whose length is a non-constant, non-literal expression with no
+	// type info is unresolved: Len -1, rendered [...] (distinct from a genuine [0]).
 	arr := TypeRefFromExpr(&ast.ArrayType{Len: &ast.Ident{Name: "N"}, Elt: &ast.Ident{Name: "byte"}}, nil)
 	require.Equal(t, RefArray, arr.Kind)
-	assert.Equal(t, 0, arr.Len)
+	assert.Equal(t, -1, arr.Len)
+	assert.Equal(t, "[...]byte", arr.String())
+
+	// An inferred-length array [...]T (only valid in composite literals, so
+	// constructed directly) renders [...]T, not a wrong [0]T.
+	ell := TypeRefFromExpr(&ast.ArrayType{Len: &ast.Ellipsis{}, Elt: &ast.Ident{Name: "int"}}, nil)
+	require.Equal(t, RefArray, ell.Kind)
+	assert.Equal(t, -1, ell.Len)
+	assert.Equal(t, "[...]int", ell.String())
 
 	// A composite whose inner type is unrecognized propagates nil instead of
 	// fabricating a "*" / "[]" / "map[]" shell (the documented contract).

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -232,6 +232,16 @@ func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
 	// A generic whose base is not a type (here a literal) yields no usable type.
 	assert.Nil(t, TypeRefFromExpr(&ast.IndexExpr{X: &ast.BasicLit{Kind: token.INT, Value: "1"}, Index: &ast.Ident{Name: "T"}}, nil))
 
+	// A generic whose base is recognized but not a NAMED type — a composite,
+	// a primitive, or a type parameter (all ill-typed) — is nil, never a
+	// fabricated "[T]"/"int[T]" identifier.
+	tp := &ast.Ident{Name: "T"}
+	assert.Nil(t, TypeRefFromExpr(&ast.IndexExpr{X: &ast.ArrayType{Elt: &ast.Ident{Name: "int"}}, Index: tp}, nil))                // ([]int)[T]
+	assert.Nil(t, TypeRefFromExpr(&ast.IndexExpr{X: &ast.Ident{Name: "int"}, Index: tp}, nil))                                     // int[T]
+	assert.Nil(t, TypeRefFromExpr(&ast.IndexListExpr{X: &ast.StarExpr{X: &ast.Ident{Name: "Foo"}}, Indices: []ast.Expr{tp}}, nil)) // (*Foo)[T]
+	// A named base with an unrecognized argument also yields nil, not an empty arg.
+	assert.Nil(t, TypeRefFromExpr(&ast.IndexExpr{X: &ast.Ident{Name: "Foo"}, Index: &ast.BasicLit{Kind: token.INT, Value: "1"}}, nil))
+
 	// An array whose length is a non-constant, non-literal expression and no
 	// type info to resolve it falls back to length 0 (still an array).
 	arr := TypeRefFromExpr(&ast.ArrayType{Len: &ast.Ident{Name: "N"}, Elt: &ast.Ident{Name: "byte"}}, nil)

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -92,6 +92,8 @@ type S struct {
 	N **User
 	O map[string][]*User
 	P qual.Type
+	T1 [0x10]byte
+	T2 [1_000]int
 }`
 	exprs, _ := fieldExprs(t, src, false)
 
@@ -117,7 +119,9 @@ type S struct {
 		{"M", RefSlice, "[][]int"},
 		{"N", RefPointer, "**User"},
 		{"O", RefMap, "map[string][]*User"},
-		{"P", RefNamed, "qual.Type"}, // selector, no type info → source qualifier
+		{"P", RefNamed, "qual.Type"},  // selector, no type info → source qualifier
+		{"T1", RefArray, "[16]byte"},  // hex literal length, no type info (ParseInt base 0)
+		{"T2", RefArray, "[1000]int"}, // underscore-separated literal length
 	}
 	for _, c := range cases {
 		ref := TypeRefFromExpr(exprs[c.field], nil)

--- a/internal/metadata/typeref_test.go
+++ b/internal/metadata/typeref_test.go
@@ -186,6 +186,40 @@ type S struct {
 	assert.Equal(t, "net/http.Header", f.String())
 }
 
+func TestTypeRefFromExpr_TypeParam(t *testing.T) {
+	exprs, info := fieldExprs(t, `package x
+type Local int
+type Box[T any] struct {
+	V T
+	W []T
+	X Local
+	U Undefined
+}`, true)
+	require.NotNil(t, info)
+
+	// A generic type parameter is its own kind, not a package type — so Qualify
+	// must not turn T into pkg.T.
+	v := TypeRefFromExpr(exprs["V"], info)
+	require.Equal(t, RefParam, v.Kind)
+	assert.Equal(t, "T", v.Name)
+	v.Qualify("pkg")
+	assert.Equal(t, "T", v.String())
+
+	w := TypeRefFromExpr(exprs["W"], info)
+	require.Equal(t, RefSlice, w.Kind)
+	assert.Equal(t, RefParam, w.Elem.Kind)
+	w.Qualify("pkg")
+	assert.Equal(t, "[]T", w.String())
+
+	// A defined non-parameter type and an undefined identifier both classify as
+	// named (exercising isTypeParam's non-param and nil-object branches).
+	assert.Equal(t, RefNamed, TypeRefFromExpr(exprs["X"], info).Kind)
+	assert.Equal(t, RefNamed, TypeRefFromExpr(exprs["U"], info).Kind)
+
+	// Without type info a bare T cannot be told apart from a package-local type.
+	assert.Equal(t, RefNamed, TypeRefFromExpr(exprs["V"], nil).Kind)
+}
+
 func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
 	assert.Nil(t, TypeRefFromExpr(nil, nil))
 	assert.Nil(t, TypeRefFromExpr(&ast.BasicLit{Kind: token.INT, Value: "1"}, nil)) // not a type expr
@@ -203,6 +237,13 @@ func TestTypeRefFromExpr_NilAndUnrecognized(t *testing.T) {
 	arr := TypeRefFromExpr(&ast.ArrayType{Len: &ast.Ident{Name: "N"}, Elt: &ast.Ident{Name: "byte"}}, nil)
 	require.Equal(t, RefArray, arr.Kind)
 	assert.Equal(t, 0, arr.Len)
+
+	// A composite whose inner type is unrecognized propagates nil instead of
+	// fabricating a "*" / "[]" / "map[]" shell (the documented contract).
+	lit := &ast.BasicLit{Kind: token.INT, Value: "1"}
+	assert.Nil(t, TypeRefFromExpr(&ast.StarExpr{X: lit}, nil))
+	assert.Nil(t, TypeRefFromExpr(&ast.ArrayType{Elt: lit}, nil))
+	assert.Nil(t, TypeRefFromExpr(&ast.MapType{Key: &ast.Ident{Name: "string"}, Value: lit}, nil))
 
 	// A selector whose base is not a plain package ident (a.b.C) has no simple
 	// qualifier; it degrades to the trailing name with no package.


### PR DESCRIPTION
## Phase 1 of the typed type model — clean re-do of #59

Introduces `TypeRef`, a structured recursive representation of a Go type, **built directly from the type expression** (`TypeRefFromExpr(ast.Expr, *types.Info)`) where the structure is still intact — rather than re-parsed from a flattened string downstream.

### Why
`getTypeName` (internal/metadata/helpers.go) walks the AST and flattens it into a string, discarding structure:
- every function → `"func"`, every struct → `"struct{}"`
- every array degrades to a slice (the length is dropped)
- multi-parameter generics have **no case at all** → produce `""`

A consumer that re-parses such a string cannot recover what was thrown away, and a parser that tries to is an open-ended reimplementation of Go's type grammar (every malformed/exotic string shape becomes a special case). Building the tree from the AST sidesteps all of it: `*ast.FuncType`, `*ast.IndexListExpr`, and `*ast.ArrayType.Len` each answer the question directly — no comma-splitting, no bracket-matching, no parameter-vs-type guessing.

### What
- `internal/metadata/typeref.go`: the `TypeRef` model (`RefKind`/`Ref*`, distinct from the existing `CallArgument` `Kind*` string constants), `TypeRefFromExpr`, `String` (canonical rendering), and `Qualify` (attach an enclosing package to bare named nodes).
- Fixes two real `getTypeName` gaps by construction: array lengths are preserved (`[16]byte` stays an array) and multi-parameter generics (`Pair[K, V]`) are captured instead of collapsing to `""`.

### Scope
Phase 1 is **additive** — `TypeRef` is unconsumed by production. Later phases serialize it at the metadata boundary and migrate the schema generators off the flattened strings. `typeref.go` is at **100%** statement coverage (metadata package 98.9%); no golden output changes.

---
Supersedes #59, which accumulated a string-parser approach (later abandoned) plus bot auto-commits; this branch is the clean final state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal type representation system to better support complex Go type expressions, including generic types, arrays, maps, pointers, slices, and interfaces.
  * Added comprehensive test coverage for type reference handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->